### PR TITLE
Add read-only advertising report foundation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,6 +21,25 @@ paths:
       responses:
         "200":
           description: OK
+  /tools/report/overview:
+    get:
+      operationId: getOverviewReport
+      summary: Get the consolidated read-only advertising report
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: date_preset
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [last_7d, last_14d, last_30d, last_90d]
+            default: last_30d
+      responses:
+        "200":
+          description: Consolidated Meta metrics and Google reader readiness
+        "400":
+          description: Invalid date preset
   /tools/google/test:
     get:
       operationId: testGoogleAds

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "check": "node --check server.js"
+    "check": "node --check server.js && node --check reporting.js",
+    "test": "node --test"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/reporting.js
+++ b/reporting.js
@@ -1,0 +1,148 @@
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function round(value, decimals = 2) {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function normalizeActions(actions) {
+  if (!Array.isArray(actions)) return [];
+
+  return actions
+    .filter((action) => action && typeof action.action_type === "string")
+    .map((action) => ({
+      type: action.action_type,
+      value: toNumber(action.value),
+    }));
+}
+
+function normalizeMetaInsight(insight = {}) {
+  return {
+    campaign_id: String(insight.campaign_id || ""),
+    campaign_name: insight.campaign_name || null,
+    spend_eur: round(toNumber(insight.spend)),
+    impressions: toNumber(insight.impressions),
+    reach: toNumber(insight.reach),
+    clicks: toNumber(insight.clicks),
+    ctr_percent: round(toNumber(insight.ctr), 4),
+    cpc_eur: round(toNumber(insight.cpc), 4),
+    cpm_eur: round(toNumber(insight.cpm), 4),
+    frequency: round(toNumber(insight.frequency), 4),
+    actions: normalizeActions(insight.actions),
+    cost_per_action_type: normalizeActions(insight.cost_per_action_type),
+  };
+}
+
+function hasEffectiveStatus(campaign, expectedStatus) {
+  if (campaign.effective_status) {
+    return campaign.effective_status === expectedStatus;
+  }
+
+  return campaign.status === expectedStatus;
+}
+
+function buildMetaOverview(campaigns = [], insights = []) {
+  const normalizedInsights = insights.map(normalizeMetaInsight);
+  const insightsByCampaignId = new Map(
+    normalizedInsights.map((insight) => [insight.campaign_id, insight])
+  );
+
+  const campaignRows = campaigns.map((campaign) => {
+    const campaignId = String(campaign.id || "");
+    const insight = insightsByCampaignId.get(campaignId) || null;
+
+    return {
+      id: campaignId,
+      name: campaign.name || null,
+      status: campaign.status || null,
+      effective_status: campaign.effective_status || null,
+      objective: campaign.objective || null,
+      data_status: insight ? "has_data" : "no_data",
+      metrics: insight,
+    };
+  });
+
+  const totals = normalizedInsights.reduce(
+    (summary, insight) => {
+      summary.spend_eur += insight.spend_eur;
+      summary.impressions += insight.impressions;
+      summary.reach_sum += insight.reach;
+      summary.clicks += insight.clicks;
+      return summary;
+    },
+    { spend_eur: 0, impressions: 0, reach_sum: 0, clicks: 0 }
+  );
+
+  totals.spend_eur = round(totals.spend_eur);
+  totals.ctr_percent = totals.impressions
+    ? round((totals.clicks / totals.impressions) * 100, 4)
+    : 0;
+  totals.cpc_eur = totals.clicks
+    ? round(totals.spend_eur / totals.clicks, 4)
+    : 0;
+  totals.cpm_eur = totals.impressions
+    ? round((totals.spend_eur / totals.impressions) * 1000, 4)
+    : 0;
+
+  const active = campaigns.filter((campaign) =>
+    hasEffectiveStatus(campaign, "ACTIVE")
+  ).length;
+  const paused = campaigns.filter((campaign) =>
+    hasEffectiveStatus(campaign, "PAUSED")
+  ).length;
+  const withIssues = campaigns.filter(
+    (campaign) => campaign.effective_status === "WITH_ISSUES"
+  ).length;
+
+  return {
+    campaign_counts: {
+      total: campaigns.length,
+      active,
+      paused,
+      with_issues: withIssues,
+      with_data: campaignRows.filter((campaign) => campaign.data_status === "has_data")
+        .length,
+      without_data: campaignRows.filter(
+        (campaign) => campaign.data_status === "no_data"
+      ).length,
+      unmatched_insight_rows: normalizedInsights.filter(
+        (insight) =>
+          !campaigns.some(
+            (campaign) => String(campaign.id || "") === insight.campaign_id
+          )
+      ).length,
+    },
+    totals,
+    campaigns: campaignRows,
+  };
+}
+
+function buildGoogleReadiness(environment = process.env) {
+  const configurationComplete = Boolean(
+    environment.GOOGLE_CLIENT_ID &&
+      environment.GOOGLE_CLIENT_SECRET &&
+      environment.GOOGLE_DEVELOPER_TOKEN &&
+      environment.GOOGLE_REFRESH_TOKEN &&
+      environment.GOOGLE_CUSTOMER_ID
+  );
+
+  return {
+    configuration_complete: configurationComplete,
+    api_access: "not_checked_by_report",
+    reader_status: configurationComplete
+      ? "configuration_ready_live_test_required"
+      : "configuration_incomplete",
+    next_step: configurationComplete
+      ? "Run the protected Google test after Basic Access approval"
+      : "Complete the protected Google configuration",
+  };
+}
+
+module.exports = {
+  buildGoogleReadiness,
+  buildMetaOverview,
+  normalizeMetaInsight,
+};

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const path = require("path");
 const axios = require("axios");
 const { randomUUID } = require("crypto");
 const { GoogleAdsApi } = require("google-ads-api");
+const { buildGoogleReadiness, buildMetaOverview } = require("./reporting");
 
 const app = express();
 app.use(express.json({ limit: "100kb" }));
@@ -125,17 +126,56 @@ function eurToMetaCents(eur) {
   return Math.round(value * 100);
 }
 
-async function getCampaigns() {
-  const response = await metaClient.get(`/${META_AD_ACCOUNT_ID}/campaigns`, {
-    params: {
-      access_token: META_ACCESS_TOKEN,
-      fields:
-        "id,name,status,effective_status,objective,created_time,updated_time,daily_budget,lifetime_budget,buying_type,special_ad_categories",
-      limit: 100,
-    },
-  });
+async function getMetaCollection(endpoint, params, maxPages = 20) {
+  const data = [];
+  let after = null;
+  let pageCount = 0;
+  let hasMore = false;
 
-  return response.data.data || [];
+  do {
+    const response = await metaClient.get(endpoint, {
+      params: {
+        ...params,
+        access_token: META_ACCESS_TOKEN,
+        limit: 100,
+        ...(after ? { after } : {}),
+      },
+    });
+
+    data.push(...(response.data.data || []));
+    pageCount += 1;
+
+    const nextCursor = response.data.paging?.cursors?.after || null;
+    hasMore = Boolean(response.data.paging?.next && nextCursor);
+    after = hasMore ? nextCursor : null;
+  } while (hasMore && pageCount < maxPages);
+
+  return {
+    data,
+    pages: pageCount,
+    truncated: hasMore,
+  };
+}
+
+async function getCampaignCollection() {
+  return getMetaCollection(`/${META_AD_ACCOUNT_ID}/campaigns`, {
+    fields:
+      "id,name,status,effective_status,objective,created_time,updated_time,daily_budget,lifetime_budget,buying_type,special_ad_categories",
+  });
+}
+
+async function getCampaigns() {
+  const collection = await getCampaignCollection();
+  return collection.data;
+}
+
+async function getCampaignInsights(datePreset) {
+  return getMetaCollection(`/${META_AD_ACCOUNT_ID}/insights`, {
+    date_preset: datePreset,
+    level: "campaign",
+    fields:
+      "campaign_id,campaign_name,spend,impressions,reach,clicks,ctr,cpc,cpm,frequency,actions,cost_per_action_type",
+  });
 }
 
 async function getCampaign(campaignId) {
@@ -749,41 +789,61 @@ app.get("/tools/status", requireApiKey, async (req, res) => {
   }
 });
 
-app.get("/tools/dashboard", requireApiKey, async (req, res) => {
+async function handleOverviewReport(req, res) {
   if (!checkMetaConfig(res)) return;
 
-  try {
-    const campaigns = await getCampaigns();
+  const datePreset = parseMetaDatePreset(req.query.date_preset);
 
-    const campaignsTotal = campaigns.length;
-    const campaignsActive = campaigns.filter(
-      (campaign) => campaign.status === "ACTIVE" || campaign.effective_status === "ACTIVE"
-    ).length;
-    const campaignsPaused = campaigns.filter(
-      (campaign) => campaign.status === "PAUSED" || campaign.effective_status === "PAUSED"
-    ).length;
+  if (!datePreset) {
+    return res.status(400).json({
+      success: false,
+      error:
+        "date_preset must be one of: last_7d, last_14d, last_30d, last_90d",
+    });
+  }
+
+  try {
+    const [campaignCollection, insightCollection] = await Promise.all([
+      getCampaignCollection(),
+      getCampaignInsights(datePreset),
+    ]);
+    const metaOverview = buildMetaOverview(
+      campaignCollection.data,
+      insightCollection.data
+    );
+    const partialData =
+      campaignCollection.truncated || insightCollection.truncated;
 
     res.json({
       success: true,
-      meta: {
-        connected: true,
-        ad_account_id: META_AD_ACCOUNT_ID,
-        campaigns_total: campaignsTotal,
-        campaigns_active: campaignsActive,
-        campaigns_paused: campaignsPaused,
-        campaigns,
-      },
-      google: {
-        connected: Boolean(
-          process.env.GOOGLE_CLIENT_ID &&
-          process.env.GOOGLE_CLIENT_SECRET &&
-          process.env.GOOGLE_REFRESH_TOKEN
-        ),
-        conversion_tracking: "booking_completed configured in GA4 / Google Ads",
+      generated_at: new Date().toISOString(),
+      period: {
+        source: "meta_date_preset",
+        value: datePreset,
       },
       system: {
         railway_online: true,
         api_key_required: true,
+        report_mode: "read_only",
+        ad_writes_enabled: false,
+      },
+      meta: {
+        connected: true,
+        ad_account_id: META_AD_ACCOUNT_ID,
+        ...metaOverview,
+      },
+      google: buildGoogleReadiness(),
+      data_quality: {
+        status: partialData ? "partial" : "complete_for_returned_scope",
+        meta_pages: {
+          campaigns: campaignCollection.pages,
+          insights: insightCollection.pages,
+        },
+        caveats: [
+          "reach_sum can count the same person in more than one campaign",
+          "Meta action types are returned separately and are not combined into a conversion total until the business conversion definition is approved",
+          "This report does not call Google Ads; use the protected Google test and campaign metrics endpoints to verify live access",
+        ],
       },
     });
   } catch (error) {
@@ -792,7 +852,10 @@ app.get("/tools/dashboard", requireApiKey, async (req, res) => {
       error: cleanMetaError(error),
     });
   }
-});
+}
+
+app.get("/tools/report/overview", requireApiKey, handleOverviewReport);
+app.get("/tools/dashboard", requireApiKey, handleOverviewReport);
 
 app.get("/meta/campaigns", requireApiKey, async (req, res) => {
   if (!checkMetaConfig(res)) return;

--- a/test/reporting.test.js
+++ b/test/reporting.test.js
@@ -1,0 +1,100 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildGoogleReadiness,
+  buildMetaOverview,
+  normalizeMetaInsight,
+} = require("../reporting");
+
+test("normalizes Meta numeric strings and preserves raw action types", () => {
+  const result = normalizeMetaInsight({
+    campaign_id: "123",
+    campaign_name: "Dinner",
+    spend: "12.345",
+    impressions: "1000",
+    clicks: "25",
+    ctr: "2.5",
+    actions: [{ action_type: "link_click", value: "8" }],
+  });
+
+  assert.equal(result.spend_eur, 12.35);
+  assert.equal(result.impressions, 1000);
+  assert.equal(result.clicks, 25);
+  assert.deepEqual(result.actions, [{ type: "link_click", value: 8 }]);
+});
+
+test("builds weighted totals and identifies campaigns without data", () => {
+  const result = buildMetaOverview(
+    [
+      { id: "1", name: "A", status: "ACTIVE", effective_status: "ACTIVE" },
+      { id: "2", name: "B", status: "PAUSED", effective_status: "PAUSED" },
+    ],
+    [
+      {
+        campaign_id: "1",
+        spend: "10",
+        impressions: "1000",
+        reach: "800",
+        clicks: "20",
+      },
+    ]
+  );
+
+  assert.deepEqual(result.campaign_counts, {
+    total: 2,
+    active: 1,
+    paused: 1,
+    with_issues: 0,
+    with_data: 1,
+    without_data: 1,
+    unmatched_insight_rows: 0,
+  });
+  assert.equal(result.totals.ctr_percent, 2);
+  assert.equal(result.totals.cpc_eur, 0.5);
+  assert.equal(result.totals.cpm_eur, 10);
+  assert.equal(result.campaigns[1].data_status, "no_data");
+  assert.equal(result.campaigns[1].metrics, null);
+});
+
+test("uses effective Meta status instead of configured status when present", () => {
+  const result = buildMetaOverview(
+    [
+      {
+        id: "1",
+        status: "ACTIVE",
+        effective_status: "WITH_ISSUES",
+      },
+    ],
+    []
+  );
+
+  assert.equal(result.campaign_counts.active, 0);
+  assert.equal(result.campaign_counts.paused, 0);
+  assert.equal(result.campaign_counts.with_issues, 1);
+});
+
+test("does not claim Google API access from configuration alone", () => {
+  const result = buildGoogleReadiness({
+    GOOGLE_CLIENT_ID: "configured",
+    GOOGLE_CLIENT_SECRET: "configured",
+    GOOGLE_DEVELOPER_TOKEN: "configured",
+    GOOGLE_REFRESH_TOKEN: "configured",
+    GOOGLE_CUSTOMER_ID: "configured",
+  });
+
+  assert.equal(result.configuration_complete, true);
+  assert.equal(result.api_access, "not_checked_by_report");
+  assert.equal(result.reader_status, "configuration_ready_live_test_required");
+});
+
+test("reports incomplete Google configuration without exposing values", () => {
+  const result = buildGoogleReadiness({ GOOGLE_CLIENT_ID: "configured" });
+
+  assert.deepEqual(result, {
+    configuration_complete: false,
+    api_access: "not_checked_by_report",
+    reader_status: "configuration_incomplete",
+    next_step: "Complete the protected Google configuration",
+  });
+});


### PR DESCRIPTION
## Cosa cambia

- aggiunge `GET /tools/report/overview`, protetto da `x-api-key` e solo lettura
- consolida metriche Meta per campagna e totali di spesa, impressioni, clic, CTR, CPC e CPM
- gestisce la paginazione Meta senza seguire URL contenenti token
- indica esplicitamente completezza e limiti dei dati
- non aggrega le azioni Meta in una conversione arbitraria
- descrive Google come configurato ma non verificato dal report
- mantiene `/tools/dashboard` come alias compatibile
- aggiorna OpenAPI e aggiunge test automatici

## Sicurezza

- nessun comando pubblicitario nuovo
- tutte le scritture pubblicitarie restano disabilitate
- nessuna chiave o token incluso
- nessuna modifica a Railway, OAuth, Google Ads o Meta Ads

## Validazione

- 5 test automatici superati
- controllo sintattico di `server.js` e `reporting.js` superato
- OpenAPI YAML valido
- `git diff --check` superato

Questa PR resta in bozza e non deve essere unita finché non viene autorizzato il deployment.