### PR TITLE
Add minimal read-only Meta issue report workflow

### DIFF
--- a/.github/workflows/meta-issue-report.yml
+++ b/.github/workflows/meta-issue-report.yml
@@ -1,0 +1,19 @@
+name: meta-issue-report
+on:
+  workflow_dispatch:
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run sanitized read-only Meta issue report
+        env:
+          META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
+          META_AD_ACCOUNT_ID: ${{ secrets.META_AD_ACCOUNT_ID }}
+          META_API_VERSION: ${{ secrets.META_API_VERSION }}
+        run: node scripts/run-meta-issue-report.js

--- a/scripts/run-meta-issue-report.js
+++ b/scripts/run-meta-issue-report.js
@@ -1,0 +1,9 @@
+require('dotenv').config();
+const {collectMetaShadowData}=require('../live-shadow-data');
+
+(async()=>{
+ const result=await collectMetaShadowData();
+ if(!result.access_ok){console.error(JSON.stringify({access_ok:false,error:result.error||'meta_read_failed'}));process.exitCode=1;return;}
+ const overview=result.overview||{};
+ console.log(JSON.stringify({access_ok:true,collected_at:result.collected_at,campaign_counts:overview.campaign_counts||{},issue_report:overview.issue_report||{affected_objects:0,categories:{},objects:[]}},null,2));
+})().catch(error=>{console.error(JSON.stringify({access_ok:false,error:String(error?.message||'meta_issue_report_failed').slice(0,180)}));process.exitCode=1;});

--- a/test/meta-issue-report-api-version-contract.test.js
+++ b/test/meta-issue-report-api-version-contract.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector validates API version and falls back to project constant',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8');
+ assert.match(s,/const candidate=String\(env\.META_API_VERSION\|\|META_API_VERSION\)/);
+ assert.match(s,/\^v\\d\+\\\.0\$/);
+});

--- a/test/meta-issue-report-classification-contract.test.js
+++ b/test/meta-issue-report-classification-contract.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {buildMetaIssueReport}=require('../meta-issue-classification');
+
+test('classified issue report summarizes affected delivery objects',()=>{
+ const report=buildMetaIssueReport({campaigns:[{id:'1',name:'x',issues:[{level:'ERROR',code:'100',summary:'Invalid parameter',message:'Invalid parameter'}]}],adsets:[],ads:[]});
+ assert.equal(report.affected_objects,1);
+ assert.ok(Array.isArray(report.objects));
+ assert.equal(report.objects.length,1);
+});

--- a/test/meta-issue-report-live-api-read.test.js
+++ b/test/meta-issue-report-live-api-read.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta issue fields are requested through the existing GET collection helper',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.match(m,/const getCollection=.*client\.get/);
+ assert.equal((m.match(/issues_info/g)||[]).length>=6,true);
+});

--- a/test/meta-issue-report-live-api-version.test.js
+++ b/test/meta-issue-report-live-api-version.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector rejects malformed API version overrides',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8');
+ assert.match(s,/\^v\\d\+\\\.0\$/.source ? s : s/);
+ assert.match(s,/candidate\)\?candidate:META_API_VERSION/);
+});

--- a/test/meta-issue-report-live-api-version.test.js
+++ b/test/meta-issue-report-live-api-version.test.js
@@ -4,6 +4,6 @@ const fs=require('node:fs');
 
 test('Meta collector rejects malformed API version overrides',()=>{
  const s=fs.readFileSync('live-shadow-data.js','utf8');
- assert.match(s,/\^v\\d\+\\\.0\$/.source ? s : s/);
+ assert.match(s,/const candidate=String\(env\.META_API_VERSION\|\|META_API_VERSION\)/);
  assert.match(s,/candidate\)\?candidate:META_API_VERSION/);
 });

--- a/test/meta-issue-report-live-contract.test.js
+++ b/test/meta-issue-report-live-contract.test.js
@@ -1,0 +1,12 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+const {sanitizeMetaIssues}=require('../live-shadow-data');
+
+test('live Meta diagnostic path requests all levels and remains GET-only',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.match(m,/campaigns[^\n]+issues_info/); assert.match(m,/adsets[^\n]+issues_info/); assert.match(m,/ads[^\n]+issues_info/); assert.match(m,/buildMetaIssueReport/);
+ assert.match(m,/client\.get/); assert.doesNotMatch(m,/client\.(post|put|patch|delete)/);
+ const out=sanitizeMetaIssues(Array.from({length:30},()=>({error_summary:'x'.repeat(300),error_message:'y'.repeat(500)})));
+ assert.equal(out.length,20); assert.ok(out.every(x=>x.summary.length<=180&&x.message.length<=300));
+});

--- a/test/meta-issue-report-live-error-boundary.test.js
+++ b/test/meta-issue-report-live-error-boundary.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector error path returns bounded diagnostic fields rather than credentials',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.match(m,/error:error\?\.response\?\.data\?\.error\?\.message/);
+ assert.doesNotMatch(m,/return \{[^}]*access_token/);
+});

