### PR TITLE
Sanitize Meta draft inventory already on main

### DIFF
--- a/.github/workflows/meta-draft-inventory.yml
+++ b/.github/workflows/meta-draft-inventory.yml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Install dependencies reproducibly
+        run: npm ci --ignore-scripts
       - name: Inspect recent paused Meta draft objects read-only
         env:
           META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}

--- a/scripts/run-meta-draft-inventory.js
+++ b/scripts/run-meta-draft-inventory.js
@@ -1,12 +1,80 @@
-const token=process.env.META_ACCESS_TOKEN;
-const raw=String(process.env.META_AD_ACCOUNT_ID||'');
-const account=raw.startsWith('act_')?raw:`act_${raw}`;
-const v=/^v\d+\.0$/.test(String(process.env.META_API_VERSION||''))?process.env.META_API_VERSION:'v19.0';
-const clean=(x,n=160)=>String(x||'').replace(/[\r\n\t]+/g,' ').slice(0,n);
-async function get(path,fields){const u=new URL(`https://graph.facebook.com/${v}/${path}`);u.searchParams.set('fields',fields);u.searchParams.set('limit','100');u.searchParams.set('access_token',token);const r=await fetch(u,{method:'GET'});const b=await r.json();if(!r.ok||b.error)throw new Error(clean(b?.error?.message||`meta_http_${r.status}`));return b.data||[];}
-(async()=>{if(!token||!raw)throw new Error('meta_configuration_incomplete');const [cs,as,ads]=await Promise.all([
-get(`${account}/campaigns`,'id,name,status,effective_status,objective,created_time,updated_time,start_time,stop_time'),
-get(`${account}/adsets`,'id,name,campaign_id,status,effective_status,start_time,end_time,created_time,updated_time,daily_budget,lifetime_budget,optimization_goal,billing_event,targeting'),
-get(`${account}/ads`,'id,name,campaign_id,adset_id,status,effective_status,created_time,updated_time,creative{id,name,object_story_spec,effective_object_story_id,instagram_permalink_url}')]);
-const candidates=cs.filter(c=>c.status==='PAUSED'&&!['WITH_ISSUES','CAMPAIGN_PAUSED'].includes(c.effective_status)&&Date.parse(c.created_time||0)>=Date.parse('2026-08-20T00:00:00Z'));
-const out=candidates.map(c=>{const aa=as.filter(a=>String(a.campaign_id)===String(c.id));const dd=ads.filter(a=>String(a.campaign_id)===String(c.id));return {campaign:{id:String(c.id),name:clean(c.name),status:c.status,effective_status:c.effective_status,objective:c.objective,created_time:c.created_time,updated_time:c.updated_time},adsets:aa.map(a=>({id:String(a.id),name:clean(a.name),status:a.status,effective_status:a.effective_status,start_time:a.start_time,end_time:a.end_time,daily_budget:a.daily_budget,lifetime_budget:a.lifetime_budget,optimization_goal:a.optimization_goal,billing_event:a.billing_event,targeting:a.targeting})),ads:dd.map(a=>({id:String(a.id),adset_id:String(a.adset_id||''),name:clean(a.name),status:a.status,effective_status:a.effective_status,creative:a.creative||null})),safety:{any_active:[c,...aa,...dd].some(x=>x.status==='ACTIVE'||x.effective_status==='ACTIVE'),adset_count:aa.length,ad_count:dd.length}}});console.log(JSON.stringify({access_ok:true,candidate_count:out.length,candidates:out},null,2));})().catch(e=>{console.error(JSON.stringify({access_ok:false,error:clean(e?.message||'meta_inventory_failed')}));process.exitCode=1;});
+const { META_API_VERSION } = require("../meta-paused-draft-next");
+const { assertPublicPayloadSafe } = require("../public-output-safety");
+
+const token = process.env.META_ACCESS_TOKEN;
+const rawAccount = String(process.env.META_AD_ACCOUNT_ID || "");
+const account = rawAccount.startsWith("act_") ? rawAccount : `act_${rawAccount}`;
+const candidateVersion = String(process.env.META_API_VERSION || META_API_VERSION);
+const version = /^v\d+\.0$/.test(candidateVersion) ? candidateVersion : META_API_VERSION;
+const createdSince = Date.parse("2026-08-20T00:00:00Z");
+
+function clean(value, max = 120) {
+  return String(value || "").replace(/[\r\n\t]+/g, " ").slice(0, max);
+}
+
+async function getCollection(path, fields) {
+  let url = new URL(`https://graph.facebook.com/${version}/${path}`);
+  url.searchParams.set("fields", fields);
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("access_token", token);
+  const items = [];
+
+  while (url) {
+    const response = await fetch(url, { method: "GET" });
+    const body = await response.json();
+    if (!response.ok || body.error) {
+      throw new Error(clean(body?.error?.message || `meta_http_${response.status}`, 180));
+    }
+    items.push(...(body.data || []));
+    url = body.paging?.next ? new URL(body.paging.next) : null;
+  }
+  return items;
+}
+
+function isActive(item) {
+  return item?.status === "ACTIVE" || item?.effective_status === "ACTIVE";
+}
+
+(async () => {
+  if (!token || !rawAccount) throw new Error("meta_configuration_incomplete");
+
+  const [campaigns, adsets, ads] = await Promise.all([
+    getCollection(`${account}/campaigns`, "id,name,status,effective_status,created_time"),
+    getCollection(`${account}/adsets`, "id,campaign_id,status,effective_status"),
+    getCollection(`${account}/ads`, "campaign_id,adset_id,status,effective_status"),
+  ]);
+
+  const candidates = campaigns.filter((campaign) =>
+    campaign.status === "PAUSED" && Date.parse(campaign.created_time || 0) >= createdSince
+  );
+
+  const summaries = candidates.map((campaign) => {
+    const childAdsets = adsets.filter((adset) => String(adset.campaign_id) === String(campaign.id));
+    const childAds = ads.filter((ad) => String(ad.campaign_id) === String(campaign.id));
+    return {
+      name: clean(campaign.name),
+      configured_status: clean(campaign.status, 40),
+      effective_status: clean(campaign.effective_status, 40),
+      child_adsets: childAdsets.length,
+      child_ads: childAds.length,
+      any_active_child: childAdsets.some(isActive) || childAds.some(isActive),
+    };
+  });
+
+  const payload = assertPublicPayloadSafe({
+    access_ok: true,
+    candidate_count: summaries.length,
+    any_active_objects: summaries.some((item) => item.any_active_child),
+    candidates: summaries,
+    writes_allowed: false,
+  });
+
+  console.log(JSON.stringify(payload, null, 2));
+})().catch((error) => {
+  console.error(JSON.stringify({
+    access_ok: false,
+    error: clean(error?.message || "meta_inventory_failed", 180),
+    writes_allowed: false,
+  }));
+  process.exitCode = 1;
+});

