### PR TITLE
Add read-only reservation landing diagnostics

### DIFF
--- a/landing-page-diagnostics.js
+++ b/landing-page-diagnostics.js
@@ -1,0 +1,16 @@
+function n(value){const x=Number(value);return Number.isFinite(x)?x:0;}
+
+function diagnoseLanding({adClicks=0,landingViews=0,bookingStarts=null,bookings=0,lcpMs=null,inpMs=null,cls=null}={}){
+  const clicks=n(adClicks),views=n(landingViews),done=n(bookings);
+  const starts=bookingStarts===null?null:n(bookingStarts);
+  const issues=[];
+  if(clicks>=10&&views/clicks<0.7)issues.push({code:"LANDING_VIEW_LOSS",severity:"high",reason:"Too many ad clicks fail to become reservation-page views."});
+  if(starts!==null&&views>=10&&starts/views<0.1)issues.push({code:"BOOKING_START_RATE_LOW",severity:"medium",reason:"Reservation-page traffic rarely begins the booking flow."});
+  if(starts!==null&&starts>=5&&done/starts<0.3)issues.push({code:"BOOKING_COMPLETION_RATE_LOW",severity:"high",reason:"Many booking starts do not complete."});
+  if(lcpMs!==null&&n(lcpMs)>2500)issues.push({code:"LCP_SLOW",severity:"medium",reason:"Largest Contentful Paint exceeds 2.5 seconds."});
+  if(inpMs!==null&&n(inpMs)>200)issues.push({code:"INP_SLOW",severity:"medium",reason:"Interaction to Next Paint exceeds 200 ms."});
+  if(cls!==null&&n(cls)>0.1)issues.push({code:"CLS_HIGH",severity:"medium",reason:"Cumulative Layout Shift exceeds 0.1."});
+  return {status:issues.some(x=>x.severity==="high")?"attention_required":issues.length?"watch":"healthy",issues,metrics:{ad_clicks:clicks,landing_views:views,booking_starts:starts,bookings:done,lcp_ms:lcpMs===null?null:n(lcpMs),inp_ms:inpMs===null?null:n(inpMs),cls:cls===null?null:n(cls)},requires_write:false};
+}
+
+module.exports={diagnoseLanding};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node bootstrap.js",
-    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
+    "check": "node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check landing-page-diagnostics.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js",
     "shadow:live": "node scripts/run-live-shadow-report.js",
     "shadow:full": "node scripts/run-full-live-shadow-report.js",
     "test": "node --test"

--- a/test/landing-page-diagnostics.test.js
+++ b/test/landing-page-diagnostics.test.js
@@ -1,0 +1,25 @@
+const test=require("node:test");
+const assert=require("node:assert/strict");
+const {diagnoseLanding}=require("../landing-page-diagnostics");
+
+test("landing diagnostics flags click loss and slow web vitals",()=>{
+  const r=diagnoseLanding({adClicks:20,landingViews:10,bookingStarts:2,bookings:1,lcpMs:3200,inpMs:250,cls:0.2});
+  assert.equal(r.requires_write,false);
+  assert.ok(r.issues.some(x=>x.code==="LANDING_VIEW_LOSS"));
+  assert.ok(r.issues.some(x=>x.code==="LCP_SLOW"));
+  assert.ok(r.issues.some(x=>x.code==="INP_SLOW"));
+  assert.ok(r.issues.some(x=>x.code==="CLS_HIGH"));
+});
+
+test("landing diagnostics does not invent booking-start leakage when event is unavailable",()=>{
+  const r=diagnoseLanding({adClicks:20,landingViews:18,bookingStarts:null,bookings:3});
+  assert.equal(r.metrics.booking_starts,null);
+  assert.equal(r.issues.some(x=>x.code==="BOOKING_START_RATE_LOW"),false);
+  assert.equal(r.issues.some(x=>x.code==="BOOKING_COMPLETION_RATE_LOW"),false);
+});
+
+test("healthy funnel returns healthy status",()=>{
+  const r=diagnoseLanding({adClicks:20,landingViews:18,bookingStarts:8,bookings:4,lcpMs:1800,inpMs:120,cls:0.05});
+  assert.equal(r.status,"healthy");
+  assert.deepEqual(r.issues,[]);
+});


### PR DESCRIPTION
Superseded by merged PR #41, which ports the read-only reservation landing diagnostics and tests onto the current main. No site mutation or ad-platform mutation was introduced.