--- a/test/meta-issue-report-live-filter.test.js
+++ b/test/meta-issue-report-live-filter.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector includes explicit WITH_ISSUES objects even when issue list is empty',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8');
+ assert.match(s,/x\.effective_status==="WITH_ISSUES"\|\|x\.issues_info\?\.length/);
+});

--- a/test/meta-issue-report-live-ids.test.js
+++ b/test/meta-issue-report-live-ids.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector normalizes diagnostic object references to strings',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('overview.issue_diagnostics=')[1].split('overview.issue_report=')[0];
+ assert.match(m,/id:String\(x\.id\)/);
+ assert.match(m,/campaign_id:String\(x\.campaign_id\|\|""\)/);
+});

--- a/test/meta-issue-report-live-issue-levels.test.js
+++ b/test/meta-issue-report-live-issue-levels.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta issue diagnostics preserve campaign adset and ad hierarchy',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8');
+ assert.match(s,/issue_diagnostics=\{campaigns:/);
+ assert.match(s,/adsets:adsets\.filter/);
+ assert.match(s,/ads:ads\.filter/);
+});

--- a/test/meta-issue-report-live-no-mutation-method.test.js
+++ b/test/meta-issue-report-live-no-mutation-method.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector diagnostic function has no HTTP mutation method',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.doesNotMatch(m,/\.post\(|\.put\(|\.patch\(|\.delete\(/);
+});

--- a/test/meta-issue-report-live-no-write-import.test.js
+++ b/test/meta-issue-report-live-no-write-import.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector diagnostic function does not invoke campaign write functions',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.doesNotMatch(m,/createPaused|createCampaign|createAdset|createAd|activate|publish|writeGate/i);
+});

