### PR TITLE
Add read-only Meta dinner proposal

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -110,6 +110,41 @@ paths:
       responses:
         "200":
           description: OK
+  /tools/meta/proposal/dinner:
+    get:
+      operationId: getMetaDinnerProposal
+      summary: Prepare a read-only Meta dinner campaign proposal for human review
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: daily_budget_eur
+          in: query
+          required: false
+          schema:
+            type: number
+            minimum: 3
+            maximum: 20
+            default: 6
+        - name: duration_days
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 7
+            maximum: 30
+            default: 14
+        - name: goal
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [dinner_visits, reservations]
+            default: dinner_visits
+      responses:
+        "200":
+          description: Draft proposal based on current Meta state; no ads are created
+        "400":
+          description: Invalid proposal parameters
 components:
   schemas: {}
   securitySchemes:

--- a/proposals.js
+++ b/proposals.js
@@ -1,0 +1,137 @@
+function roundMoney(value) {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function buildMetaDinnerProposal({
+  metaOverview,
+  dailyBudgetEur = 6,
+  durationDays = 14,
+  goal = "dinner_visits",
+  generatedAt = new Date(),
+}) {
+  const totalBudgetEur = roundMoney(dailyBudgetEur * durationDays);
+  const counts = metaOverview.campaign_counts;
+  const hasRecentData = counts.with_data > 0;
+
+  const objective =
+    goal === "reservations" ? "OUTCOME_TRAFFIC" : "OUTCOME_AWARENESS";
+  const optimization =
+    goal === "reservations" ? "LANDING_PAGE_VIEWS" : "REACH";
+
+  return {
+    success: true,
+    proposal: {
+      id: `meta-dinner-${generatedAt.toISOString().slice(0, 10)}`,
+      status: "draft_requires_human_approval",
+      title: "Parma Berlin — controlled dinner customer experiment",
+      business_goal:
+        goal === "reservations"
+          ? "Generate qualified visits to the approved reservation destination."
+          : "Increase local awareness and dinner visits near Wrangelstraße 90.",
+      evidence: {
+        period: "last_30d",
+        campaigns_total: counts.total,
+        campaigns_active: counts.active,
+        campaigns_completed: counts.completed,
+        campaigns_paused: counts.paused,
+        campaigns_with_issues: counts.with_issues,
+        campaigns_with_data: counts.with_data,
+        spend_eur: metaOverview.totals.spend_eur,
+        conclusion:
+          counts.active === 0
+            ? "No Meta campaign is currently delivering."
+            : "At least one Meta campaign is currently delivering.",
+        data_limit:
+          hasRecentData
+            ? "Recent Meta delivery data is available for comparison."
+            : "No recent Meta delivery baseline is available; do not invent forecasts or ROI.",
+      },
+      recommendation: {
+        decision:
+          "Prepare one small local dinner campaign instead of reusing recruiting or obsolete campaigns.",
+        rationale: [
+          "A single campaign avoids fragmenting a small test budget.",
+          "Local targeting keeps the experiment relevant to people near the restaurant.",
+          "A capped test creates real performance data before any scale decision.",
+        ],
+      },
+      campaign_draft: {
+        name: "Parma | Dinner | Kreuzberg | Controlled test",
+        objective,
+        buying_type: "AUCTION",
+        configured_status: "PAUSED_DRAFT",
+        daily_budget_eur: dailyBudgetEur,
+        duration_days: durationDays,
+        maximum_total_budget_eur: totalBudgetEur,
+      },
+      ad_set_draft: {
+        location: "Wrangelstraße 90, Berlin",
+        radius_km: 3,
+        age_range: "23–60",
+        genders: "all",
+        detailed_targeting: "broad local audience; no sensitive targeting",
+        optimization_goal: optimization,
+        placements: [
+          "Instagram Reels",
+          "Instagram Stories",
+          "Instagram Feed",
+          "Facebook Feed",
+          "Facebook Reels",
+        ],
+        delivery_window_local:
+          "Dinner hours only after opening days and exact hours are confirmed",
+      },
+      creative_drafts: [
+        {
+          language: "de",
+          format: "vertical video or authentic restaurant photo",
+          primary_text:
+            "Sauerteigpizza, Bio-Zutaten und echtes Handwerk in Kreuzberg. Heute Abend bei Parma in der Wrangelstraße 90.",
+          headline: "Pizzaabend in Kreuzberg",
+          call_to_action:
+            goal === "reservations" ? "Reservieren" : "Route planen",
+        },
+        {
+          language: "en",
+          format: "vertical video or authentic restaurant photo",
+          primary_text:
+            "Sourdough pizza, organic ingredients and honest craft in Kreuzberg. Dinner tonight at Parma, Wrangelstraße 90.",
+          headline: "Pizza night in Kreuzberg",
+          call_to_action:
+            goal === "reservations" ? "Book now" : "Get directions",
+        },
+      ],
+      measurement_plan: {
+        reporting_after_days: [3, 7, durationDays],
+        metrics: [
+          "spend",
+          "reach",
+          "impressions",
+          "frequency",
+          goal === "reservations" ? "landing_page_views" : "link_clicks",
+          "cost_per_result",
+        ],
+        decision_rule:
+          "Do not increase budget until real delivery data and the restaurant's business result are reviewed together.",
+      },
+      approval_checklist: [
+        "Confirm the campaign goal: dinner visits or reservations",
+        "Confirm opening days and exact advertising hours",
+        "Confirm the destination: directions, website, menu or reservation page",
+        "Approve daily budget, duration and maximum total budget",
+        "Approve the final photos or videos and both ad texts",
+        "Confirm that no discount or offer should be added unless explicitly approved",
+      ],
+      safety: {
+        read_only: true,
+        creates_campaign: false,
+        publishes_ads: false,
+        activates_spend: false,
+        human_approval_required: true,
+        recruiting_campaigns_excluded: true,
+      },
+    },
+  };
+}
+
+module.exports = { buildMetaDinnerProposal };

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const axios = require("axios");
 const { randomUUID } = require("crypto");
 const { GoogleAdsApi } = require("google-ads-api");
 const { buildGoogleReadiness, buildMetaOverview } = require("./reporting");
+const { buildMetaDinnerProposal } = require("./proposals");
 
 const app = express();
 app.use(express.json({ limit: "100kb" }));
@@ -118,6 +119,25 @@ const allowedMetaDatePresets = new Set([
 function parseMetaDatePreset(value) {
   const preset = String(value || "last_30d").trim();
   return allowedMetaDatePresets.has(preset) ? preset : null;
+}
+
+function parseProposalBudget(value) {
+  const budget = Number(value ?? 6);
+  return Number.isFinite(budget) && budget >= 3 && budget <= 20
+    ? Math.round(budget * 100) / 100
+    : null;
+}
+
+function parseProposalDuration(value) {
+  const duration = Number(value ?? 14);
+  return Number.isInteger(duration) && duration >= 7 && duration <= 30
+    ? duration
+    : null;
+}
+
+function parseProposalGoal(value) {
+  const goal = String(value || "dinner_visits").trim();
+  return new Set(["dinner_visits", "reservations"]).has(goal) ? goal : null;
 }
 
 function eurToMetaCents(eur) {
@@ -1175,6 +1195,50 @@ app.post("/tools/campaign/update-budget", requireApiKey, disableAdWrites, async 
 
 app.get("/tools/dinner-baseline-template", requireApiKey, (req, res) => {
   res.json(buildDinnerBaselineTemplate());
+});
+
+app.get("/tools/meta/proposal/dinner", requireApiKey, async (req, res) => {
+  if (!checkMetaConfig(res)) return;
+
+  const dailyBudgetEur = parseProposalBudget(req.query.daily_budget_eur);
+  const durationDays = parseProposalDuration(req.query.duration_days);
+  const goal = parseProposalGoal(req.query.goal);
+
+  if (dailyBudgetEur === null || durationDays === null || goal === null) {
+    return res.status(400).json({
+      success: false,
+      error:
+        "daily_budget_eur must be 3–20, duration_days must be 7–30, and goal must be dinner_visits or reservations",
+    });
+  }
+
+  try {
+    const [campaignCollection, insightCollection, adSetCollection] =
+      await Promise.all([
+        getCampaignCollection(),
+        getCampaignInsights("last_30d"),
+        getAdSetCollection(),
+      ]);
+    const metaOverview = buildMetaOverview(
+      campaignCollection.data,
+      insightCollection.data,
+      adSetCollection.data
+    );
+
+    res.json(
+      buildMetaDinnerProposal({
+        metaOverview,
+        dailyBudgetEur,
+        durationDays,
+        goal,
+      })
+    );
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: cleanMetaError(error),
+    });
+  }
 });
 
 app.get("/tools/test-ui", requireApiKey, disableAdWrites, (req, res) => {

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1,0 +1,52 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildMetaDinnerProposal } = require("../proposals");
+
+function metaOverview(overrides = {}) {
+  return {
+    campaign_counts: {
+      total: 7,
+      active: 0,
+      completed: 1,
+      paused: 1,
+      with_issues: 5,
+      with_data: 0,
+      ...overrides,
+    },
+    totals: { spend_eur: 0 },
+  };
+}
+
+test("builds a capped read-only dinner proposal from real Meta state", () => {
+  const result = buildMetaDinnerProposal({
+    metaOverview: metaOverview(),
+    dailyBudgetEur: 6,
+    durationDays: 14,
+    generatedAt: new Date("2026-08-20T12:00:00Z"),
+  });
+
+  assert.equal(result.proposal.status, "draft_requires_human_approval");
+  assert.equal(result.proposal.evidence.campaigns_active, 0);
+  assert.equal(result.proposal.campaign_draft.maximum_total_budget_eur, 84);
+  assert.equal(result.proposal.campaign_draft.objective, "OUTCOME_AWARENESS");
+  assert.equal(result.proposal.safety.creates_campaign, false);
+  assert.equal(result.proposal.safety.activates_spend, false);
+  assert.match(result.proposal.evidence.data_limit, /do not invent/i);
+});
+
+test("uses a traffic objective only for an approved reservation goal", () => {
+  const result = buildMetaDinnerProposal({
+    metaOverview: metaOverview({ with_data: 1 }),
+    dailyBudgetEur: 5,
+    durationDays: 10,
+    goal: "reservations",
+  });
+
+  assert.equal(result.proposal.campaign_draft.objective, "OUTCOME_TRAFFIC");
+  assert.equal(
+    result.proposal.ad_set_draft.optimization_goal,
+    "LANDING_PAGE_VIEWS"
+  );
+  assert.equal(result.proposal.campaign_draft.maximum_total_budget_eur, 50);
+});


### PR DESCRIPTION
## Cosa cambia
- aggiunge l'azione protetta `getMetaDinnerProposal`
- prepara una proposta Meta basata sullo stato reale degli ultimi 30 giorni
- include struttura, pubblico locale, budget limitato, testi DE/EN, misurazione e checklist di approvazione
- valida budget (3–20 EUR/giorno), durata (7–30 giorni) e obiettivo

## Sicurezza
- sola lettura
- nessuna creazione o pubblicazione di campagne
- nessuna attivazione di spesa
- approvazione umana obbligatoria dichiarata nell'output

## Verifica
- 11 test automatici superati
- OpenAPI YAML valido
- nessuna nuova chiamata Meta POST/PUT/DELETE