### PR TITLE
Fix GPT Actions schema compatibility

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -111,6 +111,7 @@ paths:
         "200":
           description: OK
 components:
+  schemas: {}
   securitySchemes:
     ApiKeyAuth:
       type: apiKey


### PR DESCRIPTION
## Modifica

- aggiunge `components.schemas: {}` allo schema OpenAPI

## Motivo

Il validatore delle GPT Actions richiede che la sottosezione `schemas` sia presente come oggetto anche quando non contiene modelli.

## Sicurezza e verifica

- un solo file modificato
- una sola riga aggiunta
- nessuna modifica a runtime, autenticazione, chiavi o campagne
- YAML validato e 5 test automatici superati