--- a/test/meta-issue-report-live-one-request-level.test.js
+++ b/test/meta-issue-report-live-one-request-level.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta collector defines one campaign adset and ad issue query in the collection batch',()=>{
+ const s=fs.readFileSync('live-shadow-data.js','utf8'); const m=s.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+ assert.equal((m.match(/\/campaigns`/g)||[]).length,1);
+ assert.equal((m.match(/\/adsets`/g)||[]).length,1);
+ assert.equal((m.match(/\/ads`/g)||[]).length,1);
+});

--- a/test/meta-issue-report-live-sanitizer-cap.test.js
+++ b/test/meta-issue-report-live-sanitizer-cap.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {sanitizeMetaIssues}=require('../live-shadow-data');
+
+test('Meta issue sanitizer caps issue entries at twenty per object',()=>{
+ const out=sanitizeMetaIssues(Array.from({length:50},(_,i)=>({error_code:i,error_summary:'issue'})));
+ assert.equal(out.length,20);
+});

--- a/test/meta-issue-report-live-sanitizer-null.test.js
+++ b/test/meta-issue-report-live-sanitizer-null.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {sanitizeMetaIssues}=require('../live-shadow-data');
+
+test('Meta issue sanitizer is null safe',()=>{
+ assert.deepEqual(sanitizeMetaIssues(null),[]);
+ assert.deepEqual(sanitizeMetaIssues({}),[]);
+});

--- a/test/meta-issue-report-live-summary-fallback.test.js
+++ b/test/meta-issue-report-live-summary-fallback.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {sanitizeMetaIssues}=require('../live-shadow-data');
+
+test('Meta issue sanitizer supplies a bounded generic summary when absent',()=>{
+ const [x]=sanitizeMetaIssues([{}]);
+ assert.equal(x.summary,'meta_delivery_issue');
+ assert.equal(x.message,'');
+});

--- a/test/meta-issue-report-no-repair.test.js
+++ b/test/meta-issue-report-no-repair.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('issue classification module contains no network or campaign mutation code',()=>{
+ const s=fs.readFileSync('meta-issue-classification.js','utf8');
+ assert.doesNotMatch(s,/axios|fetch\(|\.post\(|\.delete\(|createCampaign|updateCampaign|activate/i);
+});

--- a/test/meta-issue-report-no-secret-output.test.js
+++ b/test/meta-issue-report-no-secret-output.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {buildMetaIssueReport}=require('../meta-issue-classification');
+
+test('classified issue report contains no credential-shaped fields',()=>{
+ const report=buildMetaIssueReport({campaigns:[{id:'1',issues:[{level:'ERROR',summary:'delivery issue',message:'review configuration'}]}],adsets:[],ads:[]});
+ const text=JSON.stringify(report);
+ assert.doesNotMatch(text,/access_token|refresh_token|client_secret|password/i);
+});

--- a/test/meta-issue-report-runner-counts.test.js
+++ b/test/meta-issue-report-runner-counts.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta report runner includes campaign delivery counts for context',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/campaign_counts:overview\.campaign_counts\|\|\{\}/);
+});

--- a/test/meta-issue-report-runner-default.test.js
+++ b/test/meta-issue-report-runner-default.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta report runner default issue shape is deterministic',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/affected_objects:0,categories:\{\},objects:\[\]/);
+});

--- a/test/meta-issue-report-runner-error-boundary.test.js
+++ b/test/meta-issue-report-runner-error-boundary.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner does not expose stack traces or environment on error',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.doesNotMatch(s,/error\.stack|process\.env\)|JSON\.stringify\(process\.env/);
+ assert.match(s,/String\(error\?\.message/);
+});

--- a/test/meta-issue-report-runner-error.test.js
+++ b/test/meta-issue-report-runner-error.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta report runner emits compact access failure shape',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/\{access_ok:false,error:result\.error\|\|'meta_read_failed'\}/);
+});

--- a/test/meta-issue-report-runner-exit.test.js
+++ b/test/meta-issue-report-runner-exit.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner explicitly marks read failures and leaves success non-mutating',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/access_ok:false/); assert.match(s,/process\.exitCode=1/); assert.match(s,/access_ok:true/);
+ assert.doesNotMatch(s,/process\.exitCode=0|process\.exit\(0\)/);
+});

--- a/test/meta-issue-report-runner-network-boundary.test.js
+++ b/test/meta-issue-report-runner-network-boundary.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta report runner has no direct network or write-module path',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.doesNotMatch(s,/axios|fetch\(|https?:|graph\.facebook|meta-paused-draft|write-gate|execution/);
+ assert.match(s,/live-shadow-data/);
+});

--- a/test/meta-issue-report-runner-no-identifiers.test.js
+++ b/test/meta-issue-report-runner-no-identifiers.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner does not explicitly emit account or credential environment values',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.doesNotMatch(s,/META_ACCESS_TOKEN|META_AD_ACCOUNT_ID|process\.env/);
+});

--- a/test/meta-issue-report-runner-no-overview.test.js
+++ b/test/meta-issue-report-runner-no-overview.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner selects compact fields rather than outputting full overview',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.doesNotMatch(s,/console\.log\([^\n]*overview\s*\)/);
+ assert.match(s,/campaign_counts:overview\.campaign_counts/);
+ assert.match(s,/issue_report:overview\.issue_report/);
+});

--- a/test/meta-issue-report-runner-no-retry.test.js
+++ b/test/meta-issue-report-runner-no-retry.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner performs exactly one collector call and no retry loop',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.equal((s.match(/await collectMetaShadowData\(\)/g)||[]).length,1);
+ assert.doesNotMatch(s,/setTimeout|setInterval|retry/i);
+});

--- a/test/meta-issue-report-runner-output.test.js
+++ b/test/meta-issue-report-runner-output.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner never serializes raw result overview or diagnostics',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.doesNotMatch(s,/JSON\.stringify\(result\)|JSON\.stringify\(overview\)|issue_diagnostics/);
+ assert.match(s,/affected_objects:0,categories:\{\},objects:\[\]/);
+});

--- a/test/meta-issue-report-runner-safety.test.js
+++ b/test/meta-issue-report-runner-safety.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta issue runner delegates only to read collector and emits compact report',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/collectMetaShadowData/); assert.match(s,/campaign_counts/); assert.match(s,/issue_report/);
+ assert.doesNotMatch(s,/axios|fetch\(|\.post\(|\.delete\(|createPaused|WRITE|APPROVAL|BUDGET|META_ACCESS_TOKEN|META_AD_ACCOUNT_ID|issue_diagnostics/);
+ assert.match(s,/if\(!result\.access_ok\)/); assert.match(s,/process\.exitCode=1/); assert.match(s,/slice\(0,180\)/);
+});

--- a/test/meta-issue-report-runner-timestamp.test.js
+++ b/test/meta-issue-report-runner-timestamp.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta report runner includes collector timestamp for evidence freshness',()=>{
+ const s=fs.readFileSync('scripts/run-meta-issue-report.js','utf8');
+ assert.match(s,/collected_at:result\.collected_at/);
+});

--- a/test/meta-issue-report-sanitization.test.js
+++ b/test/meta-issue-report-sanitization.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {sanitizeMetaIssues}=require('../live-shadow-data');
+
+test('Meta issue sanitizer removes line breaks and bounds diagnostic text',()=>{
+ const [x]=sanitizeMetaIssues([{level:'ERROR\nX',error_code:100,error_summary:'a\nb\t'+ 'x'.repeat(300),error_message:'m\rn'+ 'y'.repeat(500)}]);
+ assert.doesNotMatch(x.summary,/\r|\n|\t/); assert.doesNotMatch(x.message,/\r|\n|\t/);
+ assert.ok(x.summary.length<=180); assert.ok(x.message.length<=300);
+});

--- a/test/meta-issue-report-workflow-actions.test.js
+++ b/test/meta-issue-report-workflow-actions.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow uses only standard checkout and setup-node actions',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.deepEqual([...(w.matchAll(/uses:\s*([^\n]+)/g))].map(m=>m[1].trim()),['actions/checkout@v4','actions/setup-node@v4']);
+ assert.match(w,/runs-on: ubuntu-latest/); assert.match(w,/node-version: 20/); assert.match(w,/cache: npm/);
+});

--- a/test/meta-issue-report-workflow-dependency-order.test.js
+++ b/test/meta-issue-report-workflow-dependency-order.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('dependency install completes before Meta credentials are introduced',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.ok(w.indexOf('run: npm ci') < w.indexOf('META_ACCESS_TOKEN'));
+ assert.doesNotMatch(w,/npm install|yarn|pnpm|npx/);
+});

--- a/test/meta-issue-report-workflow-env-allowlist.test.js
+++ b/test/meta-issue-report-workflow-env-allowlist.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic report step environment allowlist is exact',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8'); const r=w.split('- name: Run sanitized read-only Meta issue report')[1];
+ const keys=(r.match(/^\s{10}META_[A-Z_]+:/gm)||[]).map(x=>x.trim().split(':')[0]);
+ assert.deepEqual(keys,['META_ACCESS_TOKEN','META_AD_ACCOUNT_ID','META_API_VERSION']);
+});

--- a/test/meta-issue-report-workflow-no-active.test.js
+++ b/test/meta-issue-report-workflow-no-active.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no activation state or delivery mutation',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/ACTIVE|PAUSED|effective_status|status=/);
+});

--- a/test/meta-issue-report-workflow-no-age-write.test.js
+++ b/test/meta-issue-report-workflow-no-age-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no age or audience targeting controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/age_min|age_max|audience|custom_audience/i);
+});

--- a/test/meta-issue-report-workflow-no-app-id.test.js
+++ b/test/meta-issue-report-workflow-no-app-id.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow needs no Meta app or client identifier',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/META_APP_ID|CLIENT_ID/);
+});

--- a/test/meta-issue-report-workflow-no-approval.test.js
+++ b/test/meta-issue-report-workflow-no-approval.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no approval or one-shot write gate controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/approval|write_gate|one_shot|trigger/i);
+});

--- a/test/meta-issue-report-workflow-no-artifact.test.js
+++ b/test/meta-issue-report-workflow-no-artifact.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic output is not uploaded cached or persisted as an artifact',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/upload-artifact|download-artifact|artifact|save-state|set-output/i);
+});

--- a/test/meta-issue-report-workflow-no-background.test.js
+++ b/test/meta-issue-report-workflow-no-background.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no background daemon or server execution',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/nohup|&\s*$|npm start|node server|serve\b/m);
+});

--- a/test/meta-issue-report-workflow-no-bid-write.test.js
+++ b/test/meta-issue-report-workflow-no-bid-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no bid or spend mutation controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/bid_amount|bid_strategy|spend_cap|budget/i);
+});

--- a/test/meta-issue-report-workflow-no-browser.test.js
+++ b/test/meta-issue-report-workflow-no-browser.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no browser automation path',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/playwright|puppeteer|selenium|browser/i);
+});

--- a/test/meta-issue-report-workflow-no-budget.test.js
+++ b/test/meta-issue-report-workflow-no-budget.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no spend bid or budget controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/budget|bid_amount|spend_cap|daily_budget|lifetime_budget/i);
+});

--- a/test/meta-issue-report-workflow-no-business-secret.test.js
+++ b/test/meta-issue-report-workflow-no-business-secret.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow needs no separate business page or system user identifiers',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/BUSINESS_ID|PAGE_ID|SYSTEM_USER|INSTAGRAM_USER_ID/);
+});

--- a/test/meta-issue-report-workflow-no-cloud.test.js
+++ b/test/meta-issue-report-workflow-no-cloud.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no cloud deployment CLI',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/railway|vercel|netlify|aws|gcloud|azure|terraform/i);
+});

--- a/test/meta-issue-report-workflow-no-concurrency.test.js
+++ b/test/meta-issue-report-workflow-no-concurrency.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no concurrency cancellation configuration',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/concurrency:|cancel-in-progress:/);
+});

--- a/test/meta-issue-report-workflow-no-condition.test.js
+++ b/test/meta-issue-report-workflow-no-condition.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no conditional bypass',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/\bif:/);
+});

--- a/test/meta-issue-report-workflow-no-conversion-write.test.js
+++ b/test/meta-issue-report-workflow-no-conversion-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no conversion event configuration',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/CONVERSION|EVENT_ID|custom_event/i);
+});

--- a/test/meta-issue-report-workflow-no-cookie.test.js
+++ b/test/meta-issue-report-workflow-no-cookie.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow needs no browser cookie session or username credential',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/COOKIE|SESSION|USERNAME|PASSWORD/);
+});

--- a/test/meta-issue-report-workflow-no-creative.test.js
+++ b/test/meta-issue-report-workflow-no-creative.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no creative targeting or CTA controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/creative|targeting|placement|BOOK_NOW|call_to_action|reel/i);
+});

--- a/test/meta-issue-report-workflow-no-cta-write.test.js
+++ b/test/meta-issue-report-workflow-no-cta-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no call-to-action or destination controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/BOOK_NOW|CTA|call_to_action|DESTINATION|RESERVATION_URL/);
+});

--- a/test/meta-issue-report-workflow-no-custom-shell.test.js
+++ b/test/meta-issue-report-workflow-no-custom-shell.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no custom shell or working directory override',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/shell:|working-directory:|defaults:/);
+});

--- a/test/meta-issue-report-workflow-no-database.test.js
+++ b/test/meta-issue-report-workflow-no-database.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no database or migration command',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/database|migration|migrate|prisma|sequelize|knex|psql/i);
+});

--- a/test/meta-issue-report-workflow-no-deploy.test.js
+++ b/test/meta-issue-report-workflow-no-deploy.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no deployment publication or release path',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/deploy|release|publish|environment:|pages/i);
+});

--- a/test/meta-issue-report-workflow-no-dispatch-input.test.js
+++ b/test/meta-issue-report-workflow-no-dispatch-input.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic manual trigger accepts no user-controlled inputs',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8'); const on=w.split('on:')[1].split('jobs:')[0];
+ assert.match(on,/workflow_dispatch:/); assert.doesNotMatch(on,/inputs:/);
+});

--- a/test/meta-issue-report-workflow-no-dsa-write.test.js
+++ b/test/meta-issue-report-workflow-no-dsa-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no beneficiary payor or DSA write controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/beneficiary|payor|DSA/i);
+});

--- a/test/meta-issue-report-workflow-no-env-write.test.js
+++ b/test/meta-issue-report-workflow-no-env-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow does not persist secrets through runner command files',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/GITHUB_ENV|GITHUB_OUTPUT|GITHUB_STATE|GITHUB_PATH|GITHUB_STEP_SUMMARY/);
+});

--- a/test/meta-issue-report-workflow-no-eval.test.js
+++ b/test/meta-issue-report-workflow-no-eval.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no dynamic eval or command substitution',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/node\s+-e|eval\s|\$\(|`/);
+});

