### PR TITLE
Add EU DSA beneficiary and payor declarations

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -33,6 +33,17 @@ function requireIsoDate(value, label) {
   return date;
 }
 
+function requireDsaDeclaration(value, label) {
+  const declaration = String(value || "").trim();
+  if (declaration.length < 2 || declaration.length > 100) {
+    throw new TypeError(`${label} must contain between 2 and 100 characters`);
+  }
+  if (/[\r\n\t]/.test(declaration)) {
+    throw new TypeError(`${label} must be a single line`);
+  }
+  return declaration;
+}
+
 function toMetaCents(eur) {
   const amount = Number(eur);
   if (!Number.isFinite(amount) || amount < 3 || amount > 20) {
@@ -308,6 +319,8 @@ function buildPausedReservationDraft({
   dailyBudgetEur = 6,
   durationDays = 14,
   startsAt,
+  dsaBeneficiary,
+  dsaPayor,
   destinationUrl = RESERVATION_URL,
 }) {
   if (destinationUrl !== RESERVATION_URL) {
@@ -329,6 +342,11 @@ function buildPausedReservationDraft({
   );
   const normalizedLatitude = requireCoordinate(latitude, "latitude", -90, 90);
   const normalizedLongitude = requireCoordinate(longitude, "longitude", -180, 180);
+  const normalizedDsaBeneficiary = requireDsaDeclaration(
+    dsaBeneficiary,
+    "dsaBeneficiary"
+  );
+  const normalizedDsaPayor = requireDsaDeclaration(dsaPayor, "dsaPayor");
   const start = requireIsoDate(startsAt, "startsAt");
   const end = new Date(start.getTime() + durationDays * 24 * 60 * 60 * 1000);
   const dailyBudgetCents = toMetaCents(dailyBudgetEur);
@@ -365,6 +383,8 @@ function buildPausedReservationDraft({
       start_time: start.toISOString(),
       end_time: end.toISOString(),
       destination_type: "WEBSITE",
+      dsa_beneficiary: normalizedDsaBeneficiary,
+      dsa_payor: normalizedDsaPayor,
       pacing_type: ["day_parting"],
       adset_schedule: [
         {

--- a/server.js
+++ b/server.js
@@ -46,6 +46,8 @@ let META_AD_ACCOUNT_ID = process.env.META_AD_ACCOUNT_ID;
 const PARMA_AGENT_API_KEY = process.env.PARMA_AGENT_API_KEY;
 const META_PAUSED_DRAFT_WRITES_ENABLED =
   process.env.META_PAUSED_DRAFT_WRITES_ENABLED === "true";
+const META_AD_DSA_BENEFICIARY = process.env.META_AD_DSA_BENEFICIARY;
+const META_AD_DSA_PAYOR = process.env.META_AD_DSA_PAYOR;
 
 if (META_AD_ACCOUNT_ID && !META_AD_ACCOUNT_ID.startsWith("act_")) {
   META_AD_ACCOUNT_ID = `act_${META_AD_ACCOUNT_ID}`;
@@ -989,6 +991,8 @@ async function preparePausedReservationDraft(startsAt) {
     dailyBudgetEur: 6,
     durationDays: 14,
     startsAt,
+    dsaBeneficiary: META_AD_DSA_BENEFICIARY,
+    dsaPayor: META_AD_DSA_PAYOR,
   });
 }
 
@@ -1013,6 +1017,10 @@ function summarizePausedReservationDraft(draft) {
       radius_km: 3,
       age_min: 23,
       age_max: 60,
+    },
+    eu_transparency: {
+      beneficiary_configured: Boolean(draft.adSet.dsa_beneficiary),
+      payor_configured: Boolean(draft.adSet.dsa_payor),
     },
     placements: {
       platform: "instagram",

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -20,6 +20,8 @@ function validInput(overrides = {}) {
     latitude: 52.5,
     longitude: 13.44,
     startsAt: "2026-08-24T09:00:00.000Z",
+    dsaBeneficiary: "PARMA DI VINI BENEDETTI",
+    dsaPayor: "PARMA DI VINI BENEDETTI",
     ...overrides,
   };
 }
@@ -33,6 +35,8 @@ test("builds the approved reservation campaign as a capped paused-only draft", (
   assert.equal(draft.campaign.objective, "OUTCOME_TRAFFIC");
   assert.equal(draft.campaign.is_adset_budget_sharing_enabled, false);
   assert.equal(draft.adSet.optimization_goal, "LINK_CLICKS");
+  assert.equal(draft.adSet.dsa_beneficiary, "PARMA DI VINI BENEDETTI");
+  assert.equal(draft.adSet.dsa_payor, "PARMA DI VINI BENEDETTI");
   assert.equal(draft.adSet.lifetime_budget, 8400);
   assert.equal("daily_budget" in draft.adSet, false);
   assert.deepEqual(draft.adSet.pacing_type, ["day_parting"]);
@@ -74,6 +78,17 @@ test("rejects invalid Meta identifiers and unsafe budgets", () => {
   assert.throws(
     () => buildPausedReservationDraft(validInput({ dailyBudgetEur: 25 })),
     /dailyBudgetEur must be between/
+  );
+});
+
+test("requires explicit EU DSA beneficiary and payor declarations", () => {
+  assert.throws(
+    () => buildPausedReservationDraft(validInput({ dsaBeneficiary: "" })),
+    /dsaBeneficiary must contain/
+  );
+  assert.throws(
+    () => buildPausedReservationDraft(validInput({ dsaPayor: "" })),
+    /dsaPayor must contain/
   );
 });
 


### PR DESCRIPTION
Adds the required Meta EU DSA beneficiary and payor fields to paused reservation ad sets.

- Reads both declarations from Railway environment variables
- Fails closed when either declaration is missing or malformed
- Keeps every created object PAUSED
- Adds test coverage for the DSA fields

Validation: `node --test` — 27/27 passed.