### PR TITLE
Align OpenAPI with safe Meta approval and sanitized health

### DIFF
--- a/meta-safe-create-route.js
+++ b/meta-safe-create-route.js
@@ -47,6 +47,14 @@ function createWriteTransport({ accessToken, apiVersion = META_API_VERSION, clie
   };
 }
 
+function resolveApprovalToken(body = {}) {
+  const canonical = body.approval_token;
+  const legacy = body.confirmation;
+  if (canonical != null && legacy != null && canonical !== legacy) return { valid: false, reason: 'conflicting_approval_tokens', token: null };
+  const token = canonical ?? legacy ?? null;
+  return { valid: token === APPROVAL_TOKEN, reason: token === APPROVAL_TOKEN ? null : 'approval_token_invalid', token };
+}
+
 function operationKey({ env = process.env, startsAt } = {}) {
   const config = runtimeConfig(env);
   const normalizedStart = parseFutureStart(startsAt) || String(startsAt || '').trim();
@@ -141,7 +149,8 @@ function registerMetaSafeCreateRoute(app, { authorized, env = process.env, httpC
   app.post('/tools/meta/reservation-draft/create', async (req, res) => {
     res.setHeader('Cache-Control', 'no-store');
     if (typeof authorized === 'function' && !authorized(req)) return res.status(401).json({ success: false, error: 'Unauthorized' });
-    if (req.body?.confirmation !== APPROVAL_TOKEN) return res.status(400).json({ success: false, error: 'Exact paused-draft approval token is required', activates_spend: false });
+    const approval = resolveApprovalToken(req.body || {});
+    if (!approval.valid) return res.status(400).json({ success: false, blocked: true, reason: approval.reason, error: 'Exact paused-draft approval token is required', activates_spend: false, may_activate: false, may_spend: false });
     if (env.PARMA_AGENT_KILL_SWITCH === 'true') return res.status(423).json({ success: false, blocked: true, reason: 'kill_switch_enabled', activates_spend: false });
 
     const lockKey = operationKey({ env, startsAt: req.body?.starts_at });
@@ -163,7 +172,7 @@ function registerMetaSafeCreateRoute(app, { authorized, env = process.env, httpC
         transport: prepared.writeTransport,
         adAccountId: prepared.config.adAccountId,
         draft: prepared.draft,
-        approvalToken: req.body.confirmation,
+        approvalToken: approval.token,
         existing: prepared.knownPartial,
         assets: prepared.assets,
         writeGateEnabled: prepared.config.writeGateEnabled,
@@ -195,6 +204,7 @@ function registerMetaSafeCreateRoute(app, { authorized, env = process.env, httpC
 
 module.exports = {
   createWriteTransport,
+  resolveApprovalToken,
   operationKey,
   acquireOperationLock,
   releaseOperationLock,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,30 @@ paths:
       responses:
         "200":
           description: OK
+  /health/agent-shadow-summary:
+    get:
+      operationId: getSanitizedShadowHealth
+      summary: Get sanitized read-only Shadow health
+      description: Returns source health, data confidence, tracking availability and promotion blockers without credentials or advertising object IDs. Writes are always disabled.
+      responses:
+        "200":
+          description: Latest completed sanitized Shadow snapshot
+        "202":
+          description: First Shadow snapshot is still running
+        "500":
+          description: No completed Shadow snapshot is available because collection failed safely
+  /health/meta-real-preflight-summary:
+    get:
+      operationId: getSanitizedMetaPreflightHealth
+      summary: Get sanitized Meta read-only preflight health
+      description: Separates read-only readiness from write readiness. This endpoint never authorizes a write, delivery, or spend.
+      responses:
+        "200":
+          description: Sanitized Meta preflight completed
+        "202":
+          description: Meta preflight is pending or running
+        "500":
+          description: Meta preflight failed safely
   /tools/status:
     get:
       operationId: getStatus
@@ -220,7 +244,7 @@ paths:
     post:
       operationId: createPausedMetaReservationDraft
       summary: Create the approved Parma reservations campaign as PAUSED Meta objects only
-      description: This operation never activates delivery or spend. It is blocked unless the server write gate is temporarily enabled and the exact human-approval phrase is supplied.
+      description: This operation never activates delivery or spend. It is blocked unless the server write gate is temporarily enabled, the kill switch is clear, the live preflight is safe and the exact human-approval phrase is supplied. The canonical request field is approval_token; the runtime accepts the former confirmation field only for backward compatibility and fails closed if both disagree.
       security:
         - ApiKeyAuth: []
       requestBody:
@@ -243,15 +267,17 @@ paths:
                   description: Exact scoped phrase confirming creation of paused draft objects only
       responses:
         "201":
-          description: Campaign, ad set, creative and ad created and verified PAUSED
+          description: Missing draft stages created and the complete chain verified PAUSED; no delivery or spend is activated
         "400":
-          description: Invalid request
-        "403":
-          description: Server write gate disabled or approval phrase missing
+          description: Invalid request or missing/conflicting approval token
+        "401":
+          description: Unauthorized
         "409":
-          description: A draft already exists for the selected start date
+          description: Write gate disabled, duplicate operation in flight, unsafe existing chain, or another fail-closed preflight blocker
+        "423":
+          description: Kill switch enabled
         "502":
-          description: Partial paused draft; returned object IDs require inspection
+          description: Meta execution failed safely; response contains only sanitized stage and error diagnostics
 components:
   schemas: {}
   securitySchemes:

--- a/test/meta-safe-create-route.test.js
+++ b/test/meta-safe-create-route.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const { APPROVAL_TOKEN, META_API_VERSION } = require('../meta-paused-draft-next');
 const {
   createWriteTransport,
+  resolveApprovalToken,
   operationKey,
   acquireOperationLock,
   releaseOperationLock,
@@ -35,6 +36,18 @@ test('write transport pins the current Meta API generation', () => {
   assert.equal(config.baseURL, `https://graph.facebook.com/${META_API_VERSION}`);
 });
 
+test('canonical approval_token matches OpenAPI and legacy confirmation remains compatible', () => {
+  assert.deepEqual(resolveApprovalToken({ approval_token: APPROVAL_TOKEN }), { valid: true, reason: null, token: APPROVAL_TOKEN });
+  assert.deepEqual(resolveApprovalToken({ confirmation: APPROVAL_TOKEN }), { valid: true, reason: null, token: APPROVAL_TOKEN });
+});
+
+test('conflicting approval fields fail closed', () => {
+  const result = resolveApprovalToken({ approval_token: APPROVAL_TOKEN, confirmation: 'DIFFERENT' });
+  assert.equal(result.valid, false);
+  assert.equal(result.reason, 'conflicting_approval_tokens');
+  assert.equal(result.token, null);
+});
+
 test('sanitized create result never exposes Meta object ids', () => {
   const safe = sanitizeCreateResult({
     success: true,
@@ -57,12 +70,12 @@ test('safe create route rejects missing exact approval before any network work',
   assert.equal(res.body.activates_spend, false);
 });
 
-test('kill switch blocks even with the exact approval token', async () => {
+test('kill switch blocks even with canonical approval token', async () => {
   let handler;
   const app = { post(route, fn) { handler = fn; } };
   registerMetaSafeCreateRoute(app, { authorized: () => true, env: { PARMA_AGENT_KILL_SWITCH: 'true' } });
   const res = responseStub();
-  await handler({ body: { confirmation: APPROVAL_TOKEN } }, res);
+  await handler({ body: { approval_token: APPROVAL_TOKEN } }, res);
   assert.equal(res.statusCode, 423);
   assert.equal(res.body.blocked, true);
   assert.equal(res.body.reason, 'kill_switch_enabled');

--- a/test/openapi-contract.test.js
+++ b/test/openapi-contract.test.js
@@ -7,6 +7,7 @@ const root = path.join(__dirname, "..");
 const openapi = fs.readFileSync(path.join(root, "openapi.yaml"), "utf8");
 const server = fs.readFileSync(path.join(root, "server.js"), "utf8");
 const bootstrap = fs.readFileSync(path.join(root, "bootstrap.js"), "utf8");
+const safeCreate = fs.readFileSync(path.join(root, "meta-safe-create-route.js"), "utf8");
 const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 
 test("OpenAPI version matches package version", () => {
@@ -28,17 +29,12 @@ test("Google campaign metric routes are declared in OpenAPI and implemented by t
       expressPath: '"/tools/campaign/:id/metrics"',
     },
   ];
-
   for (const contract of contracts) {
     assert.match(openapi, new RegExp(contract.openapiPath.replace(/[{}]/g, "\\$&")));
     assert.ok(openapi.includes(contract.operationId), `${contract.operationId} missing`);
     assert.ok(server.includes(contract.expressPath), `${contract.expressPath} missing`);
   }
-
-  assert.ok(
-    server.includes("handleGoogleCampaignMetrics"),
-    "shared Google campaign metric handler is missing"
-  );
+  assert.ok(server.includes("handleGoogleCampaignMetrics"), "shared Google campaign metric handler is missing");
 });
 
 test("Meta campaign metrics remain on a distinct namespace", () => {
@@ -56,6 +52,23 @@ test("protected shadow refresh is declared in OpenAPI and wired through bootstra
   assert.ok(bootstrap.includes("triggerShadowReport().catch(() => {})"));
   assert.ok(bootstrap.includes("collectFullLiveShadowInput"));
   assert.ok(bootstrap.includes('writes_allowed: false'));
+});
+
+test("sanitized runtime health endpoints are documented", () => {
+  assert.ok(openapi.includes("/health/agent-shadow-summary:"));
+  assert.ok(openapi.includes("operationId: getSanitizedShadowHealth"));
+  assert.ok(openapi.includes("/health/meta-real-preflight-summary:"));
+  assert.ok(openapi.includes("operationId: getSanitizedMetaPreflightHealth"));
+  assert.ok(bootstrap.includes('/health/agent-shadow-summary'));
+});
+
+test("Meta paused create contract uses canonical approval_token and fail-closed responses", () => {
+  assert.ok(openapi.includes("required: [starts_at, approval_token]"));
+  assert.ok(openapi.includes("approval_token:"));
+  assert.ok(openapi.includes('"423":'));
+  assert.ok(safeCreate.includes("body.approval_token"));
+  assert.ok(safeCreate.includes("conflicting_approval_tokens"));
+  assert.ok(safeCreate.includes("approvalToken: approval.token"));
 });
 
 test("OpenAPI is served by the application", () => {


### PR DESCRIPTION
Aligns the canonical Meta PAUSED Action contract with runtime without executing any writes. Runtime now accepts the documented approval_token field, keeps the former confirmation field only for backward compatibility, and fails closed if both disagree. OpenAPI now documents the sanitized Shadow/Meta health endpoints and the actual fail-closed response codes for the PAUSED route. Adds regression tests for canonical token handling and runtime/OpenAPI consistency.