--- a/test/meta-issue-report-workflow-no-external-ref.test.js
+++ b/test/meta-issue-report-workflow-no-external-ref.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic checkout has no alternate repository or ref selection',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/repository:|ref:|submodules:|lfs:/);
+});

--- a/test/meta-issue-report-workflow-no-file-dump.test.js
+++ b/test/meta-issue-report-workflow-no-file-dump.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no file or environment dump commands',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/run:\s*(cat|head|tail|grep|env|printenv|find|ls)\b/);
+});

--- a/test/meta-issue-report-workflow-no-fork.test.js
+++ b/test/meta-issue-report-workflow-no-fork.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot select another repository or ref for checkout',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const checkout=w.split('actions/checkout@v4')[1].split('- uses: actions/setup-node@v4')[0];
+ assert.doesNotMatch(checkout,/with:|repository:|ref:/);
+});

--- a/test/meta-issue-report-workflow-no-geo-write.test.js
+++ b/test/meta-issue-report-workflow-no-geo-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no geographic targeting controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/latitude|longitude|radius|geo_locations|country|city/i);
+});

--- a/test/meta-issue-report-workflow-no-git-command.test.js
+++ b/test/meta-issue-report-workflow-no-git-command.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no direct git or GitHub CLI commands',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/run:\s*(git|gh)\b/);
+});

