### PR TITLE
Auto-detect Railway volume for durable Shadow history

### DIFF
--- a/shadow-history-store.js
+++ b/shadow-history-store.js
@@ -1,11 +1,128 @@
-const fs=require('node:fs');const path=require('node:path');const DEFAULT_MAX_RECORDS=90;
-function safeCode(value,fallback=null){if(value==null)return fallback;return String(value).replace(/[^A-Za-z0-9_.:-]/g,'_').slice(0,80)||fallback;}
-function historyPath(env=process.env){return env.SHADOW_HISTORY_PATH||'/tmp/parma-shadow-history.json';}
-function historyStorageStatus(env=process.env){const configured=Boolean(env.SHADOW_HISTORY_PATH),filePath=historyPath(env),ephemeral=!configured||filePath.startsWith('/tmp/');return{configured,path_class:ephemeral?'ephemeral':'durable_candidate',durable:configured&&!ephemeral,writes_allowed:false};}
-function loadHistory(filePath=historyPath()){try{const parsed=JSON.parse(fs.readFileSync(filePath,'utf8'));return Array.isArray(parsed)?parsed:[];}catch{return[];}}
-function saveHistory(records=[],filePath=historyPath(),{maxRecords=DEFAULT_MAX_RECORDS}={}){const bounded=records.slice(-maxRecords);fs.mkdirSync(path.dirname(filePath),{recursive:true});const tmp=`${filePath}.tmp`;fs.writeFileSync(tmp,`${JSON.stringify(bounded)}\n`,{mode:0o600});fs.renameSync(tmp,filePath);return bounded;}
-function buildSanitizedHistoryRecord({snapshot={},report={},generatedAt=new Date().toISOString()}={}){const priorities=(report.daily_manager?.primary_priorities||[]).slice(0,3),anomalies=(report.anomalies||[]).slice(0,10),events=Array.isArray(snapshot.live_sources?.ga4?.funnel?.event_names)?snapshot.live_sources.ga4.funnel.event_names:[];return{id:generatedAt,generated_at:generatedAt,data_quality:safeCode(snapshot.data_quality?.confidence,'unknown'),attribution_confidence:safeCode(report.conversion_integrity?.confidence,'unknown'),conversion_integrity:safeCode(report.conversion_integrity?.status,'unknown'),source_health:{google:snapshot.live_sources?.google?.access_ok===true,ga4:snapshot.live_sources?.ga4?.access_ok===true,meta:snapshot.live_sources?.meta?.access_ok===true},tracking:{reservation_start:events.includes('reservation_start')},priority_codes:priorities.map(p=>safeCode(p.code,'unknown')),anomaly_codes:anomalies.map(a=>safeCode(a.code,'unknown')),safety_violation:false,outcome:null,expected_direction:null};}
-function appendHistoryRecord(records=[],record,{maxRecords=DEFAULT_MAX_RECORDS}={}){if(!record?.generated_at)return records.slice(-maxRecords);return[...records.filter(r=>r.generated_at!==record.generated_at),record].slice(-maxRecords);}
-function appendAndPersist({records=[],record,filePath=historyPath(),maxRecords=DEFAULT_MAX_RECORDS}={}){return saveHistory(appendHistoryRecord(records,record,{maxRecords}),filePath,{maxRecords});}
-function publicHistorySummary(records=[],storage={}){const healthy=s=>records.filter(r=>r.source_health?.[s]===true).length;return{total_runs:records.length,high_data_quality_runs:records.filter(r=>r.data_quality==='high').length,source_healthy_runs:{google:healthy('google'),ga4:healthy('ga4'),meta:healthy('meta')},reservation_start_tracked_runs:records.filter(r=>r.tracking?.reservation_start===true).length,storage:{durable:storage.durable===true,path_class:storage.path_class||'unknown'},writes_allowed:false};}
-module.exports={DEFAULT_MAX_RECORDS,safeCode,historyPath,historyStorageStatus,loadHistory,saveHistory,buildSanitizedHistoryRecord,appendHistoryRecord,appendAndPersist,publicHistorySummary};
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_MAX_RECORDS = 90;
+const DEFAULT_TMP_HISTORY = "/tmp/parma-shadow-history.json";
+const VOLUME_HISTORY_FILENAME = "parma-shadow-history.json";
+
+function safeCode(value, fallback = null) {
+  if (value == null) return fallback;
+  return String(value).replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 80) || fallback;
+}
+
+function historyPath(env = process.env) {
+  if (env.SHADOW_HISTORY_PATH) return env.SHADOW_HISTORY_PATH;
+  if (env.RAILWAY_VOLUME_MOUNT_PATH) {
+    return path.join(env.RAILWAY_VOLUME_MOUNT_PATH, VOLUME_HISTORY_FILENAME);
+  }
+  return DEFAULT_TMP_HISTORY;
+}
+
+function historyStorageStatus(env = process.env) {
+  const explicitPath = Boolean(env.SHADOW_HISTORY_PATH);
+  const railwayVolume = Boolean(env.RAILWAY_VOLUME_MOUNT_PATH);
+  const filePath = historyPath(env);
+  const ephemeral = filePath.startsWith("/tmp/") || (!explicitPath && !railwayVolume);
+
+  return {
+    configured: explicitPath || railwayVolume,
+    source: explicitPath ? "explicit_path" : railwayVolume ? "railway_volume" : "default_tmp",
+    path_class: ephemeral ? "ephemeral" : "durable_candidate",
+    durable: !ephemeral && (explicitPath || railwayVolume),
+    writes_allowed: false,
+  };
+}
+
+function loadHistory(filePath = historyPath()) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(records = [], filePath = historyPath(), { maxRecords = DEFAULT_MAX_RECORDS } = {}) {
+  const bounded = records.slice(-maxRecords);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(bounded)}\n`, { mode: 0o600 });
+  fs.renameSync(tmp, filePath);
+  return bounded;
+}
+
+function buildSanitizedHistoryRecord({ snapshot = {}, report = {}, generatedAt = new Date().toISOString() } = {}) {
+  const priorities = (report.daily_manager?.primary_priorities || []).slice(0, 3);
+  const anomalies = (report.anomalies || []).slice(0, 10);
+  const events = Array.isArray(snapshot.live_sources?.ga4?.funnel?.event_names)
+    ? snapshot.live_sources.ga4.funnel.event_names
+    : [];
+
+  return {
+    id: generatedAt,
+    generated_at: generatedAt,
+    data_quality: safeCode(snapshot.data_quality?.confidence, "unknown"),
+    attribution_confidence: safeCode(report.conversion_integrity?.confidence, "unknown"),
+    conversion_integrity: safeCode(report.conversion_integrity?.status, "unknown"),
+    source_health: {
+      google: snapshot.live_sources?.google?.access_ok === true,
+      ga4: snapshot.live_sources?.ga4?.access_ok === true,
+      meta: snapshot.live_sources?.meta?.access_ok === true,
+    },
+    tracking: {
+      reservation_start: events.includes("reservation_start"),
+    },
+    priority_codes: priorities.map((priority) => safeCode(priority.code, "unknown")),
+    anomaly_codes: anomalies.map((anomaly) => safeCode(anomaly.code, "unknown")),
+    safety_violation: false,
+    outcome: null,
+    expected_direction: null,
+  };
+}
+
+function appendHistoryRecord(records = [], record, { maxRecords = DEFAULT_MAX_RECORDS } = {}) {
+  if (!record?.generated_at) return records.slice(-maxRecords);
+  return [
+    ...records.filter((existing) => existing.generated_at !== record.generated_at),
+    record,
+  ].slice(-maxRecords);
+}
+
+function appendAndPersist({ records = [], record, filePath = historyPath(), maxRecords = DEFAULT_MAX_RECORDS } = {}) {
+  return saveHistory(appendHistoryRecord(records, record, { maxRecords }), filePath, { maxRecords });
+}
+
+function publicHistorySummary(records = [], storage = {}) {
+  const healthyRuns = (source) => records.filter((record) => record.source_health?.[source] === true).length;
+  return {
+    total_runs: records.length,
+    high_data_quality_runs: records.filter((record) => record.data_quality === "high").length,
+    source_healthy_runs: {
+      google: healthyRuns("google"),
+      ga4: healthyRuns("ga4"),
+      meta: healthyRuns("meta"),
+    },
+    reservation_start_tracked_runs: records.filter((record) => record.tracking?.reservation_start === true).length,
+    storage: {
+      durable: storage.durable === true,
+      path_class: storage.path_class || "unknown",
+      source: storage.source || "unknown",
+    },
+    writes_allowed: false,
+  };
+}
+
+module.exports = {
+  DEFAULT_MAX_RECORDS,
+  DEFAULT_TMP_HISTORY,
+  VOLUME_HISTORY_FILENAME,
+  safeCode,
+  historyPath,
+  historyStorageStatus,
+  loadHistory,
+  saveHistory,
+  buildSanitizedHistoryRecord,
+  appendHistoryRecord,
+  appendAndPersist,
+  publicHistorySummary,
+};

--- a/test/shadow-history-store.test.js
+++ b/test/shadow-history-store.test.js
@@ -1,7 +1,110 @@
-const test=require('node:test');const assert=require('node:assert/strict');const fs=require('node:fs');const os=require('node:os');const path=require('node:path');const {buildSanitizedHistoryRecord,appendHistoryRecord,saveHistory,loadHistory,publicHistorySummary,historyStorageStatus}=require('../shadow-history-store');
-test('history record contains only sanitized health and codes',()=>{const record=buildSanitizedHistoryRecord({snapshot:{data_quality:{confidence:'high'},live_sources:{google:{access_ok:false},ga4:{access_ok:true,funnel:{event_names:['reservation_start','booking_completed']}},meta:{access_ok:true}}},report:{conversion_integrity:{confidence:'high',status:'healthy'},daily_manager:{primary_priorities:[{code:'A 1'}]},anomalies:[{code:'B/2'}]},generatedAt:'2026-08-23T12:00:00Z'});const text=JSON.stringify(record);assert.equal(record.priority_codes[0],'A_1');assert.equal(record.anomaly_codes[0],'B_2');assert.equal(record.tracking.reservation_start,true);assert.equal(text.includes('token'),false);assert.equal(text.includes('campaign_id'),false);});
-test('history is bounded and deduplicated',()=>{let records=[];for(let i=0;i<5;i++)records=appendHistoryRecord(records,{generated_at:String(i)},{maxRecords:3});assert.deepEqual(records.map(r=>r.generated_at),['2','3','4']);records=appendHistoryRecord(records,{generated_at:'4',x:1},{maxRecords:3});assert.equal(records.length,3);assert.equal(records[2].x,1);});
-test('history persists with owner-only file mode and loads safely',()=>{const dir=fs.mkdtempSync(path.join(os.tmpdir(),'shadow-history-'));const file=path.join(dir,'history.json');saveHistory([{generated_at:'x',source_health:{google:true}}],file);assert.equal(loadHistory(file).length,1);assert.equal(fs.statSync(file).mode&0o777,0o600);});
-test('default tmp history is classified ephemeral and cannot support promotion',()=>{const status=historyStorageStatus({});assert.equal(status.durable,false);assert.equal(status.path_class,'ephemeral');assert.equal(status.writes_allowed,false);});
-test('explicit non-tmp history path is a durable candidate',()=>{const status=historyStorageStatus({SHADOW_HISTORY_PATH:'/data/parma-shadow-history.json'});assert.equal(status.configured,true);assert.equal(status.durable,true);assert.equal(status.path_class,'durable_candidate');});
-test('public summary reports storage durability without exposing a path',()=>{const summary=publicHistorySummary([{data_quality:'high',source_health:{google:true,ga4:true,meta:true},tracking:{reservation_start:true}}],{durable:false,path_class:'ephemeral'});assert.equal(summary.total_runs,1);assert.equal(summary.storage.durable,false);assert.equal(summary.storage.path_class,'ephemeral');assert.equal(summary.storage.path,undefined);assert.equal(summary.writes_allowed,false);});
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  buildSanitizedHistoryRecord,
+  appendHistoryRecord,
+  saveHistory,
+  loadHistory,
+  publicHistorySummary,
+  historyPath,
+  historyStorageStatus,
+} = require("../shadow-history-store");
+
+test("history record contains only sanitized health and codes", () => {
+  const record = buildSanitizedHistoryRecord({
+    snapshot: {
+      data_quality: { confidence: "high" },
+      live_sources: {
+        google: { access_ok: false },
+        ga4: { access_ok: true, funnel: { event_names: ["reservation_start", "booking_completed"] } },
+        meta: { access_ok: true },
+      },
+    },
+    report: {
+      conversion_integrity: { confidence: "high", status: "healthy" },
+      daily_manager: { primary_priorities: [{ code: "A 1" }] },
+      anomalies: [{ code: "B/2" }],
+    },
+    generatedAt: "2026-08-23T12:00:00Z",
+  });
+  const text = JSON.stringify(record);
+  assert.equal(record.priority_codes[0], "A_1");
+  assert.equal(record.anomaly_codes[0], "B_2");
+  assert.equal(record.tracking.reservation_start, true);
+  assert.equal(text.includes("token"), false);
+  assert.equal(text.includes("campaign_id"), false);
+});
+
+test("history is bounded and deduplicated", () => {
+  let records = [];
+  for (let index = 0; index < 5; index += 1) {
+    records = appendHistoryRecord(records, { generated_at: String(index) }, { maxRecords: 3 });
+  }
+  assert.deepEqual(records.map((record) => record.generated_at), ["2", "3", "4"]);
+  records = appendHistoryRecord(records, { generated_at: "4", x: 1 }, { maxRecords: 3 });
+  assert.equal(records.length, 3);
+  assert.equal(records[2].x, 1);
+});
+
+test("history persists with owner-only file mode and loads safely", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "shadow-history-"));
+  const file = path.join(directory, "history.json");
+  saveHistory([{ generated_at: "x", source_health: { google: true } }], file);
+  assert.equal(loadHistory(file).length, 1);
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+});
+
+test("default tmp history is classified ephemeral and cannot support promotion", () => {
+  const status = historyStorageStatus({});
+  assert.equal(status.durable, false);
+  assert.equal(status.path_class, "ephemeral");
+  assert.equal(status.source, "default_tmp");
+  assert.equal(status.writes_allowed, false);
+});
+
+test("explicit non-tmp history path is a durable candidate", () => {
+  const status = historyStorageStatus({ SHADOW_HISTORY_PATH: "/data/parma-shadow-history.json" });
+  assert.equal(status.configured, true);
+  assert.equal(status.durable, true);
+  assert.equal(status.path_class, "durable_candidate");
+  assert.equal(status.source, "explicit_path");
+});
+
+test("Railway volume mount is automatically used as durable candidate", () => {
+  const env = { RAILWAY_VOLUME_MOUNT_PATH: "/data" };
+  assert.equal(historyPath(env), "/data/parma-shadow-history.json");
+  const status = historyStorageStatus(env);
+  assert.equal(status.configured, true);
+  assert.equal(status.durable, true);
+  assert.equal(status.path_class, "durable_candidate");
+  assert.equal(status.source, "railway_volume");
+  assert.equal(status.writes_allowed, false);
+});
+
+test("explicit history path takes precedence over Railway volume mount", () => {
+  const env = {
+    SHADOW_HISTORY_PATH: "/custom/history.json",
+    RAILWAY_VOLUME_MOUNT_PATH: "/data",
+  };
+  assert.equal(historyPath(env), "/custom/history.json");
+  assert.equal(historyStorageStatus(env).source, "explicit_path");
+});
+
+test("public summary reports durability classification without exposing a path", () => {
+  const summary = publicHistorySummary([
+    {
+      data_quality: "high",
+      source_health: { google: true, ga4: true, meta: true },
+      tracking: { reservation_start: true },
+    },
+  ], { durable: true, path_class: "durable_candidate", source: "railway_volume" });
+  assert.equal(summary.total_runs, 1);
+  assert.equal(summary.storage.durable, true);
+  assert.equal(summary.storage.path_class, "durable_candidate");
+  assert.equal(summary.storage.source, "railway_volume");
+  assert.equal(summary.storage.path, undefined);
+  assert.equal(summary.writes_allowed, false);
+});


### PR DESCRIPTION
Makes Shadow history automatically use Railway's runtime `RAILWAY_VOLUME_MOUNT_PATH` when a real persistent volume is attached, while preserving explicit `SHADOW_HISTORY_PATH` precedence. If neither exists, history remains `/tmp` and is still classified ephemeral, so promotion remains blocked. Public summaries expose only durability/source classification, never filesystem paths. Includes owner-only persistence and regression tests. No ad-platform mutation, activation, budget or spend change.