### PR TITLE
Disable legacy Meta one-shot and guard concurrent safe creates

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,6 +1,9 @@
 const { META_API_VERSION } = require("./meta-paused-draft-next");
 if (!process.env.META_API_VERSION) process.env.META_API_VERSION = META_API_VERSION;
 
+const legacyMetaOneShotRequested = Boolean(process.env.META_PAUSED_DRAFT_ONE_SHOT);
+process.env.META_PAUSED_DRAFT_ONE_SHOT = "";
+
 const realExpress = require("express");
 const { collectFullLiveShadowInput } = require("./full-live-shadow-data");
 const { buildShadowAgentReport } = require("./agent-shadow");
@@ -164,6 +167,14 @@ function wrappedExpress(...args) {
 }
 Object.assign(wrappedExpress, realExpress);
 require.cache[require.resolve("express")].exports = wrappedExpress;
+
+if (legacyMetaOneShotRequested) {
+  console.warn(JSON.stringify({
+    event: "meta_legacy_one_shot_disabled",
+    reason: "central_safe_route_required",
+    activates_spend: false,
+  }));
+}
 
 triggerShadowReport().catch(() => {});
 metaPreflightStatus.run().catch(() => {});

--- a/meta-safe-create-route.js
+++ b/meta-safe-create-route.js
@@ -15,12 +15,13 @@ const {
 } = require('./meta-runtime-preflight');
 const { inspectNamedDraftChain } = require('./meta-real-preflight');
 const { executePausedMetaDraftSafely } = require('./meta-safe-orchestrator');
-const { AUTONOMY_LEVELS } = require('./safe-execution');
+const { AUTONOMY_LEVELS, stableKey } = require('./safe-execution');
 
 const DEFAULT_REEL = 'https://www.instagram.com/reel/C9M7_b6MayR/';
 const DEFAULT_USERNAME = 'parma.divinibenedetti';
 const DEFAULT_LATITUDE = 52.499492;
 const DEFAULT_LONGITUDE = 13.4399793;
+const inFlightOperations = new Set();
 
 function createWriteTransport({ accessToken, apiVersion = META_API_VERSION, client = axios }) {
   const normalized = normalizeApiVersion(apiVersion);
@@ -44,6 +45,26 @@ function createWriteTransport({ accessToken, apiVersion = META_API_VERSION, clie
       return response.data;
     },
   };
+}
+
+function operationKey({ env = process.env, startsAt } = {}) {
+  const config = runtimeConfig(env);
+  const normalizedStart = parseFutureStart(startsAt) || String(startsAt || '').trim();
+  return stableKey({
+    ad_account: config.adAccountId || 'unknown',
+    starts_at: normalizedStart,
+    operation: 'paused_reservation_draft',
+  });
+}
+
+function acquireOperationLock(key) {
+  if (!key || inFlightOperations.has(key)) return false;
+  inFlightOperations.add(key);
+  return true;
+}
+
+function releaseOperationLock(key) {
+  inFlightOperations.delete(key);
 }
 
 async function prepareSafeCreateContext({ env = process.env, startsAt, httpClient = axios } = {}) {
@@ -122,6 +143,19 @@ function registerMetaSafeCreateRoute(app, { authorized, env = process.env, httpC
     if (typeof authorized === 'function' && !authorized(req)) return res.status(401).json({ success: false, error: 'Unauthorized' });
     if (req.body?.confirmation !== APPROVAL_TOKEN) return res.status(400).json({ success: false, error: 'Exact paused-draft approval token is required', activates_spend: false });
     if (env.PARMA_AGENT_KILL_SWITCH === 'true') return res.status(423).json({ success: false, blocked: true, reason: 'kill_switch_enabled', activates_spend: false });
+
+    const lockKey = operationKey({ env, startsAt: req.body?.starts_at });
+    if (!acquireOperationLock(lockKey)) {
+      return res.status(409).json({
+        success: false,
+        blocked: true,
+        reason: 'duplicate_operation_in_flight',
+        activates_spend: false,
+        may_activate: false,
+        may_spend: false,
+      });
+    }
+
     try {
       const prepared = await prepareSafeCreateContext({ env, startsAt: req.body?.starts_at, httpClient });
       if (!prepared.ready) return res.status(409).json({ success: false, blocked: true, blockers: prepared.blockers, activates_spend: false, may_activate: false, may_spend: false });
@@ -153,8 +187,18 @@ function registerMetaSafeCreateRoute(app, { authorized, env = process.env, httpC
         may_activate: false,
         may_spend: false,
       });
+    } finally {
+      releaseOperationLock(lockKey);
     }
   });
 }
 