--- a/test/meta-issue-report-workflow-no-google-secret.test.js
+++ b/test/meta-issue-report-workflow-no-google-secret.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow uses no Google Ads or GA4 credentials',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/GOOGLE_|GA4_/);
+});

--- a/test/meta-issue-report-workflow-no-hidden-inputs.test.js
+++ b/test/meta-issue-report-workflow-no-hidden-inputs.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no hidden vars event interpolation or checkout override',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/vars\.|inputs\.|github\.event|repository:|ref:|submodules:|lfs:|persist-credentials:/);
+});

--- a/test/meta-issue-report-workflow-no-infra-secret.test.js
+++ b/test/meta-issue-report-workflow-no-infra-secret.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow uses no infrastructure or database credentials',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/RAILWAY_|DATABASE_|AWS_|AZURE_|GCLOUD_/);
+});

--- a/test/meta-issue-report-workflow-no-install-override.test.js
+++ b/test/meta-issue-report-workflow-no-install-override.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic dependency installation has no force or alternate resolver flags',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.match(w,/run: npm ci/);
+ assert.doesNotMatch(w,/--force|--legacy-peer-deps|npm install|npx|yarn|pnpm/);
+});

--- a/test/meta-issue-report-workflow-no-lifetime-write.test.js
+++ b/test/meta-issue-report-workflow-no-lifetime-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no lifetime or daily budget controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/LIFETIME_BUDGET|DAILY_BUDGET/);
+});

--- a/test/meta-issue-report-workflow-no-mask-manipulation.test.js
+++ b/test/meta-issue-report-workflow-no-mask-manipulation.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow does not manipulate GitHub runner command masking',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/add-mask|stop-commands|set-output|save-state/);
+});

