### PR TITLE
Fix Meta ad set budget sharing parameter

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -352,6 +352,7 @@ function buildPausedReservationDraft({
       name: `Parma | Reservations | Kreuzberg | ${startDate}`,
       objective: "OUTCOME_TRAFFIC",
       buying_type: "AUCTION",
+      is_adset_budget_sharing_enabled: false,
       special_ad_categories: [],
       status: "PAUSED",
     },

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -31,6 +31,7 @@ test("builds the approved reservation campaign as a capped paused-only draft", (
   assert.equal(draft.adSet.status, "PAUSED");
   assert.equal(draft.ad.status, "PAUSED");
   assert.equal(draft.campaign.objective, "OUTCOME_TRAFFIC");
+  assert.equal(draft.campaign.is_adset_budget_sharing_enabled, false);
   assert.equal(draft.adSet.optimization_goal, "LINK_CLICKS");
   assert.equal(draft.adSet.lifetime_budget, 8400);
   assert.equal("daily_budget" in draft.adSet, false);


### PR DESCRIPTION
## Correzione
- dichiara esplicitamente `is_adset_budget_sharing_enabled: false` nella campagna Meta
- mantiene il budget esclusivamente a livello del singolo gruppo di inserzioni
- aggiunge la relativa verifica automatica

## Sicurezza
- tutti gli oggetti restano `PAUSED`
- il tetto massimo resta 84 €
- nessuna funzione di attivazione viene introdotta
- il write gate Railway resta disattivato

## Verifica
- 26 test su 26 superati
- controllo sintattico e diff check superati