### PR TITLE
Fix Meta campaign delivery status reporting

### DIFF
--- a/reporting.js
+++ b/reporting.js
@@ -44,7 +44,63 @@ function hasEffectiveStatus(campaign, expectedStatus) {
   return campaign.status === expectedStatus;
 }
 
-function buildMetaOverview(campaigns = [], insights = []) {
+function parseMetaDate(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function classifyCampaignDelivery(campaign, adsets, now = new Date()) {
+  if (campaign.effective_status === "WITH_ISSUES") return "with_issues";
+  if (
+    campaign.status === "PAUSED" ||
+    campaign.effective_status === "PAUSED" ||
+    campaign.effective_status === "CAMPAIGN_PAUSED"
+  ) {
+    return "paused";
+  }
+
+  if (!hasEffectiveStatus(campaign, "ACTIVE")) return "not_delivering";
+
+  // When child delivery data is unavailable, preserve Meta's campaign-level
+  // status but make the lower-confidence source explicit in the report.
+  if (!Array.isArray(adsets)) return "active_unverified";
+
+  const campaignAdsets = adsets.filter(
+    (adset) => String(adset.campaign_id || "") === String(campaign.id || "")
+  );
+
+  const activeNow = campaignAdsets.some((adset) => {
+    if (!hasEffectiveStatus(adset, "ACTIVE")) return false;
+    const startsAt = parseMetaDate(adset.start_time);
+    const endsAt = parseMetaDate(adset.end_time);
+    return (!startsAt || startsAt <= now) && (!endsAt || endsAt >= now);
+  });
+  if (activeNow) return "active";
+
+  const scheduled = campaignAdsets.some((adset) => {
+    const startsAt = parseMetaDate(adset.start_time);
+    return hasEffectiveStatus(adset, "ACTIVE") && startsAt && startsAt > now;
+  });
+  if (scheduled) return "scheduled";
+
+  const completed =
+    campaignAdsets.length > 0 &&
+    campaignAdsets.every((adset) => {
+      const endsAt = parseMetaDate(adset.end_time);
+      return endsAt && endsAt < now;
+    });
+  if (completed) return "completed";
+
+  return "not_delivering";
+}
+
+function buildMetaOverview(
+  campaigns = [],
+  insights = [],
+  adsets = null,
+  now = new Date()
+) {
   const normalizedInsights = insights.map(normalizeMetaInsight);
   const insightsByCampaignId = new Map(
     normalizedInsights.map((insight) => [insight.campaign_id, insight])
@@ -53,12 +109,14 @@ function buildMetaOverview(campaigns = [], insights = []) {
   const campaignRows = campaigns.map((campaign) => {
     const campaignId = String(campaign.id || "");
     const insight = insightsByCampaignId.get(campaignId) || null;
+    const deliveryStatus = classifyCampaignDelivery(campaign, adsets, now);
 
     return {
       id: campaignId,
       name: campaign.name || null,
       status: campaign.status || null,
       effective_status: campaign.effective_status || null,
+      delivery_status: deliveryStatus,
       objective: campaign.objective || null,
       data_status: insight ? "has_data" : "no_data",
       metrics: insight,
@@ -87,22 +145,19 @@ function buildMetaOverview(campaigns = [], insights = []) {
     ? round((totals.spend_eur / totals.impressions) * 1000, 4)
     : 0;
 
-  const active = campaigns.filter((campaign) =>
-    hasEffectiveStatus(campaign, "ACTIVE")
-  ).length;
-  const paused = campaigns.filter((campaign) =>
-    hasEffectiveStatus(campaign, "PAUSED")
-  ).length;
-  const withIssues = campaigns.filter(
-    (campaign) => campaign.effective_status === "WITH_ISSUES"
-  ).length;
+  const countDeliveryStatus = (status) =>
+    campaignRows.filter((campaign) => campaign.delivery_status === status).length;
 
   return {
     campaign_counts: {
       total: campaigns.length,
-      active,
-      paused,
-      with_issues: withIssues,
+      active: countDeliveryStatus("active"),
+      active_unverified: countDeliveryStatus("active_unverified"),
+      completed: countDeliveryStatus("completed"),
+      paused: countDeliveryStatus("paused"),
+      scheduled: countDeliveryStatus("scheduled"),
+      not_delivering: countDeliveryStatus("not_delivering"),
+      with_issues: countDeliveryStatus("with_issues"),
       with_data: campaignRows.filter((campaign) => campaign.data_status === "has_data")
         .length,
       without_data: campaignRows.filter(
@@ -144,5 +199,6 @@ function buildGoogleReadiness(environment = process.env) {
 module.exports = {
   buildGoogleReadiness,
   buildMetaOverview,
+  classifyCampaignDelivery,
   normalizeMetaInsight,
 };

--- a/server.js
+++ b/server.js
@@ -178,6 +178,13 @@ async function getCampaignInsights(datePreset) {
   });
 }
 
+async function getAdSetCollection() {
+  return getMetaCollection(`/${META_AD_ACCOUNT_ID}/adsets`, {
+    fields:
+      "id,campaign_id,status,effective_status,start_time,end_time,created_time,updated_time",
+  });
+}
+
 async function getCampaign(campaignId) {
   const response = await metaClient.get(`/${campaignId}`, {
     params: {
@@ -803,16 +810,20 @@ async function handleOverviewReport(req, res) {
   }
 
   try {
-    const [campaignCollection, insightCollection] = await Promise.all([
+    const [campaignCollection, insightCollection, adSetCollection] = await Promise.all([
       getCampaignCollection(),
       getCampaignInsights(datePreset),
+      getAdSetCollection(),
     ]);
     const metaOverview = buildMetaOverview(
       campaignCollection.data,
-      insightCollection.data
+      insightCollection.data,
+      adSetCollection.data
     );
     const partialData =
-      campaignCollection.truncated || insightCollection.truncated;
+      campaignCollection.truncated ||
+      insightCollection.truncated ||
+      adSetCollection.truncated;
 
     res.json({
       success: true,
@@ -838,8 +849,10 @@ async function handleOverviewReport(req, res) {
         meta_pages: {
           campaigns: campaignCollection.pages,
           insights: insightCollection.pages,
+          adsets: adSetCollection.pages,
         },
         caveats: [
+          "Campaign delivery status is verified against ad set schedules; an enabled campaign with only expired ad sets is reported as completed, not active",
           "reach_sum can count the same person in more than one campaign",
           "Meta action types are returned separately and are not combined into a conversion total until the business conversion definition is approved",
           "This report does not call Google Ads; use the protected Google test and campaign metrics endpoints to verify live access",

--- a/test/reporting.test.js
+++ b/test/reporting.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   buildGoogleReadiness,
   buildMetaOverview,
+  classifyCampaignDelivery,
   normalizeMetaInsight,
 } = require("../reporting");
 
@@ -38,13 +39,18 @@ test("builds weighted totals and identifies campaigns without data", () => {
         reach: "800",
         clicks: "20",
       },
-    ]
+    ],
+    null
   );
 
   assert.deepEqual(result.campaign_counts, {
     total: 2,
-    active: 1,
+    active: 0,
+    active_unverified: 1,
+    completed: 0,
     paused: 1,
+    scheduled: 0,
+    not_delivering: 0,
     with_issues: 0,
     with_data: 1,
     without_data: 1,
@@ -70,8 +76,93 @@ test("uses effective Meta status instead of configured status when present", () 
   );
 
   assert.equal(result.campaign_counts.active, 0);
+  assert.equal(result.campaign_counts.active_unverified, 0);
   assert.equal(result.campaign_counts.paused, 0);
   assert.equal(result.campaign_counts.with_issues, 1);
+});
+
+test("classifies an enabled campaign with an expired ad set as completed", () => {
+  const now = new Date("2026-08-20T12:00:00Z");
+  const campaign = {
+    id: "7",
+    status: "ACTIVE",
+    effective_status: "ACTIVE",
+  };
+  const adsets = [
+    {
+      campaign_id: "7",
+      status: "ACTIVE",
+      effective_status: "ACTIVE",
+      start_time: "2026-07-01T00:00:00Z",
+      end_time: "2026-08-01T00:00:00Z",
+    },
+  ];
+
+  assert.equal(classifyCampaignDelivery(campaign, adsets, now), "completed");
+
+  const result = buildMetaOverview([campaign], [], adsets, now);
+  assert.equal(result.campaign_counts.active, 0);
+  assert.equal(result.campaign_counts.completed, 1);
+  assert.equal(result.campaigns[0].delivery_status, "completed");
+});
+
+test("classifies a campaign as active only with a currently deliverable ad set", () => {
+  const now = new Date("2026-08-20T12:00:00Z");
+  const campaign = {
+    id: "8",
+    status: "ACTIVE",
+    effective_status: "ACTIVE",
+  };
+  const adsets = [
+    {
+      campaign_id: "8",
+      status: "ACTIVE",
+      effective_status: "ACTIVE",
+      start_time: "2026-08-01T00:00:00Z",
+      end_time: "2026-09-01T00:00:00Z",
+    },
+  ];
+
+  assert.equal(classifyCampaignDelivery(campaign, adsets, now), "active");
+});
+
+test("does not call a campaign completed when only some ad sets have ended", () => {
+  const now = new Date("2026-08-20T12:00:00Z");
+  const campaign = {
+    id: "9",
+    status: "ACTIVE",
+    effective_status: "ACTIVE",
+  };
+  const adsets = [
+    {
+      campaign_id: "9",
+      status: "ACTIVE",
+      effective_status: "ACTIVE",
+      end_time: "2026-08-01T00:00:00Z",
+    },
+    {
+      campaign_id: "9",
+      status: "PAUSED",
+      effective_status: "PAUSED",
+      end_time: null,
+    },
+  ];
+
+  assert.equal(classifyCampaignDelivery(campaign, adsets, now), "not_delivering");
+});
+
+test("recognizes a configured paused campaign even with a derived Meta status", () => {
+  assert.equal(
+    classifyCampaignDelivery(
+      {
+        id: "10",
+        status: "PAUSED",
+        effective_status: "CAMPAIGN_PAUSED",
+      },
+      []
+    ),
+    "paused"
+  );
 });
 
 test("does not claim Google API access from configuration alone", () => {


### PR DESCRIPTION
## Cosa cambia
- verifica lo stato di consegna delle campagne usando anche gruppi di inserzioni e relative date
- distingue campagne attive, completate, programmate, in pausa, con problemi e non in pubblicazione
- evita di presentare come attiva una campagna con tutti i gruppi già scaduti
- aggiunge paginazione e trasparenza dei dati dei gruppi di inserzioni al report

## Sicurezza
- sola lettura
- nessuna modifica a campagne, budget, token o variabili Railway

## Verifica
- 9 test automatici superati
- sintassi e diff controllati