--- a/test/meta-issue-report-workflow-no-meta-object-input.test.js
+++ b/test/meta-issue-report-workflow-no-meta-object-input.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no campaign adset ad or media object selection input',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/CAMPAIGN_ID|ADSET_ID|AD_ID|MEDIA_ID|PAGE_ID|INSTAGRAM_USER_ID/);
+});

--- a/test/meta-issue-report-workflow-no-meta-post.test.js
+++ b/test/meta-issue-report-workflow-no-meta-post.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no HTTP mutation command or write endpoint',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/POST|PUT|PATCH|DELETE|\/campaigns\b|\/adsets\b|\/ads\b/);
+});

--- a/test/meta-issue-report-workflow-no-multijob.test.js
+++ b/test/meta-issue-report-workflow-no-multijob.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no upstream downstream or matrix execution graph',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/needs:|strategy:|matrix:|max-parallel:|fail-fast:/);
+});

--- a/test/meta-issue-report-workflow-no-name-write.test.js
+++ b/test/meta-issue-report-workflow-no-name-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no campaign adset or ad naming controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/CAMPAIGN_NAME|ADSET_NAME|AD_NAME/);
+});

--- a/test/meta-issue-report-workflow-no-network-tool.test.js
+++ b/test/meta-issue-report-workflow-no-network-tool.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no curl wget or direct HTTP command',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/\bcurl\b|\bwget\b|https?:\/\//i);
+});

--- a/test/meta-issue-report-workflow-no-objective-write.test.js
+++ b/test/meta-issue-report-workflow-no-objective-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no objective optimization or billing write controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/objective|optimization_goal|billing_event/i);
+});

--- a/test/meta-issue-report-workflow-no-other-secrets.test.js
+++ b/test/meta-issue-report-workflow-no-other-secrets.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow references no Google GA4 TikTok or infrastructure secrets',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/GOOGLE_|GA4_|TIKTOK_|RAILWAY_|DATABASE_|API_KEY/);
+});

--- a/test/meta-issue-report-workflow-no-output.test.js
+++ b/test/meta-issue-report-workflow-no-output.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow exports no job or step outputs',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/outputs:|GITHUB_OUTPUT/);
+});

--- a/test/meta-issue-report-workflow-no-package-publish.test.js
+++ b/test/meta-issue-report-workflow-no-package-publish.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot publish packages or releases',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/npm publish|package|release|registry/i);
+});

--- a/test/meta-issue-report-workflow-no-page-token.test.js
+++ b/test/meta-issue-report-workflow-no-page-token.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no separate Page or Instagram access token',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/PAGE_ACCESS_TOKEN|INSTAGRAM_ACCESS_TOKEN/);
+});

--- a/test/meta-issue-report-workflow-no-page-write.test.js
+++ b/test/meta-issue-report-workflow-no-page-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no Page Instagram or media selection controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/PAGE_ID|INSTAGRAM_USER_ID|MEDIA_ID|INSTAGRAM_MEDIA_ID/);
+});

--- a/test/meta-issue-report-workflow-no-persistence.test.js
+++ b/test/meta-issue-report-workflow-no-persistence.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no output persistence or repository mutation path',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/upload-artifact|GITHUB_(ENV|OUTPUT|PATH|STATE|STEP_SUMMARY)|git push|gh pr|deploy|release/i);
+ assert.doesNotMatch(w,/strategy:|matrix:|needs:|\bif:/);
+});

--- a/test/meta-issue-report-workflow-no-pixel-write.test.js
+++ b/test/meta-issue-report-workflow-no-pixel-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no pixel event or tracking configuration',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/PIXEL|EVENT_ID|TRACKING|UTM/);
+});

--- a/test/meta-issue-report-workflow-no-pr-trigger.test.js
+++ b/test/meta-issue-report-workflow-no-pr-trigger.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot run automatically on pull request code',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/pull_request|pull_request_target/);
+});

--- a/test/meta-issue-report-workflow-no-promoted-write.test.js
+++ b/test/meta-issue-report-workflow-no-promoted-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no promoted object configuration',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/promoted_object/i);
+});

--- a/test/meta-issue-report-workflow-no-push-trigger.test.js
+++ b/test/meta-issue-report-workflow-no-push-trigger.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot run automatically on repository push',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/\bpush:/);
+});

--- a/test/meta-issue-report-workflow-no-refresh-token.test.js
+++ b/test/meta-issue-report-workflow-no-refresh-token.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow needs no OAuth refresh token',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/REFRESH_TOKEN/);
+});

--- a/test/meta-issue-report-workflow-no-remote-trigger.test.js
+++ b/test/meta-issue-report-workflow-no-remote-trigger.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no remote reusable or event-driven trigger',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/workflow_call|repository_dispatch|workflow_run|issue_comment|pull_request|push:|schedule:/);
+});

