### PR TITLE
Prefer Page-linked Instagram identity discovery

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -95,28 +95,6 @@ async function discoverInstagramReelAssets({
 
   const reelCode = getInstagramReelCode(reelPermalink);
   const expectedUsername = String(instagramUsername || "").trim().toLowerCase();
-  const instagramCollection = await transport.get(
-    `/${normalizedAdAccountId}/instagram_accounts`,
-    {
-      fields: "id,username",
-      limit: 100,
-    }
-  );
-  const instagramAccount = (instagramCollection?.data || []).find(
-    (candidate) =>
-      String(candidate?.username || "").trim().toLowerCase() === expectedUsername
-  );
-
-  if (!instagramAccount) {
-    throw new Error(
-      `No Instagram account @${expectedUsername} is associated with ${normalizedAdAccountId}`
-    );
-  }
-
-  const instagramUserId = requireNumericId(
-    instagramAccount.id,
-    "discovered Instagram user id"
-  );
   const pageCollection = await transport.get(
     `/${normalizedAdAccountId}/promote_pages`,
     {
@@ -124,14 +102,56 @@ async function discoverInstagramReelAssets({
       limit: 100,
     }
   );
-  const page = (pageCollection?.data || []).find((candidate) => {
+  let page = (pageCollection?.data || []).find((candidate) => {
     const connectedInstagram = candidate?.instagram_business_account;
-    return (
-      String(connectedInstagram?.id || "") === instagramUserId ||
-      String(connectedInstagram?.username || "").trim().toLowerCase() ===
-        expectedUsername
-    );
+    return String(connectedInstagram?.username || "").trim().toLowerCase() ===
+      expectedUsername;
   });
+
+  let instagramAccount = page?.instagram_business_account || null;
+
+  // Some Meta system-user tokens can read the Page connection but do not expose
+  // the ad account's instagram_accounts edge. Prefer the Page-owned identity and
+  // retain the ad-account edge only as a compatibility fallback.
+  if (!instagramAccount) {
+    const instagramCollection = await transport.get(
+      `/${normalizedAdAccountId}/instagram_accounts`,
+      {
+        fields: "id,username",
+        limit: 100,
+      }
+    );
+    instagramAccount = (instagramCollection?.data || []).find(
+      (candidate) =>
+        String(candidate?.username || "").trim().toLowerCase() === expectedUsername
+    );
+
+    if (instagramAccount) {
+      const fallbackInstagramId = requireNumericId(
+        instagramAccount.id,
+        "discovered Instagram user id"
+      );
+      page = (pageCollection?.data || []).find((candidate) => {
+        const connectedInstagram = candidate?.instagram_business_account;
+        return (
+          String(connectedInstagram?.id || "") === fallbackInstagramId ||
+          String(connectedInstagram?.username || "").trim().toLowerCase() ===
+            expectedUsername
+        );
+      });
+    }
+  }
+
+  if (!instagramAccount) {
+    throw new Error(
+      `No Instagram account @${expectedUsername} is connected to a promotable Meta Page or ${normalizedAdAccountId}`
+    );
+  }
+
+  const instagramUserId = requireNumericId(
+    instagramAccount.id,
+    "discovered Instagram user id"
+  );
 
   if (!page) {
     throw new Error(

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -92,16 +92,6 @@ test("discovers the connected Page, Instagram account and approved Reel without 
   const transport = {
     get: async (path, params) => {
       calls.push({ path, params });
-      if (path === "/act_404/instagram_accounts") {
-        return {
-          data: [
-            {
-              id: "502",
-              username: "parma.divinibenedetti",
-            },
-          ],
-        };
-      }
       if (path === "/act_404/promote_pages") {
         return {
           data: [
@@ -145,6 +135,51 @@ test("discovers the connected Page, Instagram account and approved Reel without 
     contains_access_token: false,
   });
   assert.equal(calls.some((call) => "access_token" in call.params), false);
+  assert.equal(
+    calls.some((call) => call.path === "/act_404/instagram_accounts"),
+    false
+  );
+});
+
+test("falls back to the ad-account Instagram edge when Page username metadata is absent", async () => {
+  const transport = {
+    get: async (path) => {
+      if (path === "/act_404/promote_pages") {
+        return {
+          data: [
+            {
+              id: "501",
+              instagram_business_account: { id: "502" },
+            },
+          ],
+        };
+      }
+      if (path === "/act_404/instagram_accounts") {
+        return {
+          data: [{ id: "502", username: "parma.divinibenedetti" }],
+        };
+      }
+      return {
+        data: [
+          {
+            id: "503",
+            media_type: "VIDEO",
+            permalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+          },
+        ],
+      };
+    },
+  };
+
+  const result = await discoverInstagramReelAssets({
+    transport,
+    adAccountId: "act_404",
+    reelPermalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+  });
+
+  assert.equal(result.page_id, "501");
+  assert.equal(result.instagram_user_id, "502");
+  assert.equal(result.source_instagram_media_id, "503");
 });
 
 test("fails clearly when the expected Instagram account is not connected", async () => {


### PR DESCRIPTION
## Summary
- discover the Instagram identity from the promotable Meta Page first
- retain the ad-account Instagram edge as a compatibility fallback
- add regression coverage for both discovery paths

## Validation
- `node --test`: 24/24 passing
- `node --check meta-paused-draft.js`
- `git diff --check`

No campaign write route or spend activation is introduced.