### PR TITLE
Add minimal read-only Meta issue report workflow

### DIFF
--- a/.github/workflows/meta-issue-report.yml
+++ b/.github/workflows/meta-issue-report.yml
@@ -1,0 +1,19 @@
+name: meta-issue-report
+on:
+  workflow_dispatch:
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run sanitized read-only Meta issue report
+        env:
+          META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
+          META_AD_ACCOUNT_ID: ${{ secrets.META_AD_ACCOUNT_ID }}
+          META_API_VERSION: ${{ secrets.META_API_VERSION }}
+        run: node scripts/run-meta-issue-report.js

--- a/scripts/run-meta-issue-report.js
+++ b/scripts/run-meta-issue-report.js
@@ -1,0 +1,21 @@
+require('dotenv').config();
+const { collectMetaShadowData } = require('../live-shadow-data');
+
+(async () => {
+  const result = await collectMetaShadowData();
+  if (!result.access_ok) {
+    console.error(JSON.stringify({ access_ok: false, error: result.error || 'meta_read_failed' }));
+    process.exitCode = 1;
+    return;
+  }
+  const overview = result.overview || {};
+  console.log(JSON.stringify({
+    access_ok: true,
+    collected_at: result.collected_at,
+    campaign_counts: overview.campaign_counts || {},
+    issue_report: overview.issue_report || { affected_objects: 0, categories: {}, objects: [] },
+  }, null, 2));
+})().catch((error) => {
+  console.error(JSON.stringify({ access_ok: false, error: String(error?.message || 'meta_issue_report_failed').slice(0, 180) }));
+  process.exitCode = 1;
+});

--- a/test/meta-issue-report-live-contract.test.js
+++ b/test/meta-issue-report-live-contract.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('live Meta issue path requests all delivery levels and remains GET-only', () => {
+  const source = fs.readFileSync('live-shadow-data.js', 'utf8');
+  const meta = source.split('async function collectMetaShadowData')[1].split('async function collectLiveShadowInput')[0];
+  assert.match(meta, /campaigns[^\n]+issues_info/);
+  assert.match(meta, /adsets[^\n]+issues_info/);
+  assert.match(meta, /ads[^\n]+issues_info/);
+  assert.match(meta, /buildMetaIssueReport/);
+  assert.match(meta, /client\.get/);
+  assert.doesNotMatch(meta, /client\.(post|put|patch|delete)/);
+});

--- a/test/meta-issue-report-runner.test.js
+++ b/test/meta-issue-report-runner.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('Meta issue runner delegates to read collector and emits compact output', () => {
+  const source = fs.readFileSync('scripts/run-meta-issue-report.js', 'utf8');
+  assert.match(source, /collectMetaShadowData/);
+  assert.match(source, /campaign_counts/);
+  assert.match(source, /issue_report/);
+  assert.doesNotMatch(source, /axios|fetch\(|\.post\(|\.delete\(|createPaused|WRITE|APPROVAL|BUDGET|META_ACCESS_TOKEN|META_AD_ACCOUNT_ID|issue_diagnostics/);
+  assert.match(source, /process\.exitCode = 1/);
+});

--- a/test/meta-issue-report-workflow.test.js
+++ b/test/meta-issue-report-workflow.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('Meta issue workflow is manual and read-only', () => {
+  const workflow = fs.readFileSync('.github/workflows/meta-issue-report.yml', 'utf8');
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /push:|pull_request:|schedule:|repository_dispatch:/);
+  assert.deepEqual([...workflow.matchAll(/secrets\.([A-Z0-9_]+)/g)].map(m => m[1]), ['META_ACCESS_TOKEN','META_AD_ACCOUNT_ID','META_API_VERSION']);
+  assert.doesNotMatch(workflow, /WRITE_GATE|APPROVAL|BUDGET|ACTIVE|PAUSED|upload-artifact|GITHUB_OUTPUT|GITHUB_STEP_SUMMARY|permissions:/);
+  assert.deepEqual([...workflow.matchAll(/^\s+-?\s*run:\s*(.+)$/gm)].map(m => m[1].trim()), ['npm ci','node scripts/run-meta-issue-report.js']);
+});


### PR DESCRIPTION
Minimal clean replacement for abandoned oversized PRs. Adds exactly: a dedicated Meta issue-report runner, a manual workflow_dispatch workflow, and three focused safety/contract tests. Reuses the existing main-branch collector, which already requests issues_info for campaigns/adsets/ads and builds issue_report. No write gate, activation, budget, scheduling, creative mutation, deployment, artifact persistence, or campaign write path.