### PR TITLE
Restore Meta issue-report CI contracts

### DIFF
--- a/.github/workflows/meta-issue-report.yml
+++ b/.github/workflows/meta-issue-report.yml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Install production dependencies reproducibly
+        run: npm ci --ignore-scripts
       - name: Run sanitized read-only Meta issue report
         env:
           META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}

--- a/scripts/run-meta-issue-report.js
+++ b/scripts/run-meta-issue-report.js
@@ -1,65 +1,28 @@
-const token = process.env.META_ACCESS_TOKEN;
-const rawAccount = String(process.env.META_AD_ACCOUNT_ID || '');
-const account = rawAccount.startsWith('act_') ? rawAccount : `act_${rawAccount}`;
-const candidateVersion = String(process.env.META_API_VERSION || 'v19.0');
-const version = /^v\d+\.0$/.test(candidateVersion) ? candidateVersion : 'v19.0';
-
-function clean(value, max) {
-  return String(value || '').replace(/[\r\n\t]+/g, ' ').slice(0, max);
-}
-function issues(items) {
-  return (Array.isArray(items) ? items : []).slice(0, 20).map(x => ({
-    level: clean(x.level, 40),
-    code: x.error_code ?? null,
-    summary: clean(x.error_summary || 'meta_delivery_issue', 180),
-    message: clean(x.error_message, 300),
-  }));
-}
-async function getCollection(path, fields) {
-  const url = new URL(`https://graph.facebook.com/${version}/${path}`);
-  url.searchParams.set('fields', fields);
-  url.searchParams.set('limit', '100');
-  url.searchParams.set('access_token', token);
-  const response = await fetch(url, { method: 'GET' });
-  const body = await response.json();
-  if (!response.ok || body.error) throw new Error(clean(body?.error?.message || `meta_http_${response.status}`, 180));
-  return body.data || [];
-}
+const { collectMetaShadowData } = require("../live-shadow-data");
 
 (async () => {
-  if (!token || !rawAccount) throw new Error('meta_configuration_incomplete');
-  const [campaigns, adsets, ads] = await Promise.all([
-    getCollection(`${account}/campaigns`, 'id,name,status,effective_status,issues_info'),
-    getCollection(`${account}/adsets`, 'id,name,campaign_id,status,effective_status,issues_info'),
-    getCollection(`${account}/ads`, 'id,name,adset_id,campaign_id,status,effective_status,issues_info'),
-  ]);
-  const rows = [
-    ...campaigns.map(x => ({ type: 'campaign', ...x })),
-    ...adsets.map(x => ({ type: 'adset', ...x })),
-    ...ads.map(x => ({ type: 'ad', ...x })),
-  ].filter(x => x.effective_status === 'WITH_ISSUES' || (Array.isArray(x.issues_info) && x.issues_info.length));
-  const objects = rows.map(x => ({
-    type: x.type,
-    id: String(x.id || ''),
-    name: clean(x.name, 120),
-    campaign_id: x.campaign_id ? String(x.campaign_id) : null,
-    adset_id: x.adset_id ? String(x.adset_id) : null,
-    status: clean(x.status, 40),
-    effective_status: clean(x.effective_status, 40),
-    issues: issues(x.issues_info),
-  }));
-  const categories = {};
-  for (const object of objects) for (const issue of object.issues) {
-    const key = issue.summary || 'meta_delivery_issue';
-    categories[key] = (categories[key] || 0) + 1;
+  const result = await collectMetaShadowData();
+  if (!result.access_ok) {
+    throw new Error(String(result.error || "meta_issue_report_failed").slice(0, 180));
   }
+
+  const overview = result.overview || {};
+  const issueReport = overview.issue_report || {};
   console.log(JSON.stringify({
     access_ok: true,
-    collected_at: new Date().toISOString(),
-    campaign_counts: { total: campaigns.length, with_issues: campaigns.filter(x => x.effective_status === 'WITH_ISSUES').length },
-    issue_report: { affected_objects: objects.length, categories, objects },
+    collected_at: result.collected_at || new Date().toISOString(),
+    campaign_counts: overview.campaign_counts || {},
+    issue_report: {
+      affected_objects: Number(issueReport.affected_objects || 0),
+      categories: issueReport.categories || {},
+    },
+    writes_allowed: false,
   }, null, 2));
-})().catch(error => {
-  console.error(JSON.stringify({ access_ok: false, error: clean(error?.message || 'meta_issue_report_failed', 180) }));
+})().catch((error) => {
+  console.error(JSON.stringify({
+    access_ok: false,
+    error: String(error?.message || "meta_issue_report_failed").replace(/[\r\n\t]+/g, " ").slice(0, 180),
+    writes_allowed: false,
+  }));
   process.exitCode = 1;
 });


### PR DESCRIPTION
Fixes the two repository-wide CI regressions exposed by PR #103 without weakening any safety test. The Meta issue runner again delegates to the shared GET-only `collectMetaShadowData` collector and emits only compact sanitized counts/categories; the manual workflow restores reproducible `npm ci --ignore-scripts` before execution. No Meta mutation, write gate, activation, budget or spend change.