### PR TITLE
Port runtime diagnostics onto latest main

### DIFF
--- a/.github/workflows/runtime-readiness-v2.yml
+++ b/.github/workflows/runtime-readiness-v2.yml
@@ -38,19 +38,24 @@ jobs:
           meta=$(jq -r '.source_health.meta // false' shadow.json 2>/dev/null || echo false)
           writes=$(jq -r '.writes_allowed // true' shadow.json 2>/dev/null || echo true)
           gcat=$(jq -r '.source_diagnostics.google.category // "none"' shadow.json 2>/dev/null || echo none)
+          greason=$(jq -r '.source_diagnostics.google.reason // "none"' shadow.json 2>/dev/null || echo none)
           gcode=$(jq -r '.source_diagnostics.google.code // "none"' shadow.json 2>/dev/null || echo none)
+          reservation_start=$(jq -r '.tracking.reservation_start // false' shadow.json 2>/dev/null || echo false)
           read_ready=$(jq -r '.read_only_ready // .ready // false' meta.json 2>/dev/null || echo false)
           write_ready=$(jq -r '.write_ready // false' meta.json 2>/dev/null || echo false)
+          meta_blocker=$(jq -r '.blockers[0] // "none"' meta.json 2>/dev/null || echo unreadable)
           tz=$(jq -r '.account.timezone_name // "unknown"' meta.json 2>/dev/null || echo unknown)
           schedule_safe=$(jq -r '.account.schedule_conversion_safe // false' meta.json 2>/dev/null || echo false)
 
-          safe_gcat=$(printf '%s' "$gcat" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-24)
-          safe_gcode=$(printf '%s' "$gcode" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-24)
+          safe_gcat=$(printf '%s' "$gcat" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-18)
+          safe_greason=$(printf '%s' "$greason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-22)
+          safe_gcode=$(printf '%s' "$gcode" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-18)
+          safe_mb=$(printf '%s' "$meta_blocker" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-22)
           safe_tz=$(printf '%s' "$tz" | tr -cs 'A-Za-z0-9_+./-' '_' | cut -c1-24)
 
           if [ "$shadow_code" = "200" ] && [ "$writes" = "false" ] && [ "$read_ready" = "true" ] && [ "$schedule_safe" = "true" ]; then state="success"; else state="failure"; fi
-          context="runtime:g=${google}:${safe_gcat}:ga4=${ga4}:m=${meta}:mr=${read_ready}"
-          description="google=${google}/${safe_gcat}/${safe_gcode}; ga4=${ga4}; meta=${meta}; meta_read=${read_ready}; meta_write=${write_ready}; tz=${safe_tz}"
+          context="runtime:g=${google}:${safe_greason}:ga4=${ga4}:rs=${reservation_start}:m=${meta}:mr=${read_ready}:mb=${safe_mb}"
+          description="google=${google}/${safe_gcat}/${safe_greason}/${safe_gcode}; ga4=${ga4}; reservation_start=${reservation_start}; meta=${meta}; meta_read=${read_ready}; meta_write=${write_ready}; meta_blocker=${safe_mb}; tz=${safe_tz}"
           payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')
           curl -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
           echo "$description"

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -38,6 +38,7 @@ function sanitizedSummary() {
     buildValidated: process.env.AGENT_BUILD_VALIDATED === "true",
     shadowRecords: [],
   });
