### PR TITLE
Route paused Meta writes through mandatory safe orchestrator

### DIFF
--- a/meta-safe-orchestrator.js
+++ b/meta-safe-orchestrator.js
@@ -1,0 +1,24 @@
+const { runMetaPausedPreflight } = require('./meta-preflight');
+const { resumePausedReservationDraft } = require('./meta-draft-recovery');
+const { AUTONOMY_LEVELS, authorizeExecution, createExecutionJournal, stableKey } = require('./safe-execution');
+
+async function executePausedMetaDraftSafely({ transport, adAccountId, draft, approvalToken, existing = {}, killSwitch = false, autonomyLevel = AUTONOMY_LEVELS.SAFE_WRITE, journal = createExecutionJournal() } = {}) {
+  const preflight = runMetaPausedPreflight({ draft, knownPartial: existing });
+  const gatePreflight = { ok: preflight.ready };
+  const authorization = authorizeExecution({ level: autonomyLevel, preflight: gatePreflight, killSwitch });
+  const operationKey = stableKey({ adAccountId, draft, existing, mode: 'paused_draft_only' });
+
+  journal.record({ event: 'meta_safe_write_requested', operation_key: operationKey, preflight_ready: preflight.ready, authorization: authorization.reason });
+
+  if (!authorization.allowed) {
+    journal.record({ event: 'meta_safe_write_blocked', operation_key: operationKey, reason: authorization.reason, blockers: preflight.level_2_payload?.blockers || [] });
+    return { success: false, blocked: true, reason: authorization.reason, operation_key: operationKey, preflight, journal: journal.snapshot(), activates_spend: false };
+  }
+
+  const result = await resumePausedReservationDraft({ transport, adAccountId, draft, approvalToken, existing });
+  journal.record({ event: 'meta_safe_write_completed', operation_key: operationKey, created: result.created, reused: result.reused, activates_spend: false });
+
+  return { ...result, operation_key: operationKey, preflight, journal: journal.snapshot(), activates_spend: false };
+}
+
+module.exports = { executePausedMetaDraftSafely };

--- a/test/meta-safe-orchestrator.test.js
+++ b/test/meta-safe-orchestrator.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { executePausedMetaDraftSafely } = require('../meta-safe-orchestrator');
+const { AUTONOMY_LEVELS } = require('../safe-execution');
+const { APPROVAL_TOKEN } = require('../meta-paused-draft');
+
+const validDraft = {
+  campaign:{ name:'x', status:'PAUSED', objective:'OUTCOME_TRAFFIC', special_ad_categories:[] },
+  adSet:{ name:'x', status:'PAUSED', lifetime_budget:8400, billing_event:'IMPRESSIONS', optimization_goal:'LINK_CLICKS', targeting:{ geo_locations:{ countries:['DE'] } }, dsa_beneficiary:'Parma', dsa_payor:'Parma' },
+  creative:{ name:'x', object_id:'1', instagram_user_id:'2', source_instagram_media_id:'3' },
+  ad:{ name:'x', status:'PAUSED' }
+};
+
+test('kill switch blocks before any transport write', async () => {
+  let posts=0;
+  const transport={ get:async()=>({status:'PAUSED'}), post:async()=>{posts+=1; return {id:'1'};} };
+  const result=await executePausedMetaDraftSafely({transport,adAccountId:'act_1',draft:validDraft,approvalToken:APPROVAL_TOKEN,killSwitch:true});
+  assert.equal(result.blocked,true);
+  assert.equal(posts,0);
+});
+
+test('recommend level cannot write even when preflight is otherwise ready', async () => {
+  let posts=0;
+  const transport={ get:async()=>({status:'PAUSED'}), post:async()=>{posts+=1; return {id:'1'};} };
+  const result=await executePausedMetaDraftSafely({transport,adAccountId:'act_1',draft:validDraft,approvalToken:APPROVAL_TOKEN,autonomyLevel:AUTONOMY_LEVELS.RECOMMEND});
+  assert.equal(result.blocked,true);
+  assert.equal(posts,0);
+});


### PR DESCRIPTION
Adds a single safe-write orchestrator that requires Meta preflight plus the central autonomy/kill-switch gate before delegating to paused-draft recovery. It journals the decision, generates a deterministic operation key, and guarantees blocked paths perform zero transport writes. Includes focused tests for kill-switch and low-autonomy bypass prevention. No real campaign activation or spend.