### PR TITLE
Add sanitized read-only Meta draft inventory

### DIFF
--- a/.github/workflows/meta-draft-inventory.yml
+++ b/.github/workflows/meta-draft-inventory.yml
@@ -1,0 +1,19 @@
+name: meta-draft-inventory
+on:
+  workflow_dispatch:
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies reproducibly
+        run: npm ci --ignore-scripts
+      - name: Inspect recent paused Meta draft objects read-only
+        env:
+          META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
+          META_AD_ACCOUNT_ID: ${{ secrets.META_AD_ACCOUNT_ID }}
+          META_API_VERSION: ${{ secrets.META_API_VERSION }}
+        run: node scripts/run-meta-draft-inventory.js

--- a/scripts/run-meta-draft-inventory.js
+++ b/scripts/run-meta-draft-inventory.js
@@ -1,0 +1,80 @@
+const { META_API_VERSION } = require("../meta-paused-draft-next");
+const { assertPublicPayloadSafe } = require("../public-output-safety");
+
+const token = process.env.META_ACCESS_TOKEN;
+const rawAccount = String(process.env.META_AD_ACCOUNT_ID || "");
+const account = rawAccount.startsWith("act_") ? rawAccount : `act_${rawAccount}`;
+const candidateVersion = String(process.env.META_API_VERSION || META_API_VERSION);
+const version = /^v\d+\.0$/.test(candidateVersion) ? candidateVersion : META_API_VERSION;
+const createdSince = Date.parse("2026-08-20T00:00:00Z");
+
+function clean(value, max = 120) {
+  return String(value || "").replace(/[\r\n\t]+/g, " ").slice(0, max);
+}
+
+async function getCollection(path, fields) {
+  let url = new URL(`https://graph.facebook.com/${version}/${path}`);
+  url.searchParams.set("fields", fields);
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("access_token", token);
+  const items = [];
+
+  while (url) {
+    const response = await fetch(url, { method: "GET" });
+    const body = await response.json();
+    if (!response.ok || body.error) {
+      throw new Error(clean(body?.error?.message || `meta_http_${response.status}`, 180));
+    }
+    items.push(...(body.data || []));
+    url = body.paging?.next ? new URL(body.paging.next) : null;
+  }
+  return items;
+}
+
+function isActive(item) {
+  return item?.status === "ACTIVE" || item?.effective_status === "ACTIVE";
+}
+
+(async () => {
+  if (!token || !rawAccount) throw new Error("meta_configuration_incomplete");
+
+  const [campaigns, adsets, ads] = await Promise.all([
+    getCollection(`${account}/campaigns`, "id,name,status,effective_status,created_time"),
+    getCollection(`${account}/adsets`, "id,campaign_id,status,effective_status"),
+    getCollection(`${account}/ads`, "campaign_id,adset_id,status,effective_status"),
+  ]);
+
+  const candidates = campaigns.filter((campaign) =>
+    campaign.status === "PAUSED" && Date.parse(campaign.created_time || 0) >= createdSince
+  );
+
+  const summaries = candidates.map((campaign) => {
+    const childAdsets = adsets.filter((adset) => String(adset.campaign_id) === String(campaign.id));
+    const childAds = ads.filter((ad) => String(ad.campaign_id) === String(campaign.id));
+    return {
+      name: clean(campaign.name),
+      configured_status: clean(campaign.status, 40),
+      effective_status: clean(campaign.effective_status, 40),
+      child_adsets: childAdsets.length,
+      child_ads: childAds.length,
+      any_active_child: childAdsets.some(isActive) || childAds.some(isActive),
+    };
+  });
+
+  const payload = assertPublicPayloadSafe({
+    access_ok: true,
+    candidate_count: summaries.length,
+    any_active_objects: summaries.some((item) => item.any_active_child),
+    candidates: summaries,
+    writes_allowed: false,
+  });
+
+  console.log(JSON.stringify(payload, null, 2));
+})().catch((error) => {
+  console.error(JSON.stringify({
+    access_ok: false,
+    error: clean(error?.message || "meta_inventory_failed", 180),
+    writes_allowed: false,
+  }));
+  process.exitCode = 1;
+});

--- a/test/meta-draft-inventory.test.js
+++ b/test/meta-draft-inventory.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+test("Meta draft inventory is manual, GET-only and sanitized", () => {
+  const script = fs.readFileSync("scripts/run-meta-draft-inventory.js", "utf8");
+  const workflow = fs.readFileSync(".github/workflows/meta-draft-inventory.yml", "utf8");
+
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /push:|pull_request:|schedule:|repository_dispatch:/);
+  assert.match(workflow, /npm ci --ignore-scripts/);
+  assert.match(workflow, /node scripts\/run-meta-draft-inventory\.js/);
+
+  assert.match(script, /method:\s*"GET"/);
+  assert.match(script, /assertPublicPayloadSafe/);
+  assert.match(script, /writes_allowed:\s*false/);
+  assert.doesNotMatch(script, /\.post\(|\.delete\(|ACTIVE\s*[:=]\s*true|createPaused|write_gate|approval_token/i);
+  assert.doesNotMatch(script, /targeting|creative\{/i);
+  assert.doesNotMatch(script, /campaign_id\s*:/i);
+  assert.doesNotMatch(script, /adset_id\s*:/i);
+  assert.doesNotMatch(script, /ad_id\s*:/i);
+});


### PR DESCRIPTION
Superseded by PR #107. The original sanitized branch was created before the unsanitized inventory reached main and is now stale/conflictual. #107 applies the same stricter sanitized GET-only design directly on the current main baseline.