### PR TITLE
Start real Shadow history baseline

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -10,8 +10,10 @@ const { buildShadowAgentReport } = require("./agent-shadow");
 const { registerMetaRealPreflightRoute } = require("./meta-runtime-preflight");
 const { registerMetaSafeCreateRoute } = require("./meta-safe-create-route");
 const { buildSanitizedPromotionStatus } = require("./promotion-status");
+const { createShadowHistoryStore, recordFromShadowResult } = require("./shadow-history");
 const metaPreflightStatus = require("./meta-preflight-status");
 
+const shadowHistory = createShadowHistoryStore();
 const state = {
   status: "starting",
   started_at: new Date().toISOString(),
@@ -36,7 +38,7 @@ function sanitizedSummary() {
     shadowResult: { ...r, refresh_error: state.last_refresh_error },
     metaPreflightState: metaPreflightStatus.state,
     buildValidated: process.env.AGENT_BUILD_VALIDATED === "true",
-    shadowRecords: [],
+    shadowRecords: shadowHistory.list(),
   });
   const ga4Events = Array.isArray(r.live_sources?.ga4?.funnel?.event_names) ? r.live_sources.ga4.funnel.event_names : [];
 
@@ -118,6 +120,7 @@ function triggerShadowReport() {
         business_value: report.business_value,
         journal: report.journal,
       };
+      shadowHistory.append(recordFromShadowResult(state.result));
       console.log(JSON.stringify({
         event: "agent_shadow_live_report",
         success: true,
@@ -130,6 +133,7 @@ function triggerShadowReport() {
         data_confidence: input.data_quality?.confidence || null,
         conversion_integrity: report.conversion_integrity?.status || null,
         priority_count: report.daily_manager?.primary_priorities?.length || 0,
+        shadow_history_runs: shadowHistory.list().length,
         writes_allowed: false,
       }));
       return state.result;

--- a/shadow-history.js
+++ b/shadow-history.js
@@ -1,0 +1,56 @@
+const MAX_RECORDS = 200;
+
+function createShadowHistoryStore({ maxRecords = MAX_RECORDS } = {}) {
+  const records = [];
+  const limit = Math.max(1, Number(maxRecords) || MAX_RECORDS);
+
+  function append(record = {}) {
+    const generatedAt = record.generated_at || new Date().toISOString();
+    const normalized = {
+      id: String(record.id || `shadow-${generatedAt}`),
+      generated_at: generatedAt,
+      outcome: record.outcome ?? null,
+      expected_direction: record.expected_direction ?? null,
+      before: record.before ?? null,
+      after: record.after ?? null,
+      data_quality: record.data_quality || "unknown",
+      attribution_confidence: record.attribution_confidence || "unknown",
+      safety_violation: record.safety_violation === true,
+      source_health: {
+        google: record.source_health?.google === true,
+        ga4: record.source_health?.ga4 === true,
+        meta: record.source_health?.meta === true,
+      },
+    };
+    records.push(normalized);
+    if (records.length > limit) records.splice(0, records.length - limit);
+    return normalized;
+  }
+
+  function list() {
+    return records.map((record) => ({ ...record, source_health: { ...record.source_health } }));
+  }
+
+  return { append, list };
+}
+
+function recordFromShadowResult(result = {}) {
+  const confidence = result.data_quality?.confidence;
+  return {
+    generated_at: result.generated_at,
+    data_quality: confidence === "high" ? "high" : confidence || "unknown",
+    attribution_confidence: result.conversion_integrity?.confidence || "unknown",
+    safety_violation: false,
+    source_health: {
+      google: result.live_sources?.google?.access_ok === true,
+      ga4: result.live_sources?.ga4?.access_ok === true,
+      meta: result.live_sources?.meta?.access_ok === true,
+    },
+    outcome: null,
+    expected_direction: null,
+    before: null,
+    after: null,
+  };
+}
+
+module.exports = { createShadowHistoryStore, recordFromShadowResult };

--- a/test/shadow-history.test.js
+++ b/test/shadow-history.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createShadowHistoryStore, recordFromShadowResult } = require("../shadow-history");
+
+function sampleResult() {
+  return {
+    generated_at: "2026-08-23T18:00:00.000Z",
+    data_quality: { confidence: "high" },
+    conversion_integrity: { confidence: "medium" },
+    live_sources: {
+      google: { access_ok: false },
+      ga4: { access_ok: true },
+      meta: { access_ok: true },
+    },
+  };
+}
+
+test("real collection becomes non-evaluable history without invented outcomes", () => {
+  const record = recordFromShadowResult(sampleResult());
+  assert.equal(record.outcome, null);
+  assert.equal(record.expected_direction, null);
+  assert.equal(record.before, null);
+  assert.equal(record.after, null);
+  assert.equal(record.safety_violation, false);
+  assert.deepEqual(record.source_health, { google: false, ga4: true, meta: true });
+});
+
+test("history store is bounded and returns copies", () => {
+  const store = createShadowHistoryStore({ maxRecords: 2 });
+  store.append({ id: "a" });
+  store.append({ id: "b" });
+  store.append({ id: "c" });
+  const records = store.list();
+  assert.deepEqual(records.map((record) => record.id), ["b", "c"]);
+  records[0].source_health.google = true;
+  assert.equal(store.list()[0].source_health.google, false);
+});


### PR DESCRIPTION
Superseded by merged PR #98, which implements a stronger version of the same baseline: bounded sanitized Shadow history is persisted, deduplicated, wired into promotion readiness, owner-only on disk, and remains read-only. Closing this duplicate avoids parallel history implementations. No ad-platform mutation.