### PR TITLE
Add protected live shadow refresh endpoint

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -10,6 +10,8 @@ const state = {
   error: null,
 };
 
+let refreshPromise = null;
+
 function authorized(req) {
   const supplied = req.headers["x-api-key"] || String(req.headers["authorization"] || "").replace(/^Bearer\s+/i, "");
   return Boolean(process.env.PARMA_AGENT_API_KEY && supplied === process.env.PARMA_AGENT_API_KEY);
@@ -38,6 +40,9 @@ function sanitizedSummary() {
         configuration_complete: Boolean(r.live_sources?.ga4?.configuration_complete),
         required_variable: r.live_sources?.ga4?.required_variable || null,
       },
+      meta: r.live_sources?.meta?.access_ok ? {
+        campaign_counts: r.live_sources?.meta?.overview?.campaign_counts || {},
+      } : null,
     },
     conversion_integrity: {
       status: r.conversion_integrity?.status || "unknown",
@@ -50,10 +55,64 @@ function sanitizedSummary() {
   };
 }
 
+function triggerShadowReport() {
+  if (refreshPromise) return refreshPromise;
+
+  state.status = "starting";
+  state.started_at = new Date().toISOString();
+  state.finished_at = null;
+  state.error = null;
+
+  refreshPromise = collectFullLiveShadowInput({ days: Number(process.env.SHADOW_REPORT_DAYS || 30) })
+    .then((input) => {
+      const report = buildShadowAgentReport(input);
+      state.status = "completed";
+      state.finished_at = new Date().toISOString();
+      state.result = {
+        generated_at: state.finished_at,
+        live_sources: input.live_sources,
+        conversions: input.conversions,
+        conversion_integrity: report.conversion_integrity,
+        anomalies: report.anomalies,
+        daily_manager: report.daily_manager,
+        budget_recommendations: report.budget_recommendations,
+        channel_roles: report.channel_roles,
+        business_value: report.business_value,
+        journal: report.journal,
+      };
+      console.log(JSON.stringify({
+        event: "agent_shadow_live_report",
+        success: true,
+        generated_at: state.finished_at,
+        source_health: {
+          google: Boolean(input.access?.google_ok),
+          ga4: Boolean(input.access?.ga4_ok),
+          meta: Boolean(input.access?.meta_ok),
+        },
+        conversion_integrity: report.conversion_integrity?.status || null,
+        priority_count: report.daily_manager?.primary_priorities?.length || 0,
+        writes_allowed: false,
+      }));
+      return state.result;
+    })
+    .catch((error) => {
+      state.status = "failed";
+      state.finished_at = new Date().toISOString();
+      state.error = String(error?.message || error);
+      console.error(JSON.stringify({ event: "agent_shadow_live_report", success: false, error: state.error, writes_allowed: false }));
+      throw error;
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+
+  return refreshPromise;
+}
+
 function wrappedExpress(...args) {
   const app = realExpress(...args);
   app.get("/health/agent-shadow-summary", (req, res) => {
-    if (state.status === "starting") return res.status(202).json({ success: true, status: "running", mode: "shadow", writes_allowed: false });
+    if (state.status === "starting") return res.status(202).json({ success: true, status: "running", mode: "shadow", writes_allowed: false, started_at: state.started_at });
     if (state.status === "failed") return res.status(500).json({ success: false, status: "failed", mode: "shadow", writes_allowed: false, error: String(state.error || "shadow_report_failed").slice(0, 160) });
     return res.json({ success: true, status: "completed", ...sanitizedSummary() });
   });
@@ -63,47 +122,25 @@ function wrappedExpress(...args) {
     if (state.status === "failed") return res.status(500).json({ success: false, mode: "shadow", status: "failed", writes_allowed: false, started_at: state.started_at, finished_at: state.finished_at, error: state.error });
     return res.json({ success: true, mode: "shadow", status: "completed", writes_allowed: false, started_at: state.started_at, finished_at: state.finished_at, ...state.result });
   });
+  app.post("/tools/agent/shadow/refresh", (req, res) => {
+    if (!authorized(req)) return res.status(401).json({ success: false, error: "Unauthorized" });
+    const alreadyRunning = Boolean(refreshPromise);
+    if (!alreadyRunning) {
+      triggerShadowReport().catch(() => {});
+    }
+    return res.status(202).json({
+      success: true,
+      mode: "shadow",
+      status: alreadyRunning ? "already_running" : "started",
+      writes_allowed: false,
+      started_at: state.started_at,
+    });
+  });
   return app;
 }
 Object.assign(wrappedExpress, realExpress);
 require.cache[require.resolve("express")].exports = wrappedExpress;
 
-collectFullLiveShadowInput({ days: Number(process.env.SHADOW_REPORT_DAYS || 30) })
-  .then((input) => {
-    const report = buildShadowAgentReport(input);
-    state.status = "completed";
-    state.finished_at = new Date().toISOString();
-    state.result = {
-      generated_at: state.finished_at,
-      live_sources: input.live_sources,
-      conversions: input.conversions,
-      conversion_integrity: report.conversion_integrity,
-      anomalies: report.anomalies,
-      daily_manager: report.daily_manager,
-      budget_recommendations: report.budget_recommendations,
-      channel_roles: report.channel_roles,
-      business_value: report.business_value,
-      journal: report.journal,
-    };
-    console.log(JSON.stringify({
-      event: "agent_shadow_live_report",
-      success: true,
-      generated_at: state.finished_at,
-      source_health: {
-        google: Boolean(input.access?.google_ok),
-        ga4: Boolean(input.access?.ga4_ok),
-        meta: Boolean(input.access?.meta_ok),
-      },
-      conversion_integrity: report.conversion_integrity?.status || null,
-      priority_count: report.daily_manager?.primary_priorities?.length || 0,
-      writes_allowed: false,
-    }));
-  })
-  .catch((error) => {
-    state.status = "failed";
-    state.finished_at = new Date().toISOString();
-    state.error = String(error?.message || error);
-    console.error(JSON.stringify({ event: "agent_shadow_live_report", success: false, error: state.error, writes_allowed: false }));
-  });
+triggerShadowReport().catch(() => {});
 
 require("./server");

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,8 +43,8 @@ paths:
   /tools/agent/shadow/live:
     get:
       operationId: getLiveShadowAgentReport
-      summary: Get the first operational read-only Agent shadow report from live Google Ads, GA4 and Meta data
-      description: Returns the latest startup-generated shadow report. This endpoint never activates campaigns, publishes ads, enables delivery, or changes budgets.
+      summary: Get the latest operational read-only Agent shadow report from live Google Ads, GA4 and Meta data
+      description: Returns the latest generated shadow report. This endpoint never activates campaigns, publishes ads, enables delivery, or changes budgets.
       security:
         - ApiKeyAuth: []
       responses:
@@ -56,6 +56,18 @@ paths:
           description: Unauthorized
         "500":
           description: Live shadow report failed safely
+  /tools/agent/shadow/refresh:
+    post:
+      operationId: refreshLiveShadowAgentReport
+      summary: Start a fresh read-only Google Ads, GA4 and Meta shadow collection
+      description: Starts a new shadow collection without restarting the service. It never activates campaigns, publishes ads, enables delivery, or changes budgets.
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "202":
+          description: Refresh started or already running
+        "401":
+          description: Unauthorized
   /tools/google/test:
     get:
       operationId: testGoogleAds


### PR DESCRIPTION
Adds a protected POST /tools/agent/shadow/refresh endpoint so the live Google Ads + GA4 + Meta shadow report can be regenerated without a Railway redeploy. Keeps writes_allowed=false, reuses the existing API-key guard, prevents overlapping refreshes, and exposes only Meta campaign status counts in the public sanitized summary. OpenAPI documentation updated. No ad delivery, spend, campaign activation, or budget mutation is introduced.