### PR TITLE
Diagnose remaining npm advisories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm install --ignore-scripts
       - name: Dependency audit diagnostic
         run: npm audit --omit=dev --json || true
+      - name: Dependency tree diagnostic
+        run: npm ls gaxios uuid google-auth-library google-gax google-ads-api || true
       - name: Syntax check
         run: npm run check
       - name: Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 24
       - name: Install dependencies
         run: npm install --ignore-scripts
+      - name: Dependency audit diagnostic
+        run: npm audit --omit=dev --json || true
       - name: Syntax check
         run: npm run check
       - name: Tests


### PR DESCRIPTION
Diagnostic completed. Root cause traced to google-ads-api@24.1.0 -> google-auth-library@9.15.1 -> gaxios@6.7.1 -> uuid@9.0.1. The minimal uuid override and a permanent production audit gate were validated and merged via PR #43. This diagnostic PR is intentionally not merged.