### PR TITLE
Add guarded paused Meta reservation draft

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -302,7 +302,7 @@ async function discoverInstagramReelAssets({
 function buildPausedReservationDraft({
   pageId,
   instagramUserId,
-  adVideoId,
+  sourceInstagramMediaId,
   latitude,
   longitude,
   dailyBudgetEur = 6,
@@ -323,13 +323,17 @@ function buildPausedReservationDraft({
     instagramUserId,
     "instagramUserId"
   );
-  const normalizedAdVideoId = requireNumericId(adVideoId, "adVideoId");
+  const normalizedSourceInstagramMediaId = requireNumericId(
+    sourceInstagramMediaId,
+    "sourceInstagramMediaId"
+  );
   const normalizedLatitude = requireCoordinate(latitude, "latitude", -90, 90);
   const normalizedLongitude = requireCoordinate(longitude, "longitude", -180, 180);
   const start = requireIsoDate(startsAt, "startsAt");
   const end = new Date(start.getTime() + durationDays * 24 * 60 * 60 * 1000);
   const dailyBudgetCents = toMetaCents(dailyBudgetEur);
   const maximumTotalBudgetCents = dailyBudgetCents * durationDays;
+  const startDate = start.toISOString().slice(0, 10);
 
   const draft = {
     policy: {
@@ -345,14 +349,14 @@ function buildPausedReservationDraft({
       maximum_total_eur: maximumTotalBudgetCents / 100,
     },
     campaign: {
-      name: "Parma | Reservations | Kreuzberg | Controlled test",
+      name: `Parma | Reservations | Kreuzberg | ${startDate}`,
       objective: "OUTCOME_TRAFFIC",
       buying_type: "AUCTION",
       special_ad_categories: [],
       status: "PAUSED",
     },
     adSet: {
-      name: "Parma | 3 km | 23-60 | Reservations",
+      name: `Parma | 3 km | 23-60 | Reservations | ${startDate}`,
       billing_event: "IMPRESSIONS",
       optimization_goal: "LINK_CLICKS",
       bid_strategy: "LOWEST_COST_WITHOUT_CAP",
@@ -360,6 +364,14 @@ function buildPausedReservationDraft({
       start_time: start.toISOString(),
       end_time: end.toISOString(),
       destination_type: "WEBSITE",
+      pacing_type: ["day_parting"],
+      adset_schedule: [
+        {
+          start_minute: 17 * 60,
+          end_minute: 23 * 60,
+          days: [0, 1, 2, 3, 4, 5, 6],
+        },
+      ],
       targeting: {
         age_min: 23,
         age_max: 60,
@@ -373,25 +385,19 @@ function buildPausedReservationDraft({
             },
           ],
         },
-        publisher_platforms: ["facebook", "instagram"],
+        publisher_platforms: ["instagram"],
+        instagram_positions: ["stream", "story", "reels"],
       },
       status: "PAUSED",
     },
     creative: {
       name: "Parma | Existing Reel video | Reservations",
-      object_story_spec: {
-        page_id: normalizedPageId,
-        instagram_user_id: normalizedInstagramUserId,
-        video_data: {
-          video_id: normalizedAdVideoId,
-          message:
-            "Sauerteigpizza, Bio-Zutaten und echtes Handwerk in Kreuzberg. Jeden Abend von 17 bis 23 Uhr bei Parma in der Wrangelstraße 90.",
-          title: "Pizzaabend in Kreuzberg",
-          call_to_action: {
-            type: "BOOK_NOW",
-            value: { link: RESERVATION_URL },
-          },
-        },
+      object_id: normalizedPageId,
+      instagram_user_id: normalizedInstagramUserId,
+      source_instagram_media_id: normalizedSourceInstagramMediaId,
+      call_to_action: {
+        type: "BOOK_NOW",
+        value: { link: RESERVATION_URL },
       },
     },
     ad: {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -166,6 +166,64 @@ paths:
           description: Invalid Instagram Reel URL
         "500":
           description: The connected Page, Instagram account or Reel could not be verified
+  /tools/meta/reservation-draft/preview:
+    get:
+      operationId: previewPausedMetaReservationDraft
+      summary: Preview the fixed Parma reservations campaign as a paused-only Meta draft
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: starts_at
+          in: query
+          required: true
+          description: Campaign start date-time including timezone; must be in the future
+          schema:
+            type: string
+            format: date-time
+            example: 2026-08-24T17:00:00+02:00
+      responses:
+        "200":
+          description: Read-only preview; no Meta object is created
+        "400":
+          description: Invalid or past start date-time
+        "500":
+          description: Meta assets could not be prepared
+  /tools/meta/reservation-draft/create:
+    post:
+      operationId: createPausedMetaReservationDraft
+      summary: Create the approved Parma reservations campaign as PAUSED Meta objects only
+      description: This operation never activates delivery or spend. It is blocked unless the server write gate is temporarily enabled and the exact human-approval phrase is supplied.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [starts_at, approval_token]
+              properties:
+                starts_at:
+                  type: string
+                  format: date-time
+                  description: Campaign start date-time including timezone; must be in the future
+                  example: 2026-08-24T17:00:00+02:00
+                approval_token:
+                  type: string
+                  enum: [CREATE_PARMA_META_DRAFT_PAUSED_ONLY]
+                  description: Exact scoped phrase confirming creation of paused draft objects only
+      responses:
+        "201":
+          description: Campaign, ad set, creative and ad created and verified PAUSED
+        "400":
+          description: Invalid request
+        "403":
+          description: Server write gate disabled or approval phrase missing
+        "409":
+          description: A draft already exists for the selected start date
+        "502":
+          description: Partial paused draft; returned object IDs require inspection
 components:
   schemas: {}
   securitySchemes:

--- a/server.js
+++ b/server.js
@@ -5,7 +5,13 @@ const { randomUUID } = require("crypto");
 const { GoogleAdsApi } = require("google-ads-api");
 const { buildGoogleReadiness, buildMetaOverview } = require("./reporting");
 const { buildMetaDinnerProposal } = require("./proposals");
-const { discoverInstagramReelAssets } = require("./meta-paused-draft");
+const {
+  APPROVAL_TOKEN: META_PAUSED_DRAFT_APPROVAL_TOKEN,
+  PartialMetaDraftError,
+  buildPausedReservationDraft,
+  createPausedReservationDraft,
+  discoverInstagramReelAssets,
+} = require("./meta-paused-draft");
 
 const app = express();
 app.use(express.json({ limit: "100kb" }));
@@ -38,6 +44,8 @@ const PORT = process.env.PORT || 3000;
 const META_ACCESS_TOKEN = process.env.META_ACCESS_TOKEN;
 let META_AD_ACCOUNT_ID = process.env.META_AD_ACCOUNT_ID;
 const PARMA_AGENT_API_KEY = process.env.PARMA_AGENT_API_KEY;
+const META_PAUSED_DRAFT_WRITES_ENABLED =
+  process.env.META_PAUSED_DRAFT_WRITES_ENABLED === "true";
 
 if (META_AD_ACCOUNT_ID && !META_AD_ACCOUNT_ID.startsWith("act_")) {
   META_AD_ACCOUNT_ID = `act_${META_AD_ACCOUNT_ID}`;
@@ -57,6 +65,27 @@ const metaReadTransport = {
       params: {
         ...params,
         access_token: META_ACCESS_TOKEN,
+      },
+    });
+    return response.data;
+  },
+};
+
+const metaWriteTransport = {
+  ...metaReadTransport,
+  async post(endpoint, payload = {}) {
+    const form = new URLSearchParams();
+    Object.entries(payload).forEach(([key, value]) => {
+      form.set(
+        key,
+        value && typeof value === "object" ? JSON.stringify(value) : String(value)
+      );
+    });
+    form.set("access_token", META_ACCESS_TOKEN);
+
+    const response = await metaClient.post(endpoint, form, {
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
       },
     });
     return response.data;
@@ -927,6 +956,167 @@ app.get("/tools/meta/draft-assets", requireApiKey, async (req, res) => {
       error: isInputError
         ? { message: error.message, type: "validation_error" }
         : cleanMetaError(error),
+    });
+  }
+});
+
+const PARMA_REEL_PERMALINK =
+  "https://www.instagram.com/reel/C9M7_b6MayR/";
+const PARMA_LATITUDE = 52.499492;
+const PARMA_LONGITUDE = 13.4399793;
+
+function parseFutureMetaStart(value) {
+  const start = new Date(String(value || ""));
+  if (Number.isNaN(start.getTime())) return null;
+  if (start.getTime() <= Date.now() + 15 * 60 * 1000) return null;
+  return start.toISOString();
+}
+
+async function preparePausedReservationDraft(startsAt) {
+  const assets = await discoverInstagramReelAssets({
+    transport: metaReadTransport,
+    adAccountId: META_AD_ACCOUNT_ID,
+    instagramUsername: "parma.divinibenedetti",
+    reelPermalink: PARMA_REEL_PERMALINK,
+  });
+
+  return buildPausedReservationDraft({
+    pageId: assets.page_id,
+    instagramUserId: assets.instagram_user_id,
+    sourceInstagramMediaId: assets.source_instagram_media_id,
+    latitude: PARMA_LATITUDE,
+    longitude: PARMA_LONGITUDE,
+    dailyBudgetEur: 6,
+    durationDays: 14,
+    startsAt,
+  });
+}
+
+function summarizePausedReservationDraft(draft) {
+  return {
+    mode: draft.policy.mode,
+    ready_to_create: true,
+    creates_paused_objects_only: true,
+    activates_spend: false,
+    campaign: {
+      name: draft.campaign.name,
+      objective: draft.campaign.objective,
+      status: draft.campaign.status,
+    },
+    budget: draft.budget,
+    schedule: {
+      starts_at: draft.adSet.start_time,
+      ends_at: draft.adSet.end_time,
+      local_delivery: "Monday-Sunday, 17:00-23:00 in the ad account timezone",
+    },
+    audience: {
+      radius_km: 3,
+      age_min: 23,
+      age_max: 60,
+    },
+    placements: {
+      platform: "instagram",
+      positions: draft.adSet.targeting.instagram_positions,
+    },
+    creative: {
+      instagram_account_verified: true,
+      reel_verified: true,
+      existing_reel_reused: true,
+      call_to_action: "BOOK_NOW",
+      destination: draft.creative.call_to_action.value.link,
+    },
+    write_gate_enabled: META_PAUSED_DRAFT_WRITES_ENABLED,
+  };
+}
+
+app.get("/tools/meta/reservation-draft/preview", requireApiKey, async (req, res) => {
+  if (!checkMetaConfig(res)) return;
+
+  const startsAt = parseFutureMetaStart(req.query.starts_at);
+  if (!startsAt) {
+    return res.status(400).json({
+      success: false,
+      error: "starts_at must be a valid ISO date-time at least 15 minutes in the future",
+    });
+  }
+
+  try {
+    const draft = await preparePausedReservationDraft(startsAt);
+    res.json({
+      success: true,
+      mode: "read_only_preview",
+      ...summarizePausedReservationDraft(draft),
+    });
+  } catch (error) {
+    res.status(error instanceof TypeError ? 400 : 500).json({
+      success: false,
+      error: cleanMetaError(error),
+    });
+  }
+});
+
+app.post("/tools/meta/reservation-draft/create", requireApiKey, async (req, res) => {
+  if (!checkMetaConfig(res)) return;
+  if (!META_PAUSED_DRAFT_WRITES_ENABLED) {
+    return res.status(403).json({
+      success: false,
+      error: "Paused Meta draft creation is disabled by the server write gate",
+    });
+  }
+  if (req.body?.approval_token !== META_PAUSED_DRAFT_APPROVAL_TOKEN) {
+    return res.status(403).json({
+      success: false,
+      error: "Exact paused-draft approval token is required",
+    });
+  }
+
+  const startsAt = parseFutureMetaStart(req.body?.starts_at);
+  if (!startsAt) {
+    return res.status(400).json({
+      success: false,
+      error: "starts_at must be a valid ISO date-time at least 15 minutes in the future",
+    });
+  }
+
+  try {
+    const draft = await preparePausedReservationDraft(startsAt);
+    const existingCampaigns = await getCampaignCollection();
+    const duplicate = (existingCampaigns?.data || []).find(
+      (campaign) => campaign?.name === draft.campaign.name
+    );
+    if (duplicate) {
+      return res.status(409).json({
+        success: false,
+        error: "A Meta campaign draft already exists for this start date",
+      });
+    }
+
+    const result = await createPausedReservationDraft({
+      transport: metaWriteTransport,
+      adAccountId: META_AD_ACCOUNT_ID,
+      draft,
+      approvalToken: req.body.approval_token,
+    });
+
+    res.status(201).json({
+      success: true,
+      mode: result.mode,
+      created: result.created,
+      statuses: Object.values(result.verification).map((object) => ({
+        status: object?.status || null,
+        effective_status: object?.effective_status || null,
+      })),
+      activates_spend: false,
+      next_required_action:
+        "Inspect the paused draft in Meta Ads Manager; activation requires a separate future approval and remains disabled",
+    });
+  } catch (error) {
+    const partial = error instanceof PartialMetaDraftError;
+    res.status(partial ? 502 : error instanceof TypeError ? 400 : 500).json({
+      success: false,
+      error: cleanMetaError(partial ? error.cause : error),
+      ...(partial ? { partial_paused_objects: error.created } : {}),
+      activates_spend: false,
     });
   }
 });

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -16,7 +16,7 @@ function validInput(overrides = {}) {
   return {
     pageId: "101",
     instagramUserId: "202",
-    adVideoId: "303",
+    sourceInstagramMediaId: "303",
     latitude: 52.5,
     longitude: 13.44,
     startsAt: "2026-08-24T09:00:00.000Z",
@@ -34,15 +34,24 @@ test("builds the approved reservation campaign as a capped paused-only draft", (
   assert.equal(draft.adSet.optimization_goal, "LINK_CLICKS");
   assert.equal(draft.adSet.lifetime_budget, 8400);
   assert.equal("daily_budget" in draft.adSet, false);
+  assert.deepEqual(draft.adSet.pacing_type, ["day_parting"]);
+  assert.deepEqual(draft.adSet.adset_schedule, [
+    { start_minute: 1020, end_minute: 1380, days: [0, 1, 2, 3, 4, 5, 6] },
+  ]);
+  assert.deepEqual(draft.adSet.targeting.publisher_platforms, ["instagram"]);
   assert.equal(draft.budget.maximum_total_eur, 84);
   assert.equal(
-    draft.creative.object_story_spec.video_data.call_to_action.value.link,
+    draft.creative.call_to_action.value.link,
     RESERVATION_URL
   );
   assert.equal(
-    draft.creative.object_story_spec.video_data.call_to_action.type,
+    draft.creative.call_to_action.type,
     "BOOK_NOW"
   );
+  assert.equal(draft.creative.object_id, "101");
+  assert.equal(draft.creative.instagram_user_id, "202");
+  assert.equal(draft.creative.source_instagram_media_id, "303");
+  assert.equal("object_story_spec" in draft.creative, false);
   assert.doesNotThrow(() => assertPausedOnly(draft));
 });
 


### PR DESCRIPTION
## Summary
- add a read-only preview for the fixed Parma reservations campaign
- add a separately gated action that can create only PAUSED Meta objects
- reuse the verified Instagram Reel and reservation destination
- enforce a €6/day, 14-day, €84 maximum lifetime budget
- restrict delivery to Instagram, 3 km, ages 23–60, every day 17:00–23:00
- verify all created campaign objects remain PAUSED and fail closed otherwise

## Safety
- the Railway write gate defaults to disabled
- the exact scoped approval phrase is required
- existing activation and budget-write routes remain disabled
- deploying this PR does not create any Meta object or activate spend

## Validation
- 26/26 Node tests passed
- JavaScript syntax checks passed
- OpenAPI YAML parsed successfully
- git diff check passed