--- a/test/meta-draft-inventory.test.js
+++ b/test/meta-draft-inventory.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+test("Meta draft inventory is manual, GET-only and sanitized", () => {
+  const script = fs.readFileSync("scripts/run-meta-draft-inventory.js", "utf8");
+  const workflow = fs.readFileSync(".github/workflows/meta-draft-inventory.yml", "utf8");
+
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /push:|pull_request:|schedule:|repository_dispatch:/);
+  assert.match(workflow, /npm ci --ignore-scripts/);
+  assert.match(workflow, /node scripts\/run-meta-draft-inventory\.js/);
+
+  assert.match(script, /method:\s*"GET"/);
+  assert.match(script, /assertPublicPayloadSafe/);
+  assert.match(script, /writes_allowed:\s*false/);
+  assert.doesNotMatch(script, /\.post\(|\.delete\(|createPaused|write_gate|approval_token/i);
+  assert.doesNotMatch(script, /targeting|creative\{/i);
+  assert.doesNotMatch(script, /campaign_id\s*:/i);
+  assert.doesNotMatch(script, /adset_id\s*:/i);
+  assert.doesNotMatch(script, /ad_id\s*:/i);
+});


### PR DESCRIPTION
Hardens the Meta draft inventory that reached main before the original replacement could merge. The workflow remains manual and GET-only, but now paginates safely, emits only sanitized names/status/counts and ACTIVE-child flags, omits Meta object IDs/targeting/creative payloads, validates output with the public safety scanner, and installs dependencies reproducibly. Includes regression tests. No mutation, activation, deletion, budget or spend change.