--- a/test/meta-issue-report-workflow-no-reusable.test.js
+++ b/test/meta-issue-report-workflow-no-reusable.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow is not exposed as reusable workflow',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/workflow_call/);
+});

--- a/test/meta-issue-report-workflow-no-runtime-expansion.test.js
+++ b/test/meta-issue-report-workflow-no-runtime-expansion.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no alternate runtime container or self-hosted runner',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/python|ruby|java|docker|container:|services:|self-hosted|windows-|macos-/i);
+});

--- a/test/meta-issue-report-workflow-no-schedule-trigger.test.js
+++ b/test/meta-issue-report-workflow-no-schedule-trigger.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot run automatically on schedule',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/\bschedule:/);
+});

--- a/test/meta-issue-report-workflow-no-schedule.test.js
+++ b/test/meta-issue-report-workflow-no-schedule.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no campaign scheduling controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/start_time|end_time|duration|ad_schedule/i);
+});

--- a/test/meta-issue-report-workflow-no-secret-echo.test.js
+++ b/test/meta-issue-report-workflow-no-secret-echo.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow does not echo or print secret environment values',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/echo\s+\$|printenv|run:\s*env\b/);
+});

--- a/test/meta-issue-report-workflow-no-server.test.js
+++ b/test/meta-issue-report-workflow-no-server.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow does not boot application server or general npm scripts',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/npm start|npm run|node server|node index|node app/i);
+});

--- a/test/meta-issue-report-workflow-no-service.test.js
+++ b/test/meta-issue-report-workflow-no-service.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow declares no service containers or databases',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/services:|container:|postgres|redis|mysql|mongodb/i);
+});

--- a/test/meta-issue-report-workflow-no-shell-chain.test.js
+++ b/test/meta-issue-report-workflow-no-shell-chain.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no chained redirected or multiline shell',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/&&|\|\||>>|run:\s*\||\$\(|`|shell:/);
+});

--- a/test/meta-issue-report-workflow-no-shell-script.test.js
+++ b/test/meta-issue-report-workflow-no-shell-script.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow invokes no external shell scripts',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/\.sh\b|bash\s|sh\s+-c|pwsh|powershell/i);
+});

--- a/test/meta-issue-report-workflow-no-special-category-write.test.js
+++ b/test/meta-issue-report-workflow-no-special-category-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no special ad category controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/special_ad_categories/i);
+});

--- a/test/meta-issue-report-workflow-no-status-write.test.js
+++ b/test/meta-issue-report-workflow-no-status-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no delivery status mutation values',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/PAUSED|ACTIVE|status=|effective_status=/);
+});

--- a/test/meta-issue-report-workflow-no-submodule.test.js
+++ b/test/meta-issue-report-workflow-no-submodule.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot fetch submodules or LFS payloads',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/submodules:|lfs:/);
+});

--- a/test/meta-issue-report-workflow-no-system-user.test.js
+++ b/test/meta-issue-report-workflow-no-system-user.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow needs no system user identifier',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/SYSTEM_USER_ID/);
+});

--- a/test/meta-issue-report-workflow-no-test-with-secrets.test.js
+++ b/test/meta-issue-report-workflow-no-test-with-secrets.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow does not run tests after secrets are introduced',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const report=w.split('- name: Run sanitized read-only Meta issue report')[1];
+ assert.doesNotMatch(report,/npm test|node --test/);
+});

--- a/test/meta-issue-report-workflow-no-thirdparty-action.test.js
+++ b/test/meta-issue-report-workflow-no-thirdparty-action.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow invokes no third-party GitHub actions',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const actions=[...(w.matchAll(/uses:\s*([^\n]+)/g))].map(m=>m[1].trim());
+ assert.ok(actions.every(x=>x.startsWith('actions/')));
+});

--- a/test/meta-issue-report-workflow-no-tiktok-secret.test.js
+++ b/test/meta-issue-report-workflow-no-tiktok-secret.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow uses no TikTok credentials',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/TIKTOK_/);
+});

--- a/test/meta-issue-report-workflow-no-timeout-bypass.test.js
+++ b/test/meta-issue-report-workflow-no-timeout-bypass.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no continue-on-error or timeout customization',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/continue-on-error|timeout-minutes:/);
+});

--- a/test/meta-issue-report-workflow-no-token-permission.test.js
+++ b/test/meta-issue-report-workflow-no-token-permission.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow cannot escalate GitHub token permissions',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/GITHUB_TOKEN|GH_TOKEN|permissions:/);
+});

--- a/test/meta-issue-report-workflow-no-tracking-write.test.js
+++ b/test/meta-issue-report-workflow-no-tracking-write.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no tracking conversion or pixel write controls',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/pixel|tracking|conversion|promoted_object|utm/i);
+});

--- a/test/meta-issue-report-workflow-no-user-input.test.js
+++ b/test/meta-issue-report-workflow-no-user-input.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow has no user-controlled workflow parameters',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/inputs:|github\.event|github\.event_name|github\.event\.inputs/);
+});

