### PR TITLE
Add safe paused Meta reservation draft foundation

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -1,0 +1,362 @@
+const APPROVAL_TOKEN = "CREATE_PARMA_META_DRAFT_PAUSED_ONLY";
+const RESERVATION_URL = "https://www.parmaberlin.de/reservations";
+
+class PartialMetaDraftError extends Error {
+  constructor(message, created, cause) {
+    super(message, { cause });
+    this.name = "PartialMetaDraftError";
+    this.created = { ...created };
+  }
+}
+
+function requireNumericId(value, label) {
+  const id = String(value || "").trim();
+  if (!/^\d{1,30}$/.test(id)) {
+    throw new TypeError(`${label} must contain 1 to 30 digits`);
+  }
+  return id;
+}
+
+function requireCoordinate(value, label, minimum, maximum) {
+  const coordinate = Number(value);
+  if (!Number.isFinite(coordinate) || coordinate < minimum || coordinate > maximum) {
+    throw new TypeError(`${label} must be between ${minimum} and ${maximum}`);
+  }
+  return coordinate;
+}
+
+function requireIsoDate(value, label) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new TypeError(`${label} must be a valid date`);
+  }
+  return date;
+}
+
+function toMetaCents(eur) {
+  const amount = Number(eur);
+  if (!Number.isFinite(amount) || amount < 3 || amount > 20) {
+    throw new TypeError("dailyBudgetEur must be between 3 and 20");
+  }
+  return Math.round(amount * 100);
+}
+
+function assertPausedOnly(value, path = "draft") {
+  if (typeof value === "string" && value.toUpperCase() === "ACTIVE") {
+    throw new Error(`${path} must never contain ACTIVE status`);
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertPausedOnly(item, `${path}[${index}]`));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    Object.entries(value).forEach(([key, item]) =>
+      assertPausedOnly(item, `${path}.${key}`)
+    );
+  }
+}
+
+function getInstagramReelCode(permalink) {
+  let url;
+  try {
+    url = new URL(permalink);
+  } catch {
+    throw new TypeError("reelPermalink must be a valid Instagram Reel URL");
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const match = url.pathname.match(/^\/reel\/([A-Za-z0-9_-]+)\/?$/);
+  if (!(hostname === "instagram.com" || hostname === "www.instagram.com") || !match) {
+    throw new TypeError("reelPermalink must be a valid Instagram Reel URL");
+  }
+  return match[1];
+}
+
+async function discoverInstagramReelAssets({
+  transport,
+  instagramUsername = "parma.divinibenedetti",
+  reelPermalink,
+  maxPages = 10,
+}) {
+  if (!transport || typeof transport.get !== "function") {
+    throw new TypeError("transport must provide a get function");
+  }
+  if (!Number.isInteger(maxPages) || maxPages < 1 || maxPages > 20) {
+    throw new TypeError("maxPages must be an integer between 1 and 20");
+  }
+
+  const reelCode = getInstagramReelCode(reelPermalink);
+  const expectedUsername = String(instagramUsername || "").trim().toLowerCase();
+  const pageCollection = await transport.get("/me/accounts", {
+    fields: "id,name,instagram_business_account{id,username}",
+    limit: 100,
+  });
+  const page = (pageCollection?.data || []).find((candidate) => {
+    const username = candidate?.instagram_business_account?.username;
+    return String(username || "").trim().toLowerCase() === expectedUsername;
+  });
+
+  if (!page) {
+    throw new Error(`No connected Meta Page found for @${expectedUsername}`);
+  }
+
+  const pageId = requireNumericId(page.id, "discovered page id");
+  const instagramUserId = requireNumericId(
+    page.instagram_business_account.id,
+    "discovered Instagram user id"
+  );
+  let after = null;
+  let pagesChecked = 0;
+  let matchedMedia = null;
+
+  do {
+    const collection = await transport.get(`/${instagramUserId}/media`, {
+      fields: "id,media_type,permalink,timestamp",
+      limit: 100,
+      ...(after ? { after } : {}),
+    });
+    pagesChecked += 1;
+    matchedMedia = (collection?.data || []).find((media) => {
+      try {
+        return getInstagramReelCode(media.permalink) === reelCode;
+      } catch {
+        return false;
+      }
+    });
+    if (matchedMedia) break;
+
+    after = collection?.paging?.cursors?.after || null;
+    if (!collection?.paging?.next) after = null;
+  } while (after && pagesChecked < maxPages);
+
+  if (!matchedMedia) {
+    throw new Error(`Reel ${reelCode} was not found in the connected Instagram media`);
+  }
+
+  return {
+    page_id: pageId,
+    instagram_user_id: instagramUserId,
+    source_instagram_media_id: requireNumericId(
+      matchedMedia.id,
+      "discovered Instagram media id"
+    ),
+    instagram_username: expectedUsername,
+    reel_code: reelCode,
+    pages_checked: pagesChecked,
+    contains_access_token: false,
+  };
+}
+
+function buildPausedReservationDraft({
+  pageId,
+  instagramUserId,
+  adVideoId,
+  latitude,
+  longitude,
+  dailyBudgetEur = 6,
+  durationDays = 14,
+  startsAt,
+  destinationUrl = RESERVATION_URL,
+}) {
+  if (destinationUrl !== RESERVATION_URL) {
+    throw new TypeError(`destinationUrl must be exactly ${RESERVATION_URL}`);
+  }
+
+  if (!Number.isInteger(durationDays) || durationDays < 7 || durationDays > 30) {
+    throw new TypeError("durationDays must be an integer between 7 and 30");
+  }
+
+  const normalizedPageId = requireNumericId(pageId, "pageId");
+  const normalizedInstagramUserId = requireNumericId(
+    instagramUserId,
+    "instagramUserId"
+  );
+  const normalizedAdVideoId = requireNumericId(adVideoId, "adVideoId");
+  const normalizedLatitude = requireCoordinate(latitude, "latitude", -90, 90);
+  const normalizedLongitude = requireCoordinate(longitude, "longitude", -180, 180);
+  const start = requireIsoDate(startsAt, "startsAt");
+  const end = new Date(start.getTime() + durationDays * 24 * 60 * 60 * 1000);
+  const dailyBudgetCents = toMetaCents(dailyBudgetEur);
+  const maximumTotalBudgetCents = dailyBudgetCents * durationDays;
+
+  const draft = {
+    policy: {
+      mode: "paused_draft_only",
+      may_activate: false,
+      may_publish_active_ad: false,
+      destination_allowlist: [RESERVATION_URL],
+      approval_token_required: APPROVAL_TOKEN,
+    },
+    budget: {
+      daily_eur: dailyBudgetCents / 100,
+      duration_days: durationDays,
+      maximum_total_eur: maximumTotalBudgetCents / 100,
+    },
+    campaign: {
+      name: "Parma | Reservations | Kreuzberg | Controlled test",
+      objective: "OUTCOME_TRAFFIC",
+      buying_type: "AUCTION",
+      special_ad_categories: [],
+      status: "PAUSED",
+    },
+    adSet: {
+      name: "Parma | 3 km | 23-60 | Reservations",
+      billing_event: "IMPRESSIONS",
+      optimization_goal: "LINK_CLICKS",
+      bid_strategy: "LOWEST_COST_WITHOUT_CAP",
+      lifetime_budget: maximumTotalBudgetCents,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      destination_type: "WEBSITE",
+      targeting: {
+        age_min: 23,
+        age_max: 60,
+        geo_locations: {
+          custom_locations: [
+            {
+              latitude: normalizedLatitude,
+              longitude: normalizedLongitude,
+              radius: 3,
+              distance_unit: "kilometer",
+            },
+          ],
+        },
+        publisher_platforms: ["facebook", "instagram"],
+      },
+      status: "PAUSED",
+    },
+    creative: {
+      name: "Parma | Existing Reel video | Reservations",
+      object_story_spec: {
+        page_id: normalizedPageId,
+        instagram_user_id: normalizedInstagramUserId,
+        video_data: {
+          video_id: normalizedAdVideoId,
+          message:
+            "Sauerteigpizza, Bio-Zutaten und echtes Handwerk in Kreuzberg. Jeden Abend von 17 bis 23 Uhr bei Parma in der Wrangelstraße 90.",
+          title: "Pizzaabend in Kreuzberg",
+          call_to_action: {
+            type: "BOOK_NOW",
+            value: { link: RESERVATION_URL },
+          },
+        },
+      },
+    },
+    ad: {
+      name: "Parma | Reel | Jetzt reservieren",
+      status: "PAUSED",
+    },
+  };
+
+  assertPausedOnly(draft);
+  return draft;
+}
+
+async function createPausedReservationDraft({
+  transport,
+  adAccountId,
+  draft,
+  approvalToken,
+}) {
+  if (approvalToken !== APPROVAL_TOKEN) {
+    throw new Error("Exact paused-draft approval token is required");
+  }
+  if (!transport || typeof transport.post !== "function" || typeof transport.get !== "function") {
+    throw new TypeError("transport must provide post and get functions");
+  }
+
+  const accountId = String(adAccountId || "").trim();
+  if (!/^act_\d{1,30}$/.test(accountId)) {
+    throw new TypeError("adAccountId must use the act_<digits> format");
+  }
+
+  assertPausedOnly(draft);
+  const created = {};
+
+  try {
+    const campaign = await transport.post(`/${accountId}/campaigns`, draft.campaign);
+    created.campaign_id = requireNumericId(campaign?.id, "created campaign id");
+
+    const adSet = await transport.post(`/${accountId}/adsets`, {
+      ...draft.adSet,
+      campaign_id: created.campaign_id,
+    });
+    created.adset_id = requireNumericId(adSet?.id, "created ad set id");
+
+    const creative = await transport.post(`/${accountId}/adcreatives`, draft.creative);
+    created.creative_id = requireNumericId(creative?.id, "created creative id");
+
+    const ad = await transport.post(`/${accountId}/ads`, {
+      ...draft.ad,
+      adset_id: created.adset_id,
+      creative: { creative_id: created.creative_id },
+    });
+    created.ad_id = requireNumericId(ad?.id, "created ad id");
+
+    let verificationEntries = await Promise.all(
+      [created.campaign_id, created.adset_id, created.ad_id].map(async (id) => {
+        const object = await transport.get(`/${id}`, { fields: "id,status,effective_status" });
+        return [id, object];
+      })
+    );
+    let verification = Object.fromEntries(verificationEntries);
+    const unexpectedStatuses = Object.entries(verification).filter(
+      ([, object]) => object?.status !== "PAUSED"
+    );
+
+    if (unexpectedStatuses.length > 0) {
+      await Promise.all(
+        unexpectedStatuses.map(([id]) =>
+          transport.post(`/${id}`, { status: "PAUSED" })
+        )
+      );
+      verificationEntries = await Promise.all(
+        [created.campaign_id, created.adset_id, created.ad_id].map(async (id) => {
+          const object = await transport.get(`/${id}`, {
+            fields: "id,status,effective_status",
+          });
+          return [id, object];
+        })
+      );
+      verification = Object.fromEntries(verificationEntries);
+    }
+
+    const stillUnsafe = Object.entries(verification).filter(
+      ([, object]) => object?.status !== "PAUSED"
+    );
+    if (stillUnsafe.length > 0) {
+      throw new Error(
+        `Meta objects were not verified as PAUSED after emergency pause: ${stillUnsafe
+          .map(([id]) => id)
+          .join(",")}`
+      );
+    }
+
+    return {
+      success: true,
+      mode: "paused_draft_only",
+      created,
+      verification,
+      activates_spend: false,
+    };
+  } catch (error) {
+    throw new PartialMetaDraftError(
+      "Paused Meta draft creation did not complete; inspect the returned object IDs before any further action",
+      created,
+      error
+    );
+  }
+}
+
+module.exports = {
+  APPROVAL_TOKEN,
+  RESERVATION_URL,
+  PartialMetaDraftError,
+  assertPausedOnly,
+  discoverInstagramReelAssets,
+  getInstagramReelCode,
+  buildPausedReservationDraft,
+  createPausedReservationDraft,
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -145,6 +145,27 @@ paths:
           description: Draft proposal based on current Meta state; no ads are created
         "400":
           description: Invalid proposal parameters
+  /tools/meta/draft-assets:
+    get:
+      operationId: inspectMetaDinnerDraftAssets
+      summary: Verify the connected Parma Instagram account and approved Reel in read-only mode
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: reel_permalink
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uri
+            example: https://www.instagram.com/reel/C9M7_b6MayR/
+      responses:
+        "200":
+          description: Non-secret Meta Page, Instagram account and Reel identifiers
+        "400":
+          description: Invalid Instagram Reel URL
+        "500":
+          description: The connected Page, Instagram account or Reel could not be verified
 components:
   schemas: {}
   securitySchemes:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "check": "node --check server.js && node --check reporting.js",
+    "check": "node --check server.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js",
     "test": "node --test"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const { randomUUID } = require("crypto");
 const { GoogleAdsApi } = require("google-ads-api");
 const { buildGoogleReadiness, buildMetaOverview } = require("./reporting");
 const { buildMetaDinnerProposal } = require("./proposals");
+const { discoverInstagramReelAssets } = require("./meta-paused-draft");
 
 const app = express();
 app.use(express.json({ limit: "100kb" }));
@@ -49,6 +50,18 @@ const metaClient = axios.create({
   baseURL: META_BASE_URL,
   timeout: 20000,
 });
+
+const metaReadTransport = {
+  async get(endpoint, params = {}) {
+    const response = await metaClient.get(endpoint, {
+      params: {
+        ...params,
+        access_token: META_ACCESS_TOKEN,
+      },
+    });
+    return response.data;
+  },
+};
 
 function requireApiKey(req, res, next) {
   const apiKey =
@@ -889,6 +902,33 @@ async function handleOverviewReport(req, res) {
 
 app.get("/tools/report/overview", requireApiKey, handleOverviewReport);
 app.get("/tools/dashboard", requireApiKey, handleOverviewReport);
+
+app.get("/tools/meta/draft-assets", requireApiKey, async (req, res) => {
+  if (!checkMetaConfig(res)) return;
+
+  try {
+    const assets = await discoverInstagramReelAssets({
+      transport: metaReadTransport,
+      instagramUsername: "parma.divinibenedetti",
+      reelPermalink: req.query.reel_permalink,
+    });
+
+    res.json({
+      success: true,
+      mode: "read_only",
+      assets,
+      ad_writes_enabled: false,
+    });
+  } catch (error) {
+    const isInputError = error instanceof TypeError;
+    res.status(isInputError ? 400 : 500).json({
+      success: false,
+      error: isInputError
+        ? { message: error.message, type: "validation_error" }
+        : cleanMetaError(error),
+    });
+  }
+});
 
 app.get("/meta/campaigns", requireApiKey, async (req, res) => {
   if (!checkMetaConfig(res)) return;

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -1,0 +1,298 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  APPROVAL_TOKEN,
+  RESERVATION_URL,
+  PartialMetaDraftError,
+  assertPausedOnly,
+  discoverInstagramReelAssets,
+  getInstagramReelCode,
+  buildPausedReservationDraft,
+  createPausedReservationDraft,
+} = require("../meta-paused-draft");
+
+function validInput(overrides = {}) {
+  return {
+    pageId: "101",
+    instagramUserId: "202",
+    adVideoId: "303",
+    latitude: 52.5,
+    longitude: 13.44,
+    startsAt: "2026-08-24T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("builds the approved reservation campaign as a capped paused-only draft", () => {
+  const draft = buildPausedReservationDraft(validInput());
+
+  assert.equal(draft.campaign.status, "PAUSED");
+  assert.equal(draft.adSet.status, "PAUSED");
+  assert.equal(draft.ad.status, "PAUSED");
+  assert.equal(draft.campaign.objective, "OUTCOME_TRAFFIC");
+  assert.equal(draft.adSet.optimization_goal, "LINK_CLICKS");
+  assert.equal(draft.adSet.lifetime_budget, 8400);
+  assert.equal("daily_budget" in draft.adSet, false);
+  assert.equal(draft.budget.maximum_total_eur, 84);
+  assert.equal(
+    draft.creative.object_story_spec.video_data.call_to_action.value.link,
+    RESERVATION_URL
+  );
+  assert.equal(
+    draft.creative.object_story_spec.video_data.call_to_action.type,
+    "BOOK_NOW"
+  );
+  assert.doesNotThrow(() => assertPausedOnly(draft));
+});
+
+test("rejects destinations outside the exact reservation URL allowlist", () => {
+  assert.throws(
+    () =>
+      buildPausedReservationDraft(
+        validInput({ destinationUrl: "https://example.com/reservations" })
+      ),
+    /destinationUrl must be exactly/
+  );
+});
+
+test("rejects invalid Meta identifiers and unsafe budgets", () => {
+  assert.throws(
+    () => buildPausedReservationDraft(validInput({ pageId: "101-secret" })),
+    /pageId must contain/
+  );
+  assert.throws(
+    () => buildPausedReservationDraft(validInput({ dailyBudgetEur: 25 })),
+    /dailyBudgetEur must be between/
+  );
+});
+
+test("paused-only guard rejects ACTIVE anywhere in a request", () => {
+  assert.throws(
+    () => assertPausedOnly({ nested: { status: "ACTIVE" } }),
+    /must never contain ACTIVE/
+  );
+});
+
+test("extracts only valid Instagram Reel codes", () => {
+  assert.equal(
+    getInstagramReelCode(
+      "https://www.instagram.com/reel/C9M7_b6MayR/?igsh=cTZmeXNtb3pjbG13"
+    ),
+    "C9M7_b6MayR"
+  );
+  assert.throws(
+    () => getInstagramReelCode("https://example.com/reel/C9M7_b6MayR/"),
+    /valid Instagram Reel URL/
+  );
+});
+
+test("discovers the connected Page, Instagram account and approved Reel without secrets", async () => {
+  const calls = [];
+  const transport = {
+    get: async (path, params) => {
+      calls.push({ path, params });
+      if (path === "/me/accounts") {
+        return {
+          data: [
+            {
+              id: "501",
+              name: "Parma",
+              instagram_business_account: {
+                id: "502",
+                username: "parma.divinibenedetti",
+              },
+            },
+          ],
+        };
+      }
+      return {
+        data: [
+          {
+            id: "503",
+            media_type: "VIDEO",
+            permalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+          },
+        ],
+      };
+    },
+  };
+
+  const result = await discoverInstagramReelAssets({
+    transport,
+    reelPermalink:
+      "https://www.instagram.com/reel/C9M7_b6MayR/?igsh=cTZmeXNtb3pjbG13",
+  });
+
+  assert.deepEqual(result, {
+    page_id: "501",
+    instagram_user_id: "502",
+    source_instagram_media_id: "503",
+    instagram_username: "parma.divinibenedetti",
+    reel_code: "C9M7_b6MayR",
+    pages_checked: 1,
+    contains_access_token: false,
+  });
+  assert.equal(calls.some((call) => "access_token" in call.params), false);
+});
+
+test("fails clearly when the expected Instagram account is not connected", async () => {
+  const transport = {
+    get: async () => ({ data: [] }),
+  };
+
+  await assert.rejects(
+    discoverInstagramReelAssets({
+      transport,
+      reelPermalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+    }),
+    /No connected Meta Page found/
+  );
+});
+
+test("executor refuses all writes without the exact scoped approval token", async () => {
+  const calls = [];
+  const transport = {
+    post: async (...args) => calls.push(args),
+    get: async (...args) => calls.push(args),
+  };
+
+  await assert.rejects(
+    createPausedReservationDraft({
+      transport,
+      adAccountId: "act_404",
+      draft: buildPausedReservationDraft(validInput()),
+      approvalToken: "yes",
+    }),
+    /Exact paused-draft approval token/
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("executor creates and verifies only paused Meta objects", async () => {
+  const posts = [];
+  const ids = ["1001", "1002", "1003", "1004"];
+  const transport = {
+    post: async (path, payload) => {
+      posts.push({ path, payload });
+      return { id: ids[posts.length - 1] };
+    },
+    get: async (path) => ({
+      id: path.slice(1),
+      status: "PAUSED",
+      effective_status: "PAUSED",
+    }),
+  };
+
+  const result = await createPausedReservationDraft({
+    transport,
+    adAccountId: "act_404",
+    draft: buildPausedReservationDraft(validInput()),
+    approvalToken: APPROVAL_TOKEN,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.activates_spend, false);
+  assert.deepEqual(result.created, {
+    campaign_id: "1001",
+    adset_id: "1002",
+    creative_id: "1003",
+    ad_id: "1004",
+  });
+  assert.deepEqual(
+    posts.map((call) => call.path),
+    [
+      "/act_404/campaigns",
+      "/act_404/adsets",
+      "/act_404/adcreatives",
+      "/act_404/ads",
+    ]
+  );
+  posts.forEach((call) => assert.doesNotThrow(() => assertPausedOnly(call.payload)));
+});
+
+test("reports partial paused objects instead of hiding a failed draft", async () => {
+  let postCount = 0;
+  const transport = {
+    post: async () => {
+      postCount += 1;
+      if (postCount === 3) throw new Error("creative rejected");
+      return { id: String(2000 + postCount) };
+    },
+    get: async () => ({ status: "PAUSED" }),
+  };
+
+  await assert.rejects(
+    createPausedReservationDraft({
+      transport,
+      adAccountId: "act_404",
+      draft: buildPausedReservationDraft(validInput()),
+      approvalToken: APPROVAL_TOKEN,
+    }),
+    (error) => {
+      assert.ok(error instanceof PartialMetaDraftError);
+      assert.deepEqual(error.created, {
+        campaign_id: "2001",
+        adset_id: "2002",
+      });
+      assert.match(error.cause.message, /creative rejected/);
+      return true;
+    }
+  );
+});
+
+test("repairs and rechecks an unexpected non-paused Meta object", async () => {
+  let postCount = 0;
+  let repaired = false;
+  const transport = {
+    post: async (path, payload) => {
+      if (path === "/3002" && payload?.status === "PAUSED") {
+        repaired = true;
+        return { success: true };
+      }
+      return { id: String(3001 + postCount++) };
+    },
+    get: async (path) => ({
+      id: path.slice(1),
+      status: path === "/3002" && !repaired ? "ACTIVE" : "PAUSED",
+    }),
+  };
+
+  const result = await createPausedReservationDraft({
+    transport,
+    adAccountId: "act_404",
+    draft: buildPausedReservationDraft(validInput()),
+    approvalToken: APPROVAL_TOKEN,
+  });
+
+  assert.equal(repaired, true);
+  assert.equal(result.verification["3002"].status, "PAUSED");
+});
+
+test("fails closed if emergency pause cannot be verified", async () => {
+  let postCount = 0;
+  const transport = {
+    post: async (path) => {
+      if (/^\/\d+$/.test(path)) return { success: false };
+      return { id: String(4001 + postCount++) };
+    },
+    get: async (path) => ({
+      id: path.slice(1),
+      status: path === "/4002" ? "ACTIVE" : "PAUSED",
+    }),
+  };
+
+  await assert.rejects(
+    createPausedReservationDraft({
+      transport,
+      adAccountId: "act_404",
+      draft: buildPausedReservationDraft(validInput()),
+      approvalToken: APPROVAL_TOKEN,
+    }),
+    (error) => {
+      assert.ok(error instanceof PartialMetaDraftError);
+      assert.match(error.cause.message, /after emergency pause/);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a paused-only Meta reservation draft builder with hard safety guards
- cap the experiment with an €84 lifetime budget and an exact reservation URL allowlist
- add a read-only Action to identify the connected Parma Instagram account and selected Reel
- keep campaign creation unreachable from Express and OpenAPI

## Validation
- 23/23 Node tests pass
- OpenAPI YAML parses successfully
- no live Meta write was performed