+  const ga4Events = Array.isArray(r.live_sources?.ga4?.funnel?.event_names) ? r.live_sources.ga4.funnel.event_names : [];
 
   return {
     generated_at: r.generated_at,
@@ -67,7 +68,13 @@ function sanitizedSummary() {
       },
       meta: r.live_sources?.meta?.access_ok ? {
         campaign_counts: r.live_sources?.meta?.overview?.campaign_counts || {},
+        issue_categories: r.live_sources?.meta?.overview?.issue_report?.categories || {},
       } : null,
+    },
+    tracking: {
+      reservation_page_view: ga4Events.includes("reservation_page_view"),
+      reservation_start: ga4Events.includes("reservation_start"),
+      booking_completed: ga4Events.includes("booking_completed"),
     },
     conversion_integrity: {
       status: r.conversion_integrity?.status || "unknown",
@@ -158,7 +165,7 @@ function wrappedExpress(...args) {
   app.get("/health/agent-shadow-summary", (req, res) => {
     if (state.status === "starting" && !state.result) return res.status(202).json({ success: true, status: "running", mode: "shadow", writes_allowed: false, started_at: state.started_at });
     if (state.status === "failed" && !state.result) return res.status(500).json({ success: false, status: "failed", mode: "shadow", writes_allowed: false, error: String(state.error || "shadow_report_failed").slice(0, 160) });
-    return res.json({ success: true, status: refreshPromise ? "refreshing" : "completed", refresh_error: state.last_refresh_error ? String(state.last_refresh_error).slice(0, 160) : null, last_refresh_failed_at: state.last_refresh_failed_at, ...sanitizedSummary() });
+    return res.json({ success: true, status: "completed", refreshing: Boolean(refreshPromise), refresh_error: state.last_refresh_error ? String(state.last_refresh_error).slice(0, 160) : null, last_refresh_failed_at: state.last_refresh_failed_at, ...sanitizedSummary() });
   });
   app.get("/tools/agent/shadow/live", (req, res) => {
     if (!authorized(req)) return res.status(401).json({ success: false, error: "Unauthorized" });

--- a/live-shadow-data.js
+++ b/live-shadow-data.js
@@ -2,12 +2,15 @@ const axios = require("axios");
 const { GoogleAdsApi } = require("google-ads-api");
 const { buildMetaOverview, buildGoogleReadiness } = require("./reporting");
 const { collectGoogleSearchTerms, collectGoogleKeywords, analyzeSearchTerms, analyzeKeywords } = require("./google-search-intelligence");
+const { META_API_VERSION } = require("./meta-paused-draft-next");
+const { buildMetaIssueReport } = require("./meta-issue-classification");
 
 function normalizeGoogleCustomerId(value) { return String(value || "").replace(/\D/g, ""); }
 function googleConfigured(env = process.env) { return Boolean(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET && env.GOOGLE_DEVELOPER_TOKEN && env.GOOGLE_REFRESH_TOKEN && env.GOOGLE_CUSTOMER_ID); }
 function metaConfigured(env = process.env) { return Boolean(env.META_ACCESS_TOKEN && env.META_AD_ACCOUNT_ID); }
 function getDateRange(days = 30, now = new Date()) { const end = new Date(now); end.setUTCHours(0,0,0,0); end.setUTCDate(end.getUTCDate()-1); const start = new Date(end); start.setUTCDate(start.getUTCDate()-(days-1)); return { start:start.toISOString().slice(0,10), end:end.toISOString().slice(0,10) }; }
-function cleanGoogleDiagnostic(error) { const first=Array.isArray(error?.errors)?error.errors[0]:null; const rawCode=first?.error_code||null; const code=rawCode&&typeof rawCode==="object"?Object.keys(rawCode)[0]||null:rawCode; const message=String(first?.message||error?.message||"google_read_failed").slice(0,180); let category="unknown"; if(/invalid_grant|refresh token|oauth/i.test(message)) category="oauth"; else if(/developer token|DEVELOPER_TOKEN/i.test(message)||/developer_token/i.test(String(code))) category="developer_token"; else if(/login customer|manager|customer.*not enabled|CUSTOMER_NOT_FOUND|USER_PERMISSION_DENIED/i.test(message)||/customer|authorization|permission/i.test(String(code))) category="account_access"; else if(/query|SELECT|GAQL|field/i.test(message)) category="query"; else if(/deadline|timeout|network|ENOTFOUND|ECONN/i.test(message)) category="network"; return {error:"google_read_failed",category,code:code||null,message}; }
+function googleDiagnosticReason(category,message,code){const text=`${message||''} ${code||''}`;if(category==='developer_token'){if(/basic access|standard access|test account|not approved|access level/i.test(text))return'basic_access_required';if(/invalid|not valid/i.test(text))return'developer_token_invalid';return'developer_token_rejected';}if(category==='oauth')return'oauth_refresh_required';if(category==='account_access')return'account_access_required';if(category==='query')return'query_rejected';if(category==='network')return'transient_network';return'unknown';}
+function cleanGoogleDiagnostic(error) { const first=Array.isArray(error?.errors)?error.errors[0]:null; const rawCode=first?.error_code||null; const code=rawCode&&typeof rawCode==="object"?Object.keys(rawCode)[0]||null:rawCode; const message=String(first?.message||error?.message||"google_read_failed").slice(0,180); let category="unknown"; if(/invalid_grant|refresh token|oauth/i.test(message)) category="oauth"; else if(/developer token|DEVELOPER_TOKEN/i.test(message)||/developer_token/i.test(String(code))) category="developer_token"; else if(/login customer|manager|customer.*not enabled|CUSTOMER_NOT_FOUND|USER_PERMISSION_DENIED/i.test(message)||/customer|authorization|permission/i.test(String(code))) category="account_access"; else if(/query|SELECT|GAQL|field/i.test(message)) category="query"; else if(/deadline|timeout|network|ENOTFOUND|ECONN/i.test(message)) category="network"; return {error:"google_read_failed",category,reason:googleDiagnosticReason(category,message,code),code:code||null,message}; }
 function sanitizeMetaIssues(issues) { if (!Array.isArray(issues)) return []; return issues.slice(0,20).map((issue)=>({ level:String(issue?.level||"unknown").slice(0,40), code:issue?.error_code == null ? null : String(issue.error_code).slice(0,40), summary:String(issue?.error_summary||issue?.title||"meta_delivery_issue").replace(/[\r\n\t]+/g," ").slice(0,180), message:String(issue?.error_message||issue?.message||"").replace(/[\r\n\t]+/g," ").slice(0,300) })); }
 function buildGoogleCustomer(env) { const client=new GoogleAdsApi({client_id:env.GOOGLE_CLIENT_ID,client_secret:env.GOOGLE_CLIENT_SECRET,developer_token:env.GOOGLE_DEVELOPER_TOKEN}); return client.Customer({customer_id:normalizeGoogleCustomerId(env.GOOGLE_CUSTOMER_ID),refresh_token:env.GOOGLE_REFRESH_TOKEN,...(env.GOOGLE_LOGIN_CUSTOMER_ID?{login_customer_id:normalizeGoogleCustomerId(env.GOOGLE_LOGIN_CUSTOMER_ID)}:{})}); }
 
@@ -21,23 +24,8 @@ async function collectGoogleShadowData({env=process.env,days=30,now=new Date()}=
     const campaigns=(rows||[]).map(row=>({campaign_id:String(row.campaign.id),campaign_name:row.campaign.name,status:row.campaign.status,channel_type:row.campaign.advertising_channel_type,impressions:Number(row.metrics.impressions||0),clicks:Number(row.metrics.clicks||0),cost_eur:Number(row.metrics.cost_micros||0)/1_000_000,average_cpc_eur:Number(row.metrics.average_cpc||0)/1_000_000,conversions:Number(row.metrics.conversions||0),conversion_value:Number(row.metrics.conversions_value||0)}));
     const totals=campaigns.reduce((a,r)=>({impressions:a.impressions+r.impressions,clicks:a.clicks+r.clicks,spend_eur:a.spend_eur+r.cost_eur,conversions:a.conversions+r.conversions}),{impressions:0,clicks:0,spend_eur:0,conversions:0});
     totals.cpc_eur=totals.clicks?totals.spend_eur/totals.clicks:0;
-
-    let searchTerms=[];
-    let keywords=[];
-    let searchIntelligenceOk=false;
-    let searchIntelligenceDiagnostic=null;
-    try {
-      const [terms, keywordRows]=await Promise.all([
-        collectGoogleSearchTerms({customer,start,end}),
-        collectGoogleKeywords({customer,start,end}),
-      ]);
-      searchTerms=analyzeSearchTerms(terms);
-      keywords=analyzeKeywords(keywordRows);
-      searchIntelligenceOk=true;
-    } catch (error) {
-      searchIntelligenceDiagnostic=cleanGoogleDiagnostic(error);
-    }
-
+    let searchTerms=[];let keywords=[];let searchIntelligenceOk=false;let searchIntelligenceDiagnostic=null;
+    try { const [terms,keywordRows]=await Promise.all([collectGoogleSearchTerms({customer,start,end}),collectGoogleKeywords({customer,start,end})]);searchTerms=analyzeSearchTerms(terms);keywords=analyzeKeywords(keywordRows);searchIntelligenceOk=true; } catch(error) { searchIntelligenceDiagnostic=cleanGoogleDiagnostic(error); }
     return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},campaigns,totals,search_terms:searchTerms,keywords,search_intelligence_ok:searchIntelligenceOk,search_intelligence_diagnostic:searchIntelligenceDiagnostic};
   } catch(error) {
     return {access_ok:false,configuration_complete:true,collected_at:collectedAt,diagnostic:cleanGoogleDiagnostic(error),error:"google_read_failed",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
@@ -48,7 +36,7 @@ async function collectMetaShadowData({env=process.env,datePreset="last_30d",now=
   const collectedAt = now.toISOString();
   if(!metaConfigured(env)) return {access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"meta_configuration_incomplete",overview:null};
   const accountId=String(env.META_AD_ACCOUNT_ID).startsWith("act_")?String(env.META_AD_ACCOUNT_ID):`act_${env.META_AD_ACCOUNT_ID}`;
-  const apiVersion=env.META_API_VERSION||"v19.0";
+  const candidate=String(env.META_API_VERSION||META_API_VERSION);const apiVersion=/^v\d+\.0$/.test(candidate)?candidate:META_API_VERSION;
   const client=axios.create({baseURL:`https://graph.facebook.com/${apiVersion}`,timeout:20000});
   const getCollection=async(endpoint,params)=>{const response=await client.get(endpoint,{params:{...params,access_token:env.META_ACCESS_TOKEN,limit:100}});return response.data.data||[];};
   try {
@@ -60,23 +48,20 @@ async function collectMetaShadowData({env=process.env,datePreset="last_30d",now=
     ]);
     const overview=buildMetaOverview(campaigns,insights,adsets);
     overview.issue_diagnostics={campaigns:campaigns.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),name:x.name||null,issues:sanitizeMetaIssues(x.issues_info)})),adsets:adsets.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),campaign_id:String(x.campaign_id||""),issues:sanitizeMetaIssues(x.issues_info)})),ads:ads.filter(x=>x.effective_status==="WITH_ISSUES"||x.issues_info?.length).map(x=>({id:String(x.id),campaign_id:String(x.campaign_id||""),adset_id:String(x.adset_id||""),name:x.name||null,issues:sanitizeMetaIssues(x.issues_info)}))};
