### PR TITLE
Fix Meta identity discovery for system tokens

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -76,6 +76,7 @@ function getInstagramReelCode(permalink) {
 
 async function discoverInstagramReelAssets({
   transport,
+  adAccountId,
   instagramUsername = "parma.divinibenedetti",
   reelPermalink,
   maxPages = 10,
@@ -87,26 +88,58 @@ async function discoverInstagramReelAssets({
     throw new TypeError("maxPages must be an integer between 1 and 20");
   }
 
+  const normalizedAdAccountId = String(adAccountId || "").trim();
+  if (!/^act_\d{1,30}$/.test(normalizedAdAccountId)) {
+    throw new TypeError("adAccountId must use the act_<digits> format");
+  }
+
   const reelCode = getInstagramReelCode(reelPermalink);
   const expectedUsername = String(instagramUsername || "").trim().toLowerCase();
-  const pageCollection = await transport.get("/me/accounts", {
-    fields: "id,name,instagram_business_account{id,username}",
-    limit: 100,
-  });
+  const instagramCollection = await transport.get(
+    `/${normalizedAdAccountId}/instagram_accounts`,
+    {
+      fields: "id,username",
+      limit: 100,
+    }
+  );
+  const instagramAccount = (instagramCollection?.data || []).find(
+    (candidate) =>
+      String(candidate?.username || "").trim().toLowerCase() === expectedUsername
+  );
+
+  if (!instagramAccount) {
+    throw new Error(
+      `No Instagram account @${expectedUsername} is associated with ${normalizedAdAccountId}`
+    );
+  }
+
+  const instagramUserId = requireNumericId(
+    instagramAccount.id,
+    "discovered Instagram user id"
+  );
+  const pageCollection = await transport.get(
+    `/${normalizedAdAccountId}/promote_pages`,
+    {
+      fields: "id,name,instagram_business_account{id,username}",
+      limit: 100,
+    }
+  );
   const page = (pageCollection?.data || []).find((candidate) => {
-    const username = candidate?.instagram_business_account?.username;
-    return String(username || "").trim().toLowerCase() === expectedUsername;
+    const connectedInstagram = candidate?.instagram_business_account;
+    return (
+      String(connectedInstagram?.id || "") === instagramUserId ||
+      String(connectedInstagram?.username || "").trim().toLowerCase() ===
+        expectedUsername
+    );
   });
 
   if (!page) {
-    throw new Error(`No connected Meta Page found for @${expectedUsername}`);
+    throw new Error(
+      `No promotable Meta Page linked to @${expectedUsername} was found for ${normalizedAdAccountId}`
+    );
   }
 
   const pageId = requireNumericId(page.id, "discovered page id");
-  const instagramUserId = requireNumericId(
-    page.instagram_business_account.id,
-    "discovered Instagram user id"
-  );
   let after = null;
   let pagesChecked = 0;
   let matchedMedia = null;

--- a/server.js
+++ b/server.js
@@ -909,6 +909,7 @@ app.get("/tools/meta/draft-assets", requireApiKey, async (req, res) => {
   try {
     const assets = await discoverInstagramReelAssets({
       transport: metaReadTransport,
+      adAccountId: META_AD_ACCOUNT_ID,
       instagramUsername: "parma.divinibenedetti",
       reelPermalink: req.query.reel_permalink,
     });

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -92,7 +92,17 @@ test("discovers the connected Page, Instagram account and approved Reel without 
   const transport = {
     get: async (path, params) => {
       calls.push({ path, params });
-      if (path === "/me/accounts") {
+      if (path === "/act_404/instagram_accounts") {
+        return {
+          data: [
+            {
+              id: "502",
+              username: "parma.divinibenedetti",
+            },
+          ],
+        };
+      }
+      if (path === "/act_404/promote_pages") {
         return {
           data: [
             {
@@ -120,6 +130,7 @@ test("discovers the connected Page, Instagram account and approved Reel without 
 
   const result = await discoverInstagramReelAssets({
     transport,
+    adAccountId: "act_404",
     reelPermalink:
       "https://www.instagram.com/reel/C9M7_b6MayR/?igsh=cTZmeXNtb3pjbG13",
   });
@@ -144,9 +155,10 @@ test("fails clearly when the expected Instagram account is not connected", async
   await assert.rejects(
     discoverInstagramReelAssets({
       transport,
+      adAccountId: "act_404",
       reelPermalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
     }),
-    /No connected Meta Page found/
+    /No Instagram account/
   );
 });
 


### PR DESCRIPTION
## Summary
- discover Instagram identities from the configured ad account instead of `/me/accounts`
- resolve the promotable Meta Page linked to @parma.divinibenedetti
- keep the diagnostic Action read-only and token-free

## Validation
- 23/23 Node tests pass
- only three files changed
- no Meta write operation was performed