### PR TITLE
Harden paused Meta draft for current Marketing API

### DIFF
--- a/meta-paused-draft-next.js
+++ b/meta-paused-draft-next.js
@@ -1,0 +1,37 @@
+const base = require("./meta-paused-draft");
+
+const META_API_VERSION = "v26.0";
+
+function buildPausedReservationDraft(input) {
+  const draft = base.buildPausedReservationDraft(input);
+
+  // Marketing API v25+ requires an explicit Advantage Audience choice for
+  // normal ad-set creation. Omitting targeting_automation is rejected with
+  // OAuthException code 100 / subcode 1870227.
+  draft.adSet.targeting = {
+    ...draft.adSet.targeting,
+    targeting_automation: {
+      advantage_audience: 0,
+    },
+  };
+
+  base.assertPausedOnly(draft);
+  return draft;
+}
+
+function metaCompatibilitySummary() {
+  return {
+    api_version: META_API_VERSION,
+    paused_only: true,
+    targeting_automation_explicit: true,
+    advantage_audience: 0,
+    known_error_addressed: 1870227,
+  };
+}
+
+module.exports = {
+  ...base,
+  META_API_VERSION,
+  buildPausedReservationDraft,
+  metaCompatibilitySummary,
+};

--- a/test/meta-paused-draft-next.test.js
+++ b/test/meta-paused-draft-next.test.js
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  META_API_VERSION,
+  buildPausedReservationDraft,
+  metaCompatibilitySummary,
+  assertPausedOnly,
+} = require("../meta-paused-draft-next");
+
+function validInput() {
+  return {
+    pageId: "101",
+    instagramUserId: "202",
+    sourceInstagramMediaId: "303",
+    latitude: 52.5,
+    longitude: 13.44,
+    startsAt: "2026-08-24T15:00:00.000Z",
+    dsaBeneficiary: "PARMA DI VINI BENEDETTI",
+    dsaPayor: "PARMA DI VINI BENEDETTI",
+  };
+}
+
+test("next Meta draft explicitly disables Advantage Audience", () => {
+  const draft = buildPausedReservationDraft(validInput());
+  assert.deepEqual(draft.adSet.targeting.targeting_automation, {
+    advantage_audience: 0,
+  });
+  assert.doesNotThrow(() => assertPausedOnly(draft));
+});
+
+test("next Meta draft preserves DSA declarations and paused-only safety", () => {
+  const draft = buildPausedReservationDraft(validInput());
+  assert.equal(draft.adSet.dsa_beneficiary, "PARMA DI VINI BENEDETTI");
+  assert.equal(draft.adSet.dsa_payor, "PARMA DI VINI BENEDETTI");
+  assert.equal(draft.campaign.status, "PAUSED");
+  assert.equal(draft.adSet.status, "PAUSED");
+  assert.equal(draft.ad.status, "PAUSED");
+});
+
+test("compatibility summary pins the current Meta API generation", () => {
+  assert.equal(META_API_VERSION, "v26.0");
+  assert.deepEqual(metaCompatibilitySummary(), {
+    api_version: "v26.0",
+    paused_only: true,
+    targeting_automation_explicit: true,
+    advantage_audience: 0,
+    known_error_addressed: 1870227,
+  });
+});


### PR DESCRIPTION
Superseded by merged PR #50, which already carries the current Meta Marketing API compatibility layer and explicit targeting_automation.advantage_audience=0 into main. Keeping this stale draft open would duplicate already-integrated safety work.