### PR TITLE
Classify Meta issues_info into actionable issue families

### DIFF
--- a/meta-issue-classification.js
+++ b/meta-issue-classification.js
@@ -1,0 +1,39 @@
+function issueText(issue = {}) {
+  return `${issue.code || ''} ${issue.summary || ''} ${issue.message || ''}`.toLowerCase();
+}
+
+function classifyIssue(issue = {}) {
+  const text = issueText(issue);
+  if (/payment|billing|spend limit|account disabled|account status/.test(text)) return 'account_or_billing';
+  if (/permission|access|instagram account|page|asset/.test(text)) return 'asset_or_permission';
+  if (/creative|media|video|image|reel|instagram post/.test(text)) return 'creative_or_media';
+  if (/policy|rejected|disapproved|review|restricted/.test(text)) return 'policy_or_review';
+  if (/audience|target|geo|location|placement/.test(text)) return 'targeting_or_placement';
+  if (/budget|bid|optimization|billing event|objective/.test(text)) return 'delivery_configuration';
+  if (/schedule|start time|end time|date/.test(text)) return 'schedule';
+  return 'unknown';
+}
+
+function buildMetaIssueReport(issueDiagnostics = {}) {
+  const rows = [];
+  for (const level of ['campaigns', 'adsets', 'ads']) {
+    for (const object of issueDiagnostics[level] || []) {
+      const issues = object.issues || [];
+      rows.push({
+        object_level: level === 'campaigns' ? 'campaign' : level === 'adsets' ? 'adset' : 'ad',
+        name: object.name || null,
+        campaign_ref: object.campaign_id || (level === 'campaigns' ? object.id : null),
+        issue_count: issues.length,
+        categories: [...new Set(issues.map(classifyIssue))],
+        issues,
+      });
+    }
+  }
+  const categories = rows.reduce((acc, row) => {
+    for (const category of row.categories) acc[category] = (acc[category] || 0) + 1;
+    return acc;
+  }, {});
+  return { affected_objects: rows.length, categories, objects: rows };
+}
+
+module.exports = { classifyIssue, buildMetaIssueReport };

--- a/test/meta-issue-classification.test.js
+++ b/test/meta-issue-classification.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { classifyIssue, buildMetaIssueReport } = require('../meta-issue-classification');
+
+test('classifies common Meta issue families', () => {
+  assert.equal(classifyIssue({message:'Instagram account permission missing'}), 'asset_or_permission');
+  assert.equal(classifyIssue({summary:'Creative video unavailable'}), 'creative_or_media');
+  assert.equal(classifyIssue({message:'Ad rejected by policy review'}), 'policy_or_review');
+  assert.equal(classifyIssue({message:'Invalid audience location'}), 'targeting_or_placement');
+  assert.equal(classifyIssue({message:'Optimization goal incompatible with objective'}), 'delivery_configuration');
+});
+
+test('builds campaign-adset-ad report without inventing causes', () => {
+  const report = buildMetaIssueReport({
+    campaigns:[{id:'c1',name:'Dinner',issues:[{message:'Creative video unavailable'}]}],
+    adsets:[{campaign_id:'c1',issues:[{message:'Invalid audience location'}]}],
+    ads:[],
+  });
+  assert.equal(report.affected_objects, 2);
+  assert.equal(report.categories.creative_or_media, 1);
+  assert.equal(report.categories.targeting_or_placement, 1);
+  assert.equal(report.objects[0].campaign_ref, 'c1');
+});
+
+test('unknown diagnostics remain unknown', () => {
+  assert.equal(classifyIssue({message:'Unrecognized Meta condition'}), 'unknown');
+});


### PR DESCRIPTION
Adds a deterministic read-only classifier for sanitized Meta issues_info across campaign, ad set and ad levels. Produces actionable categories while preserving unknown diagnostics as unknown rather than guessing. Includes focused tests. No Meta writes or spend.