### PR TITLE
Add read-only Google RSA analysis

### DIFF
--- a/google-rsa-analysis.js
+++ b/google-rsa-analysis.js
@@ -1,0 +1,38 @@
+function normalizeAssets(values=[]){return (values||[]).map(v=>typeof v==="string"?v:v?.text).filter(Boolean).map(v=>String(v).trim()).filter(Boolean);}
+
+function analyzeRsa(row={}, {minHeadlines=8,minDescriptions=3}={}){
+  const headlines=normalizeAssets(row.headlines);
+  const descriptions=normalizeAssets(row.descriptions);
+  const issues=[];
+  if(headlines.length<minHeadlines)issues.push({code:"RSA_FEW_HEADLINES",severity:"medium",reason:`Only ${headlines.length} headlines available; diversify before judging performance.`});
+  if(descriptions.length<minDescriptions)issues.push({code:"RSA_FEW_DESCRIPTIONS",severity:"medium",reason:`Only ${descriptions.length} descriptions available.`});
+  const normalized=headlines.map(x=>x.toLowerCase());
+  if(new Set(normalized).size<headlines.length)issues.push({code:"RSA_DUPLICATE_HEADLINES",severity:"medium",reason:"Duplicate or near-identical headline text reduces asset diversity."});
+  const weak=headlines.filter(x=>x.length<12);
+  if(weak.length>=Math.max(2,Math.ceil(headlines.length/3)))issues.push({code:"RSA_SHORT_HEADLINES",severity:"low",reason:"A large share of headlines are very short and may underuse available message space."});
+  const adStrength=String(row.ad_strength||row.adStrength||"").toUpperCase();
+  if(["POOR","AVERAGE"].includes(adStrength))issues.push({code:"RSA_AD_STRENGTH_WEAK",severity:"medium",reason:`Google Ads reports RSA strength ${adStrength}.`});
+  const clicks=Number(row.clicks||0),conversions=Number(row.conversions||0),impressions=Number(row.impressions||0);
+  if(clicks>=20&&conversions===0)issues.push({code:"RSA_TRAFFIC_WITHOUT_CONVERSIONS",severity:"high",reason:"RSA has meaningful click volume without conversions; inspect intent and landing continuity before rewriting blindly."});
+  return {
+    ad_id:row.ad_id?String(row.ad_id):null,
+    campaign:row.campaign||null,
+    ad_group:row.ad_group||null,
+    asset_counts:{headlines:headlines.length,descriptions:descriptions.length},
+    metrics:{impressions,clicks,conversions},
+    ad_strength:adStrength||null,
+    issues,
+    requires_write:false,
+  };
+}
+
+function analyzeRsaSet(rows=[]){
+  return rows.map(analyzeRsa).sort((a,b)=>{
+    const rank={high:3,medium:2,low:1};
+    const ar=Math.max(0,...a.issues.map(i=>rank[i.severity]||0));
+    const br=Math.max(0,...b.issues.map(i=>rank[i.severity]||0));
+    return br-ar||b.metrics.clicks-a.metrics.clicks;
+  });
+}
+
+module.exports={analyzeRsa,analyzeRsaSet};

