### PR TITLE
Resume paused Meta draft safely with diagnostics

### DIFF
--- a/meta-paused-draft.js
+++ b/meta-paused-draft.js
@@ -2,10 +2,12 @@ const APPROVAL_TOKEN = "CREATE_PARMA_META_DRAFT_PAUSED_ONLY";
 const RESERVATION_URL = "https://www.parmaberlin.de/reservations";
 
 class PartialMetaDraftError extends Error {
-  constructor(message, created, cause) {
+  constructor(message, created, stage, cause, reused = {}) {
     super(message, { cause });
     this.name = "PartialMetaDraftError";
     this.created = { ...created };
+    this.stage = stage;
+    this.reused = { ...reused };
   }
 }
 
@@ -436,6 +438,7 @@ async function createPausedReservationDraft({
   adAccountId,
   draft,
   approvalToken,
+  existingCampaignId = null,
 }) {
   if (approvalToken !== APPROVAL_TOKEN) {
     throw new Error("Exact paused-draft approval token is required");
@@ -451,20 +454,30 @@ async function createPausedReservationDraft({
 
   assertPausedOnly(draft);
   const created = {};
+  const reused = {};
+  let stage = "campaign";
 
   try {
-    const campaign = await transport.post(`/${accountId}/campaigns`, draft.campaign);
-    created.campaign_id = requireNumericId(campaign?.id, "created campaign id");
+    if (existingCampaignId) {
+      created.campaign_id = requireNumericId(existingCampaignId, "existing campaign id");
+      reused.campaign = true;
+    } else {
+      const campaign = await transport.post(`/${accountId}/campaigns`, draft.campaign);
+      created.campaign_id = requireNumericId(campaign?.id, "created campaign id");
+    }
 
+    stage = "adset";
     const adSet = await transport.post(`/${accountId}/adsets`, {
       ...draft.adSet,
       campaign_id: created.campaign_id,
     });
     created.adset_id = requireNumericId(adSet?.id, "created ad set id");
 
+    stage = "creative";
     const creative = await transport.post(`/${accountId}/adcreatives`, draft.creative);
     created.creative_id = requireNumericId(creative?.id, "created creative id");
 
+    stage = "ad";
     const ad = await transport.post(`/${accountId}/ads`, {
       ...draft.ad,
       adset_id: created.adset_id,
@@ -472,6 +485,7 @@ async function createPausedReservationDraft({
     });
     created.ad_id = requireNumericId(ad?.id, "created ad id");
 
+    stage = "verification";
     let verificationEntries = await Promise.all(
       [created.campaign_id, created.adset_id, created.ad_id].map(async (id) => {
         const object = await transport.get(`/${id}`, { fields: "id,status,effective_status" });
@@ -515,6 +529,7 @@ async function createPausedReservationDraft({
       success: true,
       mode: "paused_draft_only",
       created,
+      reused,
       verification,
       activates_spend: false,
     };
@@ -522,7 +537,9 @@ async function createPausedReservationDraft({
     throw new PartialMetaDraftError(
       "Paused Meta draft creation did not complete; inspect the returned object IDs before any further action",
       created,
-      error
+      stage,
+      error,
+      reused
     );
   }
 }

--- a/server.js
+++ b/server.js
@@ -134,17 +134,28 @@ function checkMetaConfig(res) {
   return true;
 }
 
+function sanitizeMetaDiagnosticText(value) {
+  if (typeof value !== "string") return null;
+  return value
+    .replace(/\bact_\d+\b/gi, "act_[REDACTED]")
+    .replace(/\bEA[A-Za-z0-9_-]{20,}\b/g, "[REDACTED_TOKEN]")
+    .replace(/\b\d{8,}\b/g, "[REDACTED_ID]")
+    .slice(0, 500);
+}
+
 function cleanMetaError(error) {
   const metaError = error?.response?.data?.error;
 
   return {
     message:
-      metaError?.message ||
-      error?.message ||
+      sanitizeMetaDiagnosticText(metaError?.message) ||
+      sanitizeMetaDiagnosticText(error?.message) ||
       "Meta Ads request failed",
     type: metaError?.type || null,
     code: metaError?.code || null,
     subcode: metaError?.error_subcode || null,
+    user_title: sanitizeMetaDiagnosticText(metaError?.error_user_title),
+    user_message: sanitizeMetaDiagnosticText(metaError?.error_user_msg),
   };
 }
 
@@ -1089,14 +1100,35 @@ app.post("/tools/meta/reservation-draft/create", requireApiKey, async (req, res)
   try {
     const draft = await preparePausedReservationDraft(startsAt);
     const existingCampaigns = await getCampaignCollection();
-    const duplicate = (existingCampaigns?.data || []).find(
+    const duplicates = (existingCampaigns?.data || []).filter(
       (campaign) => campaign?.name === draft.campaign.name
     );
-    if (duplicate) {
+    if (duplicates.length > 1) {
       return res.status(409).json({
         success: false,
-        error: "A Meta campaign draft already exists for this start date",
+        error: "Multiple Meta campaign drafts already exist for this start date; manual inspection is required",
       });
+    }
+    const duplicate = duplicates[0] || null;
+    if (
+      duplicate &&
+      (duplicate.status !== "PAUSED" || duplicate.objective !== draft.campaign.objective)
+    ) {
+      return res.status(409).json({
+        success: false,
+        error: "The existing Meta campaign is not a resumable paused reservation draft",
+      });
+    }
+    if (duplicate) {
+      const existingAdSets = await getMetaCollection(`/${duplicate.id}/adsets`, {
+        fields: "id,status,effective_status",
+      });
+      if ((existingAdSets?.data || []).length > 0) {
+        return res.status(409).json({
+          success: false,
+          error: "The existing paused Meta campaign already contains an ad set; manual inspection is required",
+        });
+      }
     }
 
     const result = await createPausedReservationDraft({
@@ -1104,6 +1136,7 @@ app.post("/tools/meta/reservation-draft/create", requireApiKey, async (req, res)
       adAccountId: META_AD_ACCOUNT_ID,
       draft,
       approvalToken: req.body.approval_token,
+      existingCampaignId: duplicate?.id || null,
     });
 
     res.status(201).json({
@@ -1123,6 +1156,10 @@ app.post("/tools/meta/reservation-draft/create", requireApiKey, async (req, res)
     res.status(partial ? 502 : error instanceof TypeError ? 400 : 500).json({
       success: false,
       error: cleanMetaError(partial ? error.cause : error),
+      ...(partial ? { failure_stage: error.stage } : {}),
+      ...(partial && Object.keys(error.reused || {}).length > 0
+        ? { reused_paused_objects: error.reused }
+        : {}),
       ...(partial ? { partial_paused_objects: error.created } : {}),
       activates_spend: false,
     });

--- a/test/meta-paused-draft.test.js
+++ b/test/meta-paused-draft.test.js
@@ -407,7 +407,65 @@ test("reports partial paused objects instead of hiding a failed draft", async ()
         campaign_id: "2001",
         adset_id: "2002",
       });
+      assert.equal(error.stage, "creative");
       assert.match(error.cause.message, /creative rejected/);
+      return true;
+    }
+  );
+});
+
+test("resumes a known paused campaign without creating another campaign", async () => {
+  const posts = [];
+  const ids = ["5002", "5003", "5004"];
+  const transport = {
+    post: async (path, payload) => {
+      posts.push({ path, payload });
+      return { id: ids[posts.length - 1] };
+    },
+    get: async (path) => ({
+      id: path.slice(1),
+      status: "PAUSED",
+      effective_status: "PAUSED",
+    }),
+  };
+
+  const result = await createPausedReservationDraft({
+    transport,
+    adAccountId: "act_404",
+    draft: buildPausedReservationDraft(validInput()),
+    approvalToken: APPROVAL_TOKEN,
+    existingCampaignId: "5001",
+  });
+
+  assert.equal(result.reused.campaign, true);
+  assert.equal(result.created.campaign_id, "5001");
+  assert.deepEqual(
+    posts.map((call) => call.path),
+    ["/act_404/adsets", "/act_404/adcreatives", "/act_404/ads"]
+  );
+});
+
+test("reports the ad set stage when a resumed campaign still fails validation", async () => {
+  const transport = {
+    post: async () => {
+      throw new Error("Invalid parameter");
+    },
+    get: async () => ({ status: "PAUSED" }),
+  };
+
+  await assert.rejects(
+    createPausedReservationDraft({
+      transport,
+      adAccountId: "act_404",
+      draft: buildPausedReservationDraft(validInput()),
+      approvalToken: APPROVAL_TOKEN,
+      existingCampaignId: "6001",
+    }),
+    (error) => {
+      assert.ok(error instanceof PartialMetaDraftError);
+      assert.equal(error.stage, "adset");
+      assert.equal(error.reused.campaign, true);
+      assert.deepEqual(error.created, { campaign_id: "6001" });
       return true;
     }
   );


### PR DESCRIPTION
## Summary
- identify the exact Meta creation stage that fails
- expose sanitized Meta user-facing diagnostics without IDs or tokens
- reuse the single existing PAUSED campaign when it has no ad set
- stop safely when duplicates or existing child objects require manual inspection

## Validation
- JavaScript syntax checks passed
- 29/29 automated tests passed
- Railway write gate remains disabled