### PR TITLE
Integrate Shadow data quality without sacrificing readability

### DIFF
--- a/daily-shadow-report.js
+++ b/daily-shadow-report.js
@@ -1,6 +1,10 @@
 const { buildShadowDecisions, assertShadowSafe } = require("./shadow-decision-engine");
+const { evaluateShadowDataQuality, assertQualityFailClosed } = require("./shadow-data-quality");
 
-function n(value) { const x = Number(value); return Number.isFinite(x) ? x : 0; }
+function n(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 function summarizeChannel(channel = {}) {
   const spend = n(channel.cost ?? channel.spend);
@@ -15,24 +19,55 @@ function summarizeChannel(channel = {}) {
   };
 }
 
+function buildRepairDecision(dataQuality) {
+  const blockedChannels = Object.entries(dataQuality.channel_ready || {})
+    .filter(([, ready]) => !ready)
+    .map(([channel]) => channel);
+
+  if (!blockedChannels.length) return null;
+
+  return {
+    channel: "system",
+    action: "collect_or_repair_data",
+    reason: `Recommendations withheld for: ${blockedChannels.join(", ")}. Blockers: ${(dataQuality.blockers || []).join(", ") || "insufficient evidence"}`,
+    confidence: "high",
+    mode: "shadow",
+    executable: false,
+  };
+}
+
 function buildDailyShadowReport(snapshot = {}) {
   const shadow = buildShadowDecisions(snapshot);
   assertShadowSafe(shadow);
+
+  const dataQuality = snapshot.data_quality || evaluateShadowDataQuality(snapshot);
+  assertQualityFailClosed(dataQuality);
+
+  const trustedChannels = new Set(
+    Object.entries(dataQuality.channel_ready || {})
+      .filter(([, ready]) => ready)
+      .map(([channel]) => channel)
+  );
+
+  const trustedDecisions = shadow.decisions.filter((decision) => trustedChannels.has(decision.channel));
+  const repairDecision = buildRepairDecision(dataQuality);
+  const decisions = repairDecision ? [repairDecision, ...trustedDecisions] : trustedDecisions;
 
   const report = {
     mode: "shadow",
     generated_at: shadow.generated_at,
     writes_allowed: false,
     spend_changed: false,
-    source_health: snapshot.source_health || {},
+    data_quality: dataQuality,
+    source_health: dataQuality.sources || snapshot.source_health || {},
     conversion_integrity: shadow.integrity,
     channels: {
       google: summarizeChannel(snapshot.google),
       meta: summarizeChannel(snapshot.meta),
     },
-    top_priorities: shadow.decisions.slice(0, 3),
-    observations: shadow.decisions.slice(3),
-    journal: shadow.decisions.map((decision, index) => ({
+    top_priorities: decisions.slice(0, 3),
+    observations: decisions.slice(3),
+    journal: decisions.map((decision, index) => ({
       sequence: index + 1,
       timestamp: shadow.generated_at,
       channel: decision.channel,
@@ -49,7 +84,15 @@ function buildDailyShadowReport(snapshot = {}) {
   if (report.writes_allowed !== false || report.spend_changed !== false) {
     throw new Error("daily shadow report violated no-write contract");
   }
+
+  const leakedUntrustedDecision = report.top_priorities
+    .concat(report.observations)
+    .some((decision) => decision.channel !== "system" && !trustedChannels.has(decision.channel));
+  if (leakedUntrustedDecision) {
+    throw new Error("untrusted channel produced recommendation");
+  }
+
   return report;
 }
 
-module.exports = { summarizeChannel, buildDailyShadowReport };
+module.exports = { summarizeChannel, buildDailyShadowReport, buildRepairDecision };

--- a/full-live-shadow-data.js
+++ b/full-live-shadow-data.js
@@ -1,6 +1,7 @@
 const { collectLiveShadowInput } = require("./live-shadow-data");
 const { collectGa4ShadowData } = require("./ga4-shadow-data");
 const { analyzeFunnel } = require("./funnel-analysis");
+const { evaluateShadowDataQuality, assertQualityFailClosed } = require("./shadow-data-quality");
 
 function buildFunnelInput(base, ga4) {
   const totals = ga4?.funnel?.totals || {};
@@ -28,9 +29,11 @@ async function collectFullLiveShadowInput({ env = process.env, days = 30, now = 
     collectGa4ShadowData({ env, days, now }),
   ]);
 
-  return {
+  const snapshot = {
     ...base,
-    funnel: ga4.access_ok ? buildFunnelInput(base, ga4) : { landingAvailable: false, bookingStartedTracked: false, analysis: null },
+    funnel: ga4.access_ok
+      ? buildFunnelInput(base, ga4)
+      : { landingAvailable: false, bookingStartedTracked: false, analysis: null },
     conversions: {
       ...base.conversions,
       booking_completed: ga4.access_ok ? Number(ga4.google_cpc_booking_completed || 0) : null,
@@ -45,6 +48,14 @@ async function collectFullLiveShadowInput({ env = process.env, days = 30, now = 
       ...base.live_sources,
       ga4,
     },
+  };
+
+  const dataQuality = evaluateShadowDataQuality(snapshot, { now });
+  assertQualityFailClosed(dataQuality);
+
+  return {
+    ...snapshot,
+    data_quality: dataQuality,
   };
 }
 

--- a/ga4-shadow-data.js
+++ b/ga4-shadow-data.js
@@ -76,10 +76,12 @@ async function runBookingReport({ accessToken, propertyId, start, end, googleCpc
 }
 
 async function collectGa4ShadowData({ env = process.env, days = 30, now = new Date() } = {}) {
+  const collectedAt = now.toISOString();
   if (!ga4Configured(env)) {
     return {
       access_ok: false,
       configuration_complete: false,
+      collected_at: collectedAt,
       error: "ga4_configuration_incomplete",
       required_variable: "GA4_PROPERTY_ID",
       total_booking_completed: null,
@@ -103,6 +105,7 @@ async function collectGa4ShadowData({ env = process.env, days = 30, now = new Da
     return {
       access_ok: true,
       configuration_complete: true,
+      collected_at: collectedAt,
       period: { start, end },
       event_name: "booking_completed",
       total_booking_completed: allBookings.event_count,
@@ -117,6 +120,7 @@ async function collectGa4ShadowData({ env = process.env, days = 30, now = new Da
     return {
       access_ok: false,
       configuration_complete: true,
+      collected_at: collectedAt,
       error: sanitizeGoogleError(error, "ga4_read_failed"),
       total_booking_completed: null,
       google_cpc_booking_completed: null,

--- a/live-shadow-data.js
+++ b/live-shadow-data.js
@@ -12,7 +12,8 @@ function sanitizeMetaIssues(issues) { if (!Array.isArray(issues)) return []; ret
 function buildGoogleCustomer(env) { const client=new GoogleAdsApi({client_id:env.GOOGLE_CLIENT_ID,client_secret:env.GOOGLE_CLIENT_SECRET,developer_token:env.GOOGLE_DEVELOPER_TOKEN}); return client.Customer({customer_id:normalizeGoogleCustomerId(env.GOOGLE_CUSTOMER_ID),refresh_token:env.GOOGLE_REFRESH_TOKEN,...(env.GOOGLE_LOGIN_CUSTOMER_ID?{login_customer_id:normalizeGoogleCustomerId(env.GOOGLE_LOGIN_CUSTOMER_ID)}:{})}); }
 
 async function collectGoogleShadowData({env=process.env,days=30,now=new Date()}={}) {
-  if(!googleConfigured(env)) return {access_ok:false,configuration_complete:false,error:"google_configuration_incomplete",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
+  const collectedAt = now.toISOString();
+  if(!googleConfigured(env)) return {access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"google_configuration_incomplete",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
   const customer=buildGoogleCustomer(env);
   const {start,end}=getDateRange(days,now);
   try {
@@ -37,14 +38,15 @@ async function collectGoogleShadowData({env=process.env,days=30,now=new Date()}=
       searchIntelligenceDiagnostic=cleanGoogleDiagnostic(error);
     }
 
-    return {access_ok:true,configuration_complete:true,period:{start,end},campaigns,totals,search_terms:searchTerms,keywords,search_intelligence_ok:searchIntelligenceOk,search_intelligence_diagnostic:searchIntelligenceDiagnostic};
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},campaigns,totals,search_terms:searchTerms,keywords,search_intelligence_ok:searchIntelligenceOk,search_intelligence_diagnostic:searchIntelligenceDiagnostic};
   } catch(error) {
-    return {access_ok:false,configuration_complete:true,diagnostic:cleanGoogleDiagnostic(error),error:"google_read_failed",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,diagnostic:cleanGoogleDiagnostic(error),error:"google_read_failed",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
   }
 }
 
-async function collectMetaShadowData({env=process.env,datePreset="last_30d"}={}) {
-  if(!metaConfigured(env)) return {access_ok:false,configuration_complete:false,error:"meta_configuration_incomplete",overview:null};
+async function collectMetaShadowData({env=process.env,datePreset="last_30d",now=new Date()}={}) {
+  const collectedAt = now.toISOString();
+  if(!metaConfigured(env)) return {access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"meta_configuration_incomplete",overview:null};
   const accountId=String(env.META_AD_ACCOUNT_ID).startsWith("act_")?String(env.META_AD_ACCOUNT_ID):`act_${env.META_AD_ACCOUNT_ID}`;
   const apiVersion=env.META_API_VERSION||"v19.0";
   const client=axios.create({baseURL:`https://graph.facebook.com/${apiVersion}`,timeout:20000});
@@ -58,14 +60,14 @@ async function collectMetaShadowData({env=process.env,datePreset="last_30d"}={})
     ]);
     const overview=buildMetaOverview(campaigns,insights,adsets);
     overview.issue_diagnostics={campaigns:campaigns.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),name:x.name||null,issues:sanitizeMetaIssues(x.issues_info)})),adsets:adsets.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),campaign_id:String(x.campaign_id||""),issues:sanitizeMetaIssues(x.issues_info)})),ads:ads.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),campaign_id:String(x.campaign_id||""),adset_id:String(x.adset_id||""),name:x.name||null,issues:sanitizeMetaIssues(x.issues_info)}))};
-    return {access_ok:true,configuration_complete:true,date_preset:datePreset,overview};
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,date_preset:datePreset,overview};
   } catch(error) {
-    return {access_ok:false,configuration_complete:true,error:error?.response?.data?.error?.message||error?.message||"meta_read_failed",overview:null};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:error?.response?.data?.error?.message||error?.message||"meta_read_failed",overview:null};
   }
 }
 
 async function collectLiveShadowInput({env=process.env,days=30,now=new Date()}={}) {
-  const [google,meta]=await Promise.all([collectGoogleShadowData({env,days,now}),collectMetaShadowData({env})]);
+  const [google,meta]=await Promise.all([collectGoogleShadowData({env,days,now}),collectMetaShadowData({env,now})]);
   const googleTotals=google.totals||{};
   const metaTotals=meta.overview?.totals||{};
   return {

--- a/shadow-data-quality.js
+++ b/shadow-data-quality.js
@@ -1,1 +1,98 @@
-function finite(value){if(value===null||value===undefined||value==='')return null;const n=Number(value);return Number.isFinite(n)?n:null;}function isoAgeHours(value,now=new Date()){if(!value)return null;const ts=new Date(value);if(Number.isNaN(ts.getTime()))return null;const age=(now-ts)/3600000;return age<0?null:age;}function sourceState({available,ageHours,maxAgeHours}){if(!available)return'unavailable';if(ageHours==null)return'freshness_unknown';return ageHours<=maxAgeHours?'fresh':'stale';}function evaluateShadowDataQuality(snapshot={}, {now=new Date(),maxAgeHours=36}={}){const live=snapshot.live_sources||{},access=snapshot.access||{},fallback=snapshot.collected_at||snapshot.now||snapshot.generated_at,spec={google:[access.google_ok===true,live.google],ga4:[access.ga4_ok===true,live.ga4],meta:[access.meta_ok===true,live.meta]},sources={};for(const[name,[available,data]]of Object.entries(spec)){const collectedAt=data?.collected_at||fallback,age=isoAgeHours(collectedAt,now);sources[name]={available,collected_at:collectedAt||null,age_hours:age,state:sourceState({available,ageHours:age,maxAgeHours}),business_last_seen_at:data?.last_seen_at||null};}const integrityBlockers=[],clicks=finite(live.google?.totals?.clicks),cost=finite(live.google?.totals?.spend_eur??live.google?.totals?.cost),bookings=finite(snapshot.conversions?.booking_completed);if(clicks!=null&&clicks<0)integrityBlockers.push('google_negative_clicks');if(cost!=null&&cost<0)integrityBlockers.push('google_negative_cost');if(bookings!=null&&bookings<0)integrityBlockers.push('negative_bookings');const integrityOk=!integrityBlockers.length,channelReady={google:sources.google.state==='fresh'&&sources.ga4.state==='fresh'&&integrityOk,meta:sources.meta.state==='fresh'},blockers=[...integrityBlockers];for(const[name,s]of Object.entries(sources))if(s.state!=='fresh')blockers.push(`${name}_${s.state}`);const completeness=Object.values(sources).filter(s=>s.state==='fresh').length/3,ready=channelReady.google||channelReady.meta,confidence=!ready?'blocked':blockers.length?'partial':'high';return{ready_for_recommendations:ready,ready_for_execution:false,confidence,completeness_ratio:Number(completeness.toFixed(2)),max_age_hours:maxAgeHours,sources,channel_ready:channelReady,integrity_ok:integrityOk,blockers:[...new Set(blockers)],writes_allowed:false};}function assertQualityFailClosed(q){if(q?.ready_for_execution!==false||q?.writes_allowed!==false)throw new Error('shadow quality gate violated fail-closed contract');if(!q?.ready_for_recommendations&&q?.confidence!=='blocked')throw new Error('blocked data has invalid confidence');return true;}module.exports={evaluateShadowDataQuality,assertQualityFailClosed,isoAgeHours,sourceState};
+function finite(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isoAgeHours(value, now = new Date()) {
+  if (!value) return null;
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return null;
+  const ageHours = (now - timestamp) / 3_600_000;
+  return ageHours < 0 ? null : ageHours;
+}
+
+function sourceState({ available, ageHours, maxAgeHours }) {
+  if (!available) return "unavailable";
+  if (ageHours == null) return "freshness_unknown";
+  return ageHours <= maxAgeHours ? "fresh" : "stale";
+}
+
+function evaluateShadowDataQuality(snapshot = {}, { now = new Date(), maxAgeHours = 36 } = {}) {
+  const live = snapshot.live_sources || {};
+  const access = snapshot.access || {};
+  const fallbackCollectedAt = snapshot.collected_at || snapshot.now || snapshot.generated_at;
+
+  const sourceSpec = {
+    google: [access.google_ok === true, live.google],
+    ga4: [access.ga4_ok === true, live.ga4],
+    meta: [access.meta_ok === true, live.meta],
+  };
+
+  const sources = {};
+  for (const [name, [available, data]] of Object.entries(sourceSpec)) {
+    const collectedAt = data?.collected_at || fallbackCollectedAt;
+    const ageHours = isoAgeHours(collectedAt, now);
+    sources[name] = {
+      available,
+      collected_at: collectedAt || null,
+      age_hours: ageHours,
+      state: sourceState({ available, ageHours, maxAgeHours }),
+      business_last_seen_at: data?.last_seen_at || null,
+    };
+  }
+
+  const integrityBlockers = [];
+  const clicks = finite(live.google?.totals?.clicks);
+  const cost = finite(live.google?.totals?.spend_eur ?? live.google?.totals?.cost);
+  const bookings = finite(snapshot.conversions?.booking_completed);
+
+  if (clicks != null && clicks < 0) integrityBlockers.push("google_negative_clicks");
+  if (cost != null && cost < 0) integrityBlockers.push("google_negative_cost");
+  if (bookings != null && bookings < 0) integrityBlockers.push("negative_bookings");
+
+  const integrityOk = integrityBlockers.length === 0;
+  const channelReady = {
+    google: sources.google.state === "fresh" && sources.ga4.state === "fresh" && integrityOk,
+    meta: sources.meta.state === "fresh",
+  };
+
+  const blockers = [...integrityBlockers];
+  for (const [name, source] of Object.entries(sources)) {
+    if (source.state !== "fresh") blockers.push(`${name}_${source.state}`);
+  }
+
+  const completeness = Object.values(sources).filter((source) => source.state === "fresh").length / 3;
+  const readyForRecommendations = channelReady.google || channelReady.meta;
+  const confidence = !readyForRecommendations ? "blocked" : blockers.length ? "partial" : "high";
+
+  return {
+    ready_for_recommendations: readyForRecommendations,
+    ready_for_execution: false,
+    confidence,
+    completeness_ratio: Number(completeness.toFixed(2)),
+    max_age_hours: maxAgeHours,
+    sources,
+    channel_ready: channelReady,
+    integrity_ok: integrityOk,
+    blockers: [...new Set(blockers)],
+    writes_allowed: false,
+  };
+}
+
+function assertQualityFailClosed(quality) {
+  if (quality?.ready_for_execution !== false || quality?.writes_allowed !== false) {
+    throw new Error("shadow quality gate violated fail-closed contract");
+  }
+  if (!quality?.ready_for_recommendations && quality?.confidence !== "blocked") {
+    throw new Error("blocked data has invalid confidence");
+  }
+  return true;
+}
+
+module.exports = {
+  evaluateShadowDataQuality,
+  assertQualityFailClosed,
+  isoAgeHours,
+  sourceState,
+};

--- a/test/daily-shadow-report.test.js
+++ b/test/daily-shadow-report.test.js
@@ -1,32 +1,76 @@
-const test=require("node:test");
-const assert=require("node:assert/strict");
-const {summarizeChannel,buildDailyShadowReport}=require("../daily-shadow-report");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { summarizeChannel, buildDailyShadowReport } = require("../daily-shadow-report");
 
-test("channel summary calculates CPC and cost per booking",()=>{
-  assert.deepEqual(summarizeChannel({cost:24,clicks:12,bookings:3}),{spend_eur:24,clicks:12,bookings:3,cpc_eur:2,cost_per_booking_eur:8});
+function trustedEvidence() {
+  const collectedAt = new Date().toISOString();
+  return {
+    access: { google_ok: true, ga4_ok: true, meta_ok: true },
+    live_sources: {
+      google: { collected_at: collectedAt, totals: { clicks: 10, spend_eur: 20 } },
+      ga4: { collected_at: collectedAt },
+      meta: { collected_at: collectedAt },
+    },
+  };
+}
+
+test("channel summary calculates CPC and cost per booking", () => {
+  assert.deepEqual(
+    summarizeChannel({ cost: 24, clicks: 12, bookings: 3 }),
+    { spend_eur: 24, clicks: 12, bookings: 3, cpc_eur: 2, cost_per_booking_eur: 8 }
+  );
 });
 
-test("daily report preserves zero-write contract and journal",()=>{
-  const report=buildDailyShadowReport({
-    source_health:{google:true,ga4:true,meta:true},
-    conversions:{googleConversions:10,ga4GoogleCpcBookings:4},
-    google:{cost:20,clicks:10,bookings:0,baselineBookings:4},
-    meta:{cost:12,clicks:6,bookings:0,baselineBookings:2}
+test("daily report preserves zero-write contract with trusted evidence", () => {
+  const report = buildDailyShadowReport({
+    ...trustedEvidence(),
+    conversions: { googleConversions: 10, ga4GoogleCpcBookings: 4, booking_completed: 4 },
+    google: { cost: 20, clicks: 10, bookings: 0, baselineBookings: 4 },
+    meta: { cost: 12, clicks: 6, bookings: 0, baselineBookings: 2 },
   });
-  assert.equal(report.mode,"shadow");
-  assert.equal(report.writes_allowed,false);
-  assert.equal(report.spend_changed,false);
-  assert.ok(report.top_priorities.length>0);
-  assert.ok(report.journal.length>0);
-  report.journal.forEach(entry=>{
-    assert.equal(entry.executable,false);
-    assert.equal(entry.execution_status,"not_executed");
-    assert.equal(entry.requires_human_approval,true);
+
+  assert.equal(report.mode, "shadow");
+  assert.equal(report.writes_allowed, false);
+  assert.equal(report.spend_changed, false);
+  assert.equal(report.data_quality.confidence, "high");
+  report.journal.forEach((entry) => {
+    assert.equal(entry.executable, false);
+    assert.equal(entry.execution_status, "not_executed");
+    assert.equal(entry.requires_human_approval, true);
   });
 });
 
-test("daily report does not invent cost-per-booking without bookings",()=>{
-  const report=buildDailyShadowReport({conversions:{googleConversions:0,ga4GoogleCpcBookings:0},google:{cost:15,clicks:5,bookings:0}});
-  assert.equal(report.channels.google.cost_per_booking_eur,null);
-  assert.equal(report.channels.google.cpc_eur,3);
+test("missing evidence produces repair instruction instead of optimization", () => {
+  const report = buildDailyShadowReport({ google: { cost: 15, clicks: 5, bookings: 0 } });
+  assert.equal(report.data_quality.ready_for_recommendations, false);
+  assert.equal(report.top_priorities[0].channel, "system");
+  assert.equal(report.top_priorities[0].action, "collect_or_repair_data");
+});
+
+test("stale GA4 suppresses Google recommendations without blocking Meta", () => {
+  const evidence = trustedEvidence();
+  evidence.live_sources.ga4.collected_at = "2020-01-01T00:00:00Z";
+
+  const report = buildDailyShadowReport({
+    ...evidence,
+    conversions: { booking_completed: 1 },
+    google: { cost: 30, clicks: 10, bookings: 0, baselineBookings: 4 },
+    meta: { cost: 12, clicks: 6, bookings: 0, baselineBookings: 2 },
+  });
+
+  const channelDecisions = report.top_priorities
+    .concat(report.observations)
+    .filter((decision) => decision.channel !== "system");
+
+  assert.equal(report.data_quality.channel_ready.google, false);
+  assert.ok(channelDecisions.every((decision) => decision.channel === "meta"));
+});
+
+test("daily report does not invent cost per booking without bookings", () => {
+  const report = buildDailyShadowReport({
+    conversions: { googleConversions: 0, ga4GoogleCpcBookings: 0 },
+    google: { cost: 15, clicks: 5, bookings: 0 },
+  });
+  assert.equal(report.channels.google.cost_per_booking_eur, null);
+  assert.equal(report.channels.google.cpc_eur, 3);
 });


### PR DESCRIPTION
Superseded by PR #63. PR #61 landed on main while #62 was being prepared, so #63 now restores readability directly on top of the actual current baseline instead of carrying an outdated base. No campaign writes.