-module.exports = { createWriteTransport, prepareSafeCreateContext, sanitizeCreateResult, registerMetaSafeCreateRoute };
+module.exports = {
+  createWriteTransport,
+  operationKey,
+  acquireOperationLock,
+  releaseOperationLock,
+  prepareSafeCreateContext,
+  sanitizeCreateResult,
+  registerMetaSafeCreateRoute,
+};

--- a/test/meta-safe-create-route.test.js
+++ b/test/meta-safe-create-route.test.js
@@ -1,7 +1,16 @@
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { APPROVAL_TOKEN, META_API_VERSION } = require('../meta-paused-draft-next');
-const { createWriteTransport, sanitizeCreateResult, registerMetaSafeCreateRoute } = require('../meta-safe-create-route');
+const {
+  createWriteTransport,
+  operationKey,
+  acquireOperationLock,
+  releaseOperationLock,
+  sanitizeCreateResult,
+  registerMetaSafeCreateRoute,
+} = require('../meta-safe-create-route');
 
 function responseStub() {
   return {
@@ -40,7 +49,7 @@ test('sanitized create result never exposes Meta object ids', () => {
 
 test('safe create route rejects missing exact approval before any network work', async () => {
   let handler;
-  const app = { post(path, fn) { assert.equal(path, '/tools/meta/reservation-draft/create'); handler = fn; } };
+  const app = { post(route, fn) { assert.equal(route, '/tools/meta/reservation-draft/create'); handler = fn; } };
   registerMetaSafeCreateRoute(app, { authorized: () => true, env: {} });
   const res = responseStub();
   await handler({ body: {} }, res);
@@ -50,11 +59,36 @@ test('safe create route rejects missing exact approval before any network work',
 
 test('kill switch blocks even with the exact approval token', async () => {
   let handler;
-  const app = { post(path, fn) { handler = fn; } };
+  const app = { post(route, fn) { handler = fn; } };
   registerMetaSafeCreateRoute(app, { authorized: () => true, env: { PARMA_AGENT_KILL_SWITCH: 'true' } });
   const res = responseStub();
   await handler({ body: { confirmation: APPROVAL_TOKEN } }, res);
   assert.equal(res.statusCode, 423);
   assert.equal(res.body.blocked, true);
   assert.equal(res.body.reason, 'kill_switch_enabled');
+});
+
+test('equivalent start instants use the same operation lock key', () => {
+  const env = { META_AD_ACCOUNT_ID: '123' };
+  const first = operationKey({ env, startsAt: '2030-08-24T15:00:00.000Z' });
+  const second = operationKey({ env, startsAt: '2030-08-24T17:00:00.000+02:00' });
+  assert.equal(first, second);
+});
+
+test('only one identical operation can be in flight at a time', () => {
+  const key = 'same-operation';
+  releaseOperationLock(key);
+  assert.equal(acquireOperationLock(key), true);
+  assert.equal(acquireOperationLock(key), false);
+  releaseOperationLock(key);
+  assert.equal(acquireOperationLock(key), true);
+  releaseOperationLock(key);
+});
+
+test('bootstrap clears legacy startup one-shot before loading server', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'bootstrap.js'), 'utf8');
+  const disableIndex = source.indexOf('process.env.META_PAUSED_DRAFT_ONE_SHOT = ""');
+  const serverIndex = source.indexOf('require("./server")');
+  assert.ok(disableIndex >= 0);
+  assert.ok(serverIndex > disableIndex);
 });


### PR DESCRIPTION
Superseded by PR #81, rebased onto the latest main after the statistical-baseline merge. #81 carries the same startup one-shot neutralization and concurrent-operation serialization tests without diverging from current main.