### PR TITLE
Discover Instagram through Business-owned assets

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -102,13 +102,67 @@ async function discoverInstagramReelAssets({
       limit: 100,
     }
   );
-  let page = (pageCollection?.data || []).find((candidate) => {
+  const candidatePages = [...(pageCollection?.data || [])];
+  let page = candidatePages.find((candidate) => {
     const connectedInstagram = candidate?.instagram_business_account;
     return String(connectedInstagram?.username || "").trim().toLowerCase() ===
       expectedUsername;
   });
 
   let instagramAccount = page?.instagram_business_account || null;
+
+  // Business-owned assets are the canonical discovery path for system-user
+  // tokens. Derive the Business from the configured ad account so no Business
+  // identifier needs to be stored or exposed separately.
+  if (!instagramAccount) {
+    try {
+      const adAccount = await transport.get(`/${normalizedAdAccountId}`, {
+        fields: "business{id}",
+      });
+      const rawBusinessId = adAccount?.business?.id;
+      if (rawBusinessId) {
+        const businessId = requireNumericId(
+          rawBusinessId,
+          "discovered Meta Business id"
+        );
+        const [ownedInstagramCollection, ownedPageCollection] = await Promise.all([
+          transport.get(`/${businessId}/owned_instagram_accounts`, {
+            fields: "id,username",
+            limit: 100,
+          }),
+          transport.get(`/${businessId}/owned_pages`, {
+            fields: "id,name,instagram_business_account{id,username}",
+            limit: 100,
+          }),
+        ]);
+
+        instagramAccount = (ownedInstagramCollection?.data || []).find(
+          (candidate) =>
+            String(candidate?.username || "").trim().toLowerCase() ===
+            expectedUsername
+        );
+        candidatePages.push(...(ownedPageCollection?.data || []));
+
+        if (instagramAccount) {
+          const ownedInstagramId = requireNumericId(
+            instagramAccount.id,
+            "discovered Instagram user id"
+          );
+          page = candidatePages.find((candidate) => {
+            const connectedInstagram = candidate?.instagram_business_account;
+            return (
+              String(connectedInstagram?.id || "") === ownedInstagramId ||
+              String(connectedInstagram?.username || "").trim().toLowerCase() ===
+                expectedUsername
+            );
+          });
+        }
+      }
+    } catch {
+      // Continue to the compatibility edge below. A failure on one read-only
+      // discovery path must not prevent the other supported path from running.
+    }
+  }
 
   // Some Meta system-user tokens can read the Page connection but do not expose
   // the ad account's instagram_accounts edge. Prefer the Page-owned identity and
@@ -131,7 +185,7 @@ async function discoverInstagramReelAssets({
         instagramAccount.id,
         "discovered Instagram user id"
       );
-      page = (pageCollection?.data || []).find((candidate) => {
+      page = candidatePages.find((candidate) => {
         const connectedInstagram = candidate?.instagram_business_account;
         return (
           String(connectedInstagram?.id || "") === fallbackInstagramId ||

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -182,6 +182,67 @@ test("falls back to the ad-account Instagram edge when Page username metadata is
   assert.equal(result.source_instagram_media_id, "503");
 });
 
+test("discovers Instagram and its Page from Business-owned assets for a system-user token", async () => {
+  const calls = [];
+  const transport = {
+    get: async (path, params) => {
+      calls.push({ path, params });
+      if (path === "/act_404/promote_pages") {
+        return { data: [{ id: "501", name: "Parma" }] };
+      }
+      if (path === "/act_404") {
+        return { business: { id: "601" } };
+      }
+      if (path === "/601/owned_instagram_accounts") {
+        return {
+          data: [{ id: "502", username: "parma.divinibenedetti" }],
+        };
+      }
+      if (path === "/601/owned_pages") {
+        return {
+          data: [
+            {
+              id: "501",
+              name: "Parma",
+              instagram_business_account: {
+                id: "502",
+                username: "parma.divinibenedetti",
+              },
+            },
+          ],
+        };
+      }
+      if (path === "/502/media") {
+        return {
+          data: [
+            {
+              id: "503",
+              media_type: "VIDEO",
+              permalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    },
+  };
+
+  const result = await discoverInstagramReelAssets({
+    transport,
+    adAccountId: "act_404",
+    reelPermalink: "https://www.instagram.com/reel/C9M7_b6MayR/",
+  });
+
+  assert.equal(result.page_id, "501");
+  assert.equal(result.instagram_user_id, "502");
+  assert.equal(result.source_instagram_media_id, "503");
+  assert.equal(
+    calls.some((call) => call.path === "/act_404/instagram_accounts"),
+    false
+  );
+  assert.equal(calls.some((call) => "access_token" in call.params), false);
+});
+
 test("fails clearly when the expected Instagram account is not connected", async () => {
   const transport = {
     get: async () => ({ data: [] }),


### PR DESCRIPTION
## Summary
- derive the Meta Business from the configured ad account
- discover Instagram and its linked Page through Business-owned assets for system-user tokens
- keep Page-promotable and ad-account identity edges as compatibility fallbacks

## Validation
- `node --test`: 25/25 passing
- `node --check meta-paused-draft.js`
- `git diff --check`

No token, payment, campaign-write route, or spend behavior is changed.