### PR TITLE
Fix transitive uuid advisory and gate production audit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 24
       - name: Install dependencies
         run: npm install --ignore-scripts
+      - name: Production dependency audit
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Syntax check
         run: npm run check
       - name: Tests

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.22.2",
     "google-ads-api": "^24.1.0"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Applies the minimal transitive fix for the two moderate advisories traced through google-ads-api -> google-auth-library@9.15.1 -> gaxios@6.7.1 -> uuid@9.0.1. Overrides uuid to >=11.1.1 and adds a CI production dependency audit at moderate severity. No runtime campaign behavior or credentials are changed. Merge only if audit, syntax and full tests are green.