--- a/google-rsa-collector.js
+++ b/google-rsa-collector.js
@@ -1,0 +1,33 @@
+async function collectResponsiveSearchAds({customer,start,end}){
+  if(!customer||typeof customer.query!=="function")throw new TypeError("customer.query is required");
+  if(!/^\d{4}-\d{2}-\d{2}$/.test(String(start||""))||!/^\d{4}-\d{2}-\d{2}$/.test(String(end||"")))throw new TypeError("start and end must be YYYY-MM-DD");
+  const rows=await customer.query(`
+    SELECT campaign.id, campaign.name, ad_group.id, ad_group.name,
+      ad_group_ad.ad.id, ad_group_ad.status, ad_group_ad.ad_strength,
+      ad_group_ad.ad.responsive_search_ad.headlines,
+      ad_group_ad.ad.responsive_search_ad.descriptions,
+      metrics.impressions, metrics.clicks, metrics.cost_micros,
+      metrics.conversions
+    FROM ad_group_ad
+    WHERE ad_group_ad.ad.type = 'RESPONSIVE_SEARCH_AD'
+      AND ad_group_ad.status != 'REMOVED'
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows||[]).map(row=>({
+    campaign_id:String(row.campaign?.id||""),
+    campaign:row.campaign?.name||null,
+    ad_group_id:String(row.ad_group?.id||""),
+    ad_group:row.ad_group?.name||null,
+    ad_id:String(row.ad_group_ad?.ad?.id||""),
+    status:row.ad_group_ad?.status||null,
+    ad_strength:row.ad_group_ad?.ad_strength||null,
+    headlines:(row.ad_group_ad?.ad?.responsive_search_ad?.headlines||[]).map(x=>x?.text).filter(Boolean),
+    descriptions:(row.ad_group_ad?.ad?.responsive_search_ad?.descriptions||[]).map(x=>x?.text).filter(Boolean),
+    impressions:Number(row.metrics?.impressions||0),
+    clicks:Number(row.metrics?.clicks||0),
+    cost_eur:Number(row.metrics?.cost_micros||0)/1_000_000,
+    conversions:Number(row.metrics?.conversions||0),
+  }));
+}
+
+module.exports={collectResponsiveSearchAds};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node bootstrap.js",
-    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
+    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check google-rsa-analysis.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
     "shadow:live": "node scripts/run-live-shadow-report.js",
     "shadow:full": "node scripts/run-full-live-shadow-report.js",
     "test": "node --test"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node bootstrap.js",
-    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check google-rsa-analysis.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
+    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check google-rsa-analysis.js && node --check google-rsa-collector.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
     "shadow:live": "node scripts/run-live-shadow-report.js",
     "shadow:full": "node scripts/run-full-live-shadow-report.js",
     "test": "node --test"

--- a/test/google-rsa-analysis.test.js
+++ b/test/google-rsa-analysis.test.js
@@ -1,0 +1,25 @@
+const test=require("node:test");
+const assert=require("node:assert/strict");
+const {analyzeRsa,analyzeRsaSet}=require("../google-rsa-analysis");
+
+test("RSA analyzer flags weak asset coverage and traffic without conversions",()=>{
+  const r=analyzeRsa({ad_id:"1",headlines:["Pizza","Bio Pizza"],descriptions:["Book now"],ad_strength:"AVERAGE",clicks:25,conversions:0,impressions:500});
+  assert.equal(r.requires_write,false);
+  assert.ok(r.issues.some(x=>x.code==="RSA_FEW_HEADLINES"));
+  assert.ok(r.issues.some(x=>x.code==="RSA_FEW_DESCRIPTIONS"));
+  assert.ok(r.issues.some(x=>x.code==="RSA_AD_STRENGTH_WEAK"));
+  assert.ok(r.issues.some(x=>x.code==="RSA_TRAFFIC_WITHOUT_CONVERSIONS"));
+});
+
+test("RSA analyzer detects duplicate headlines",()=>{
+  const r=analyzeRsa({headlines:["Pizza Berlin","Pizza Berlin","Bio Pizza Berlin","Pizza Kreuzberg","Pizza Sourdough","Pizza Dinner","Pizza Reservation","Pizza Wine"],descriptions:["One","Two","Three"]});
+  assert.ok(r.issues.some(x=>x.code==="RSA_DUPLICATE_HEADLINES"));
+});
+
+test("RSA set prioritizes high severity issues",()=>{
+  const rows=analyzeRsaSet([
+    {ad_id:"low",headlines:Array(8).fill(0).map((_,i)=>`Long headline ${i}`),descriptions:["a","b","c"],clicks:2,conversions:0},
+    {ad_id:"high",headlines:["Pizza"],descriptions:["a"],clicks:30,conversions:0}
+  ]);
+  assert.equal(rows[0].ad_id,"high");
+});

--- a/test/google-rsa-collector.test.js
+++ b/test/google-rsa-collector.test.js
@@ -1,0 +1,21 @@
+const test=require("node:test");
+const assert=require("node:assert/strict");
+const {collectResponsiveSearchAds}=require("../google-rsa-collector");
+
+test("RSA collector uses query-only transport and maps assets",async()=>{
+  const calls=[];
+  const customer={query:async(q)=>{calls.push(q);return [{campaign:{id:1,name:"Dinner"},ad_group:{id:2,name:"Core"},ad_group_ad:{status:"ENABLED",ad_strength:"GOOD",ad:{id:3,responsive_search_ad:{headlines:[{text:"Bio Pizza Berlin"}],descriptions:[{text:"Reserve tonight"}]}}},metrics:{impressions:100,clicks:10,cost_micros:5000000,conversions:2}}];}};
+  const rows=await collectResponsiveSearchAds({customer,start:"2026-08-01",end:"2026-08-20"});
+  assert.equal(calls.length,1);
+  assert.match(calls[0],/FROM ad_group_ad/);
+  assert.match(calls[0],/RESPONSIVE_SEARCH_AD/);
+  assert.deepEqual(rows[0].headlines,["Bio Pizza Berlin"]);
+  assert.equal(rows[0].cost_eur,5);
+  assert.equal(rows[0].conversions,2);
+});
+
+test("RSA collector rejects invalid dates before querying",async()=>{
+  let called=false;
+  await assert.rejects(()=>collectResponsiveSearchAds({customer:{query:async()=>{called=true;return[];}},start:"bad",end:"2026-08-20"}),/YYYY-MM-DD/);
+  assert.equal(called,false);
+});


### PR DESCRIPTION
Superseded by merged PR #41, which ports the read-only RSA analyzer and query-only collector onto the current main, adds the same regression coverage, and validates them inside the consolidated baseline. No Google write path was introduced.