--- a/test/meta-issue-report-workflow-no-webhook.test.js
+++ b/test/meta-issue-report-workflow-no-webhook.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no webhook or notification integration',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/webhook|slack|discord|email|smtp/i);
+});

--- a/test/meta-issue-report-workflow-no-write-action.test.js
+++ b/test/meta-issue-report-workflow-no-write-action.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no commit PR issue or deployment action',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/create-pull-request|commit|push|issue|deploy|publish/i);
+});

--- a/test/meta-issue-report-workflow-no-write-inputs.test.js
+++ b/test/meta-issue-report-workflow-no-write-inputs.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow contains no campaign mutation inputs',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.doesNotMatch(w,/WRITE|APPROVAL|BUDGET|CAMPAIGN_NAME|ADSET_NAME|AD_NAME|TARGET|PLACEMENT|CTA|OBJECTIVE|START_TIME|END_TIME/);
+});

--- a/test/meta-issue-report-workflow-one-run.test.js
+++ b/test/meta-issue-report-workflow-one-run.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic runner is invoked exactly once per workflow dispatch',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.equal((w.match(/run-meta-issue-report\.js/g)||[]).length,1);
+});

--- a/test/meta-issue-report-workflow-report-only.test.js
+++ b/test/meta-issue-report-workflow-report-only.test.js
@@ -1,0 +1,9 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta workflow has exactly one application Node invocation and it is diagnostic',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const nodeRuns=[...(w.matchAll(/run:\s*(node[^\n]+)/g))].map(m=>m[1].trim());
+ assert.deepEqual(nodeRuns,['node scripts/run-meta-issue-report.js']);
+});

--- a/test/meta-issue-report-workflow-safety.test.js
+++ b/test/meta-issue-report-workflow-safety.test.js
@@ -1,0 +1,12 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta issue workflow is manual read-only minimal and secret-scoped',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const on=w.split('on:')[1].split('jobs:')[0];
+ assert.match(on,/workflow_dispatch:/); assert.doesNotMatch(on,/push:|pull_request:|schedule:|repository_dispatch:/);
+ assert.deepEqual([...(w.matchAll(/secrets\.([A-Z0-9_]+)/g))].map(m=>m[1]),['META_ACCESS_TOKEN','META_AD_ACCOUNT_ID','META_API_VERSION']);
+ assert.doesNotMatch(w,/WRITE_GATE|APPROVAL|BUDGET|ACTIVE|upload-artifact|GITHUB_OUTPUT|GITHUB_STEP_SUMMARY|permissions:/);
+ assert.deepEqual([...(w.matchAll(/^\s+-?\s*run:\s*(.+)$/gm))].map(m=>m[1].trim()),['npm ci','node scripts/run-meta-issue-report.js']);
+});

--- a/test/meta-issue-report-workflow-secret-count.test.js
+++ b/test/meta-issue-report-workflow-secret-count.test.js
@@ -1,0 +1,8 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow references exactly three repository secrets',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ assert.equal((w.match(/\$\{\{ secrets\./g)||[]).length,3);
+});

--- a/test/meta-issue-report-workflow-secret-scope.test.js
+++ b/test/meta-issue-report-workflow-secret-scope.test.js
@@ -1,0 +1,11 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta secrets are introduced only at dedicated diagnostic step',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8');
+ const marker='- name: Run sanitized read-only Meta issue report';
+ const before=w.split(marker)[0]; const after=w.split(marker)[1];
+ assert.doesNotMatch(before,/META_ACCESS_TOKEN|META_AD_ACCOUNT_ID|META_API_VERSION/);
+ assert.match(after,/META_ACCESS_TOKEN/); assert.match(after,/META_AD_ACCOUNT_ID/); assert.match(after,/META_API_VERSION/);
+});

--- a/test/meta-issue-report-workflow-step-contract.test.js
+++ b/test/meta-issue-report-workflow-step-contract.test.js
@@ -1,0 +1,10 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const fs=require('node:fs');
+
+test('Meta diagnostic workflow remains one job with four steps',()=>{
+ const w=fs.readFileSync('.github/workflows/meta-issue-report.yml','utf8'); const jobs=w.split('jobs:')[1];
+ assert.equal((jobs.match(/^  [a-zA-Z_-]+:\s*$/gm)||[]).length,1);
+ assert.equal((w.match(/^\s{6}- /gm)||[]).length,4);
+ assert.equal((w.match(/\brun:/g)||[]).length,2); assert.equal((w.match(/\buses:/g)||[]).length,2);
+});


### PR DESCRIPTION
Clean replacement for the abandoned oversized PR #95. This PR adds only the dedicated Meta issue-report runner, a manual workflow_dispatch workflow, and focused safety/contract tests. It relies on the existing main-branch collector, which already requests issues_info for campaigns/adsets/ads and builds issue_report. No campaign write path, budget control, activation, scheduling, deployment, artifact persistence, or write gate is introduced.