### PR TITLE
Expose safe Meta runtime account context

### DIFF
--- a/.github/workflows/meta-runtime-smoke.yml
+++ b/.github/workflows/meta-runtime-smoke.yml
@@ -37,6 +37,8 @@ jobs:
 
           ready=$(jq -r '.ready // false' response.json 2>/dev/null || echo false)
           blockers=$(jq -r '(.blockers // []) | join(",")' response.json 2>/dev/null || echo unreadable)
+          timezone=$(jq -r '.account.timezone_name // "unknown"' response.json 2>/dev/null || echo unknown)
+          currency=$(jq -r '.account.currency // "unknown"' response.json 2>/dev/null || echo unknown)
           if [ "$ready" = "true" ]; then
             state="success"
             description="ready=true; blockers=none"
@@ -44,9 +46,11 @@ jobs:
           else
             state="failure"
             if [ -z "$blockers" ]; then blockers="unknown"; fi
-            safe_blockers=$(printf '%s' "$blockers" | tr -cs 'A-Za-z0-9_,-' '_' | cut -c1-70)
+            safe_blockers=$(printf '%s' "$blockers" | tr -cs 'A-Za-z0-9_,-' '_' | cut -c1-48)
+            safe_tz=$(printf '%s' "$timezone" | tr -cs 'A-Za-z0-9_+./-' '_' | cut -c1-24)
+            safe_cur=$(printf '%s' "$currency" | tr -cs 'A-Za-z0-9_' '_' | cut -c1-8)
             description="ready=false; blockers=${blockers:0:100}"
-            context="meta-runtime-preflight:${safe_blockers}"
+            context="meta-runtime-preflight:tz=${safe_tz}:cur=${safe_cur}:${safe_blockers}"
           fi
 
           payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')

--- a/meta-preflight-status.js
+++ b/meta-preflight-status.js
@@ -23,6 +23,10 @@ function sanitize(result){
     may_spend: false,
     account: result.account ? {
       readable: Boolean(result.account.readable),
+      timezone_name: result.account.timezone_name || null,
+      expected_timezone: result.account.expected_timezone || null,
+      currency: result.account.currency || null,
+      expected_currency: result.account.expected_currency || null,
       timezone_match: Boolean(result.account.timezone_match),
       currency_match: Boolean(result.account.currency_match),
       account_status_present: Boolean(result.account.account_status_present),

--- a/meta-runtime-preflight.js
+++ b/meta-runtime-preflight.js
@@ -23,7 +23,7 @@ async function inspectAccountContext(transport,config){
  const account=await transport.get(`/${config.adAccountId}`,{fields:'account_status,currency,timezone_name'});
  const timezone=String(account?.timezone_name||'');const currency=String(account?.currency||'').toUpperCase();
  const blockers=[];if(!timezone)blockers.push('account_timezone_unknown');else if(timezone!==config.expectedTimezone)blockers.push('account_timezone_mismatch');if(!currency)blockers.push('account_currency_unknown');else if(currency!==config.expectedCurrency)blockers.push('account_currency_mismatch');
- return {readable:true,timezone_match:timezone===config.expectedTimezone,currency_match:currency===config.expectedCurrency,account_status_present:account?.account_status!=null,blockers};
+ return {readable:true,timezone_name:timezone,expected_timezone:config.expectedTimezone,currency,expected_currency:config.expectedCurrency,timezone_match:timezone===config.expectedTimezone,currency_match:currency===config.expectedCurrency,account_status_present:account?.account_status!=null,blockers};
 }
 
 function finalizeResult(result){return {...result,decision:decideNextMetaStep(result),write_operation_performed:false,may_activate:false,may_spend:false};}


### PR DESCRIPTION
Superseded by PR #53, which reapplies the same sanitized timezone/currency context on top of the current main after PR #50 advanced the base. No Meta IDs, tokens, writes, activation, delivery, budget mutation, or spend changes.