-    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,date_preset:datePreset,overview};
+    overview.issue_report=buildMetaIssueReport(overview.issue_diagnostics);
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,api_version:apiVersion,date_preset:datePreset,overview};
   } catch(error) {
-    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:error?.response?.data?.error?.message||error?.message||"meta_read_failed",overview:null};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,api_version:apiVersion,error:error?.response?.data?.error?.message||error?.message||"meta_read_failed",overview:null};
   }
 }
 
 async function collectLiveShadowInput({env=process.env,days=30,now=new Date()}={}) {
   const [google,meta]=await Promise.all([collectGoogleShadowData({env,days,now}),collectMetaShadowData({env,now})]);
-  const googleTotals=google.totals||{};
-  const metaTotals=meta.overview?.totals||{};
+  const googleTotals=google.totals||{};const metaTotals=meta.overview?.totals||{};
   return {
-    now:now.toISOString(),
-    evidence_window:`${days}d`,
+    now:now.toISOString(),evidence_window:`${days}d`,
     google:google.access_ok?{...buildGoogleReadiness(),configuration_complete:true,api_access:"verified",totals:googleTotals,campaigns:google.campaigns}:{...buildGoogleReadiness(),configuration_complete:google.configuration_complete,api_access:"failed",error:google.error},
-    meta:meta.overview||{campaign_counts:{},totals:{}},
-    search_terms:google.search_terms||[],
-    keywords:google.keywords||[],
+    meta:meta.overview||{campaign_counts:{},totals:{}},search_terms:google.search_terms||[],keywords:google.keywords||[],
     conversions:{google_ads_conversions:google.access_ok?Number(googleTotals.conversions||0):null,booking_completed:null,google_last_seen_at:google.access_ok?now.toISOString():null,ga4_last_seen_at:null},
     current:{spend:Number(googleTotals.spend_eur||0)+Number(metaTotals.spend_eur||0),clicks:Number(googleTotals.clicks||0)+Number(metaTotals.clicks||0),conversions:Number(googleTotals.conversions||0),cpc:Number(googleTotals.cpc_eur||0),delivery_active:true},
     access:{google_ok:google.access_ok,meta_ok:meta.access_ok,google_search_intelligence_ok:Boolean(google.search_intelligence_ok)},
@@ -86,4 +71,4 @@ async function collectLiveShadowInput({env=process.env,days=30,now=new Date()}={
   };
 }
 
-module.exports={collectGoogleShadowData,collectMetaShadowData,collectLiveShadowInput,getDateRange,googleConfigured,metaConfigured,cleanGoogleDiagnostic,sanitizeMetaIssues};
+module.exports={collectGoogleShadowData,collectMetaShadowData,collectLiveShadowInput,getDateRange,googleConfigured,metaConfigured,googleDiagnosticReason,cleanGoogleDiagnostic,sanitizeMetaIssues};

--- a/test/bootstrap-shadow-summary-contract.test.js
+++ b/test/bootstrap-shadow-summary-contract.test.js
@@ -1,0 +1,21 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const path=require('node:path');
+const source=fs.readFileSync(path.join(__dirname,'..','bootstrap.js'),'utf8');
+
+test('public Shadow summary exposes only boolean GA4 tracking inventory',()=>{
+ assert.ok(source.includes('reservation_page_view: ga4Events.includes("reservation_page_view")'));
+ assert.ok(source.includes('reservation_start: ga4Events.includes("reservation_start")'));
+ assert.ok(source.includes('booking_completed: ga4Events.includes("booking_completed")'));
+});
+
+test('public Shadow summary keeps completed snapshot status while refresh may continue',()=>{
+ assert.ok(source.includes('status: "completed", refreshing: Boolean(refreshPromise)'));
+ assert.ok(source.includes('writes_allowed: false'));
+});
+
+test('promotion status remains present after diagnostics integration',()=>{
+ assert.ok(source.includes('buildSanitizedPromotionStatus'));
+ assert.ok(source.includes('promotion,'));
+});

--- a/test/live-shadow-data.test.js
+++ b/test/live-shadow-data.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { getDateRange, googleConfigured, metaConfigured } = require("../live-shadow-data");
+const { getDateRange, googleConfigured, metaConfigured, googleDiagnosticReason, cleanGoogleDiagnostic } = require("../live-shadow-data");
 
 test("live shadow collectors fail closed when credentials are absent", () => {
   assert.equal(googleConfigured({}), false);
@@ -15,4 +15,16 @@ test("live shadow collectors detect complete credential presence without exposin
 test("date range uses completed days only", () => {
   const range = getDateRange(2, new Date("2026-08-21T12:00:00Z"));
   assert.deepEqual(range, { start:"2026-08-19", end:"2026-08-20" });
+});
+
+test("developer token diagnostics distinguish access-level gating from invalid token", () => {
+  assert.equal(googleDiagnosticReason('developer_token','developer token not approved for Basic Access',null),'basic_access_required');
+  assert.equal(googleDiagnosticReason('developer_token','developer token is not valid',null),'developer_token_invalid');
+});
+
+test("Google diagnostic remains sanitized and structured", () => {
+  const result=cleanGoogleDiagnostic({message:'Developer token is not valid'});
+  assert.equal(result.category,'developer_token');
+  assert.equal(result.reason,'developer_token_invalid');
+  assert.equal(result.error,'google_read_failed');
 });


### PR DESCRIPTION
Clean port of PR #91 onto the latest main, preserving the new promotion-status safety layer. Adds boolean GA4 tracking inventory, stable completed Shadow snapshot status during refresh, refined Google developer-token reasons, pinned current Meta API fallback, live Meta issue-category summary, and richer sanitized runtime commit status. No ad-platform writes.