### PR TITLE
Fail closed on Shadow history corruption

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -13,7 +13,7 @@ const { buildSanitizedPromotionStatus } = require("./promotion-status");
 const { buildReadonlyCycleState, assertReadonlyCycleSafe } = require("./shadow-readonly-cycle");
 const { buildOperationalDashboard } = require("./operational-dashboard");
 const {
-  loadHistory,
+  loadHistoryState,
   appendAndPersist,
   buildSanitizedHistoryRecord,
   publicHistorySummary,
@@ -34,7 +34,12 @@ const state = {
 
 let refreshPromise = null;
 const historyStorage = historyStorageStatus(process.env);
-let shadowHistory = loadHistory(historyPath(process.env));
+const initialHistory = loadHistoryState(historyPath(process.env));
+let shadowHistory = initialHistory.records;
+let historyIntegrity = {
+  healthy: initialHistory.healthy === true,
+  reason: initialHistory.reason || null,
+};
 
 function authorized(req) {
   const supplied = req.headers["x-api-key"] || String(req.headers["authorization"] || "").replace(/^Bearer\s+/i, "");
@@ -50,8 +55,10 @@ function buildRuntimeViews() {
     buildValidated: process.env.AGENT_BUILD_VALIDATED === "true",
     shadowRecords: shadowHistory,
     historyDurable: historyStorage.durable,
+    historyHealthy: historyIntegrity.healthy,
   });
   const ga4Events = Array.isArray(r.live_sources?.ga4?.funnel?.event_names) ? r.live_sources.ga4.funnel.event_names : [];
+  const publicStorage = { ...historyStorage, ...historyIntegrity };
   const summary = {
     generated_at: r.generated_at,
     mode: "shadow",
@@ -94,7 +101,7 @@ function buildRuntimeViews() {
       optimization_allowed: Boolean(r.conversion_integrity?.optimization_allowed),
       issues: r.conversion_integrity?.issues || [],
     },
-    history: publicHistorySummary(shadowHistory, historyStorage),
+    history: publicHistorySummary(shadowHistory, publicStorage),
     promotion,
     anomalies: (r.anomalies || []).map((a) => ({ code: a.code, severity: a.severity, reason: a.reason, channel: a.channel })),
     primary_priorities: (r.daily_manager?.primary_priorities || []).map((p) => ({ code: p.code, severity: p.severity, source: p.source, reason: p.reason, requires_authorization: Boolean(p.requires_authorization) })),
@@ -147,7 +154,9 @@ function triggerShadowReport() {
       const record = buildSanitizedHistoryRecord({ snapshot: input, report, generatedAt: state.finished_at });
       try {
         shadowHistory = appendAndPersist({ records: shadowHistory, record, filePath: historyPath(process.env) });
+        historyIntegrity = { healthy: true, reason: null };
       } catch (error) {
+        historyIntegrity = { healthy: false, reason: "history_persist_failed" };
         console.error(JSON.stringify({ event: "shadow_history_persist", success: false, error: String(error?.message || error).slice(0, 120), writes_allowed: false }));
       }
 
@@ -166,6 +175,7 @@ function triggerShadowReport() {
         priority_count: report.daily_manager?.primary_priorities?.length || 0,
         history_runs: shadowHistory.length,
         history_durable: historyStorage.durable,
+        history_healthy: historyIntegrity.healthy,
         cycle_blocked_stages: cycle?.blocked_stages || [],
         writes_allowed: false,
       }));

--- a/promotion-status.js
+++ b/promotion-status.js
@@ -1,8 +1,8 @@
-const { buildPromotionDecision } = require('./promotion-controller');
+const { buildPromotionDecision } = require("./promotion-controller");
 
 function allSourcesFresh(dataQuality = {}) {
   const sources = dataQuality.sources || {};
-  return ['google', 'ga4', 'meta'].every((name) => sources[name]?.state === 'fresh');
+  return ["google", "ga4", "meta"].every((name) => sources[name]?.state === "fresh");
 }
 
 function buildSanitizedPromotionStatus({
@@ -11,6 +11,7 @@ function buildSanitizedPromotionStatus({
   buildValidated = false,
   shadowRecords = [],
   historyDurable = false,
+  historyHealthy = false,
 } = {}) {
   const dataQuality = shadowResult.data_quality || {};
   const channelReady = dataQuality.channel_ready || {};
@@ -29,7 +30,7 @@ function buildSanitizedPromotionStatus({
         ga4_ready: liveSources.ga4?.access_ok === true,
       },
       conversionIntegrity: {
-        trusted: integrity.status === 'healthy' && integrity.optimization_allowed === true,
+        trusted: integrity.status === "healthy" && integrity.optimization_allowed === true,
       },
       safety: {
         zero_write_default: true,
@@ -71,22 +72,29 @@ function buildSanitizedPromotionStatus({
     shadowRecords,
   });
 
-  const durabilityBlocker = historyDurable ? [] : ['history:storage_not_durable'];
-  const blockers = [...new Set([...(decision.blockers || []), ...durabilityBlocker])];
-  const promotionReady = decision.promotion_ready === true && historyDurable === true;
+  const historyStorageReady = historyDurable === true && historyHealthy === true;
+  const storageBlockers = [];
+  if (!historyDurable) storageBlockers.push("history:storage_not_durable");
+  if (!historyHealthy) storageBlockers.push("history:storage_unhealthy");
+  const blockers = [...new Set([...(decision.blockers || []), ...storageBlockers])];
+  const promotionReady = decision.promotion_ready === true && historyStorageReady;
 
   return {
     promotion_ready: promotionReady,
-    autonomy_class: promotionReady ? decision.autonomy_class : 'observe_and_propose',
+    autonomy_class: promotionReady ? decision.autonomy_class : "observe_and_propose",
     readiness_score: decision.readiness.score,
     readiness_stage: decision.readiness.stage,
-    gates: { ...decision.gates, history_storage: historyDurable === true },
+    gates: {
+      ...decision.gates,
+      history_storage: historyStorageReady,
+    },
     blockers,
     history: {
       total_runs: decision.shadow_history.total_runs,
       evaluable_decisions: decision.shadow_history.evaluable_decisions,
       safety_violations: decision.shadow_history.safety_violations,
       durable: historyDurable === true,
+      healthy: historyHealthy === true,
     },
     external_write_authorized: false,
     spend_authorized: false,

--- a/shadow-history-store.js
+++ b/shadow-history-store.js
@@ -12,9 +12,7 @@ function safeCode(value, fallback = null) {
 
 function historyPath(env = process.env) {
   if (env.SHADOW_HISTORY_PATH) return env.SHADOW_HISTORY_PATH;
-  if (env.RAILWAY_VOLUME_MOUNT_PATH) {
-    return path.join(env.RAILWAY_VOLUME_MOUNT_PATH, VOLUME_HISTORY_FILENAME);
-  }
+  if (env.RAILWAY_VOLUME_MOUNT_PATH) return path.join(env.RAILWAY_VOLUME_MOUNT_PATH, VOLUME_HISTORY_FILENAME);
   return DEFAULT_TMP_HISTORY;
 }
 
@@ -23,7 +21,6 @@ function historyStorageStatus(env = process.env) {
   const railwayVolume = Boolean(env.RAILWAY_VOLUME_MOUNT_PATH);
   const filePath = historyPath(env);
   const ephemeral = filePath.startsWith("/tmp/") || (!explicitPath && !railwayVolume);
-
   return {
     configured: explicitPath || railwayVolume,
     source: explicitPath ? "explicit_path" : railwayVolume ? "railway_volume" : "default_tmp",
@@ -33,13 +30,28 @@ function historyStorageStatus(env = process.env) {
   };
 }
 
-function loadHistory(filePath = historyPath()) {
+function validateLoadedRecords(parsed) {
+  if (!Array.isArray(parsed)) return { healthy: false, records: [], reason: "history_not_array" };
+  const invalid = parsed.some((record) => !record || typeof record !== "object" || !record.generated_at);
+  if (invalid) return { healthy: false, records: [], reason: "history_record_invalid" };
+  return { healthy: true, records: parsed, reason: null };
+}
+
+function loadHistoryState(filePath = historyPath()) {
+  if (!fs.existsSync(filePath)) {
+    return { healthy: true, exists: false, records: [], reason: null };
+  }
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    return Array.isArray(parsed) ? parsed : [];
+    const validated = validateLoadedRecords(parsed);
+    return { ...validated, exists: true };
   } catch {
-    return [];
+    return { healthy: false, exists: true, records: [], reason: "history_parse_failed" };
   }
+}
+
+function loadHistory(filePath = historyPath()) {
+  return loadHistoryState(filePath).records;
 }
 
 function saveHistory(records = [], filePath = historyPath(), { maxRecords = DEFAULT_MAX_RECORDS } = {}) {
@@ -48,6 +60,10 @@ function saveHistory(records = [], filePath = historyPath(), { maxRecords = DEFA
   const tmp = `${filePath}.tmp`;
   fs.writeFileSync(tmp, `${JSON.stringify(bounded)}\n`, { mode: 0o600 });
   fs.renameSync(tmp, filePath);
+  const verified = loadHistoryState(filePath);
+  if (!verified.healthy || verified.records.length !== bounded.length) {
+    throw new Error("shadow_history_persistence_verification_failed");
+  }
   return bounded;
 }
 
@@ -57,7 +73,6 @@ function buildSanitizedHistoryRecord({ snapshot = {}, report = {}, generatedAt =
   const events = Array.isArray(snapshot.live_sources?.ga4?.funnel?.event_names)
     ? snapshot.live_sources.ga4.funnel.event_names
     : [];
-
   return {
     id: generatedAt,
     generated_at: generatedAt,
@@ -69,9 +84,7 @@ function buildSanitizedHistoryRecord({ snapshot = {}, report = {}, generatedAt =
       ga4: snapshot.live_sources?.ga4?.access_ok === true,
       meta: snapshot.live_sources?.meta?.access_ok === true,
     },
-    tracking: {
-      reservation_start: events.includes("reservation_start"),
-    },
+    tracking: { reservation_start: events.includes("reservation_start") },
     priority_codes: priorities.map((priority) => safeCode(priority.code, "unknown")),
     anomaly_codes: anomalies.map((anomaly) => safeCode(anomaly.code, "unknown")),
     safety_violation: false,
@@ -82,10 +95,7 @@ function buildSanitizedHistoryRecord({ snapshot = {}, report = {}, generatedAt =
 
 function appendHistoryRecord(records = [], record, { maxRecords = DEFAULT_MAX_RECORDS } = {}) {
   if (!record?.generated_at) return records.slice(-maxRecords);
-  return [
-    ...records.filter((existing) => existing.generated_at !== record.generated_at),
-    record,
-  ].slice(-maxRecords);
+  return [...records.filter((existing) => existing.generated_at !== record.generated_at), record].slice(-maxRecords);
 }
 
 function appendAndPersist({ records = [], record, filePath = historyPath(), maxRecords = DEFAULT_MAX_RECORDS } = {}) {
@@ -105,8 +115,10 @@ function publicHistorySummary(records = [], storage = {}) {
     reservation_start_tracked_runs: records.filter((record) => record.tracking?.reservation_start === true).length,
     storage: {
       durable: storage.durable === true,
+      healthy: storage.healthy === true,
       path_class: storage.path_class || "unknown",
       source: storage.source || "unknown",
+      reason: storage.reason || null,
     },
     writes_allowed: false,
   };
@@ -119,6 +131,8 @@ module.exports = {
   safeCode,
   historyPath,
   historyStorageStatus,
+  validateLoadedRecords,
+  loadHistoryState,
   loadHistory,
   saveHistory,
   buildSanitizedHistoryRecord,

--- a/test/promotion-status.test.js
+++ b/test/promotion-status.test.js
@@ -1,6 +1,6 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-const { allSourcesFresh, buildSanitizedPromotionStatus } = require('../promotion-status');
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { allSourcesFresh, buildSanitizedPromotionStatus } = require("../promotion-status");
 
 function healthyShadow() {
   const collectedAt = new Date().toISOString();
@@ -9,9 +9,9 @@ function healthyShadow() {
     data_quality: {
       channel_ready: { google: true, meta: true },
       sources: {
-        google: { state: 'fresh' },
-        ga4: { state: 'fresh' },
-        meta: { state: 'fresh' },
+        google: { state: "fresh" },
+        ga4: { state: "fresh" },
+        meta: { state: "fresh" },
       },
     },
     live_sources: {
@@ -19,7 +19,7 @@ function healthyShadow() {
       ga4: { access_ok: true, configuration_complete: true },
       meta: { access_ok: true, configuration_complete: true },
     },
-    conversion_integrity: { status: 'healthy', optimization_allowed: true },
+    conversion_integrity: { status: "healthy", optimization_allowed: true },
   };
 }
 
@@ -28,79 +28,99 @@ function goodHistory() {
     id: `r-${index}`,
     before: 1,
     after: 2,
-    outcome: 'observed',
-    expected_direction: 'up',
-    data_quality: 'high',
-    attribution_confidence: 'high',
+    outcome: "observed",
+    expected_direction: "up",
+    data_quality: "high",
+    attribution_confidence: "high",
     safety_violation: false,
   }));
 }
 
-test('source freshness requires all three live sources', () => {
+test("source freshness requires all three live sources", () => {
   assert.equal(allSourcesFresh(healthyShadow().data_quality), true);
   const degraded = healthyShadow();
-  degraded.data_quality.sources.ga4.state = 'stale';
+  degraded.data_quality.sources.ga4.state = "stale";
   assert.equal(allSourcesFresh(degraded.data_quality), false);
 });
 
-test('runtime status fails closed when build validation and history are missing', () => {
+test("runtime status fails closed when build validation and history are missing", () => {
   const status = buildSanitizedPromotionStatus({
     shadowResult: healthyShadow(),
     metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
     buildValidated: false,
     shadowRecords: [],
     historyDurable: false,
+    historyHealthy: true,
   });
   assert.equal(status.promotion_ready, false);
-  assert.equal(status.autonomy_class, 'observe_and_propose');
-  assert.ok(status.blockers.includes('readiness:regression_suite_not_verified'));
-  assert.ok(status.blockers.includes('history:insufficient_shadow_runs'));
-  assert.ok(status.blockers.includes('history:storage_not_durable'));
+  assert.equal(status.autonomy_class, "observe_and_propose");
+  assert.ok(status.blockers.includes("readiness:regression_suite_not_verified"));
+  assert.ok(status.blockers.includes("history:insufficient_shadow_runs"));
+  assert.ok(status.blockers.includes("history:storage_not_durable"));
   assert.equal(status.execution_authorized, false);
   assert.equal(status.writes_allowed, false);
 });
 
-test('missing Meta read preflight remains an independent live blocker', () => {
+test("missing Meta read preflight remains an independent live blocker", () => {
   const status = buildSanitizedPromotionStatus({
     shadowResult: healthyShadow(),
     metaPreflightState: { result: { read_only_ready: false, write_ready: false } },
     buildValidated: true,
     shadowRecords: goodHistory(),
     historyDurable: true,
+    historyHealthy: true,
   });
   assert.equal(status.gates.readiness, true);
   assert.equal(status.gates.live_validation, false);
-  assert.ok(status.blockers.includes('live:meta_preflight_ready'));
+  assert.ok(status.blockers.includes("live:meta_preflight_ready"));
   assert.equal(status.promotion_ready, false);
 });
 
-test('ephemeral history blocks promotion even when all other evidence is green', () => {
+test("ephemeral history blocks promotion even when all other evidence is green", () => {
   const status = buildSanitizedPromotionStatus({
     shadowResult: healthyShadow(),
     metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
     buildValidated: true,
     shadowRecords: goodHistory(),
     historyDurable: false,
+    historyHealthy: true,
   });
   assert.equal(status.gates.readiness, true);
   assert.equal(status.gates.live_validation, true);
   assert.equal(status.gates.shadow_history, true);
   assert.equal(status.gates.history_storage, false);
-  assert.ok(status.blockers.includes('history:storage_not_durable'));
+  assert.ok(status.blockers.includes("history:storage_not_durable"));
   assert.equal(status.promotion_ready, false);
-  assert.equal(status.autonomy_class, 'observe_and_propose');
+  assert.equal(status.autonomy_class, "observe_and_propose");
 });
 
-test('even fully green durable evidence cannot authorize external execution', () => {
+test("corrupt or unhealthy history blocks promotion independently of durability", () => {
   const status = buildSanitizedPromotionStatus({
     shadowResult: healthyShadow(),
     metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
     buildValidated: true,
     shadowRecords: goodHistory(),
     historyDurable: true,
+    historyHealthy: false,
+  });
+  assert.equal(status.gates.shadow_history, true);
+  assert.equal(status.gates.history_storage, false);
+  assert.ok(status.blockers.includes("history:storage_unhealthy"));
+  assert.equal(status.promotion_ready, false);
+  assert.equal(status.autonomy_class, "observe_and_propose");
+});
+
+test("even fully green durable healthy evidence cannot authorize external execution", () => {
+  const status = buildSanitizedPromotionStatus({
+    shadowResult: healthyShadow(),
+    metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
+    buildValidated: true,
+    shadowRecords: goodHistory(),
+    historyDurable: true,
+    historyHealthy: true,
   });
   assert.equal(status.promotion_ready, true);
-  assert.equal(status.autonomy_class, 'supervised_reversible_candidate');
+  assert.equal(status.autonomy_class, "supervised_reversible_candidate");
   assert.equal(status.external_write_authorized, false);
   assert.equal(status.spend_authorized, false);
   assert.equal(status.activation_authorized, false);

--- a/test/shadow-history-store.test.js
+++ b/test/shadow-history-store.test.js
@@ -8,6 +8,7 @@ const {
   appendHistoryRecord,
   saveHistory,
   loadHistory,
+  loadHistoryState,
   publicHistorySummary,
   historyPath,
   historyStorageStatus,
@@ -49,12 +50,41 @@ test("history is bounded and deduplicated", () => {
   assert.equal(records[2].x, 1);
 });
 
-test("history persists with owner-only file mode and loads safely", () => {
+test("history persists with owner-only file mode and verified reload", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "shadow-history-"));
   const file = path.join(directory, "history.json");
   saveHistory([{ generated_at: "x", source_health: { google: true } }], file);
   assert.equal(loadHistory(file).length, 1);
+  assert.equal(loadHistoryState(file).healthy, true);
   assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+});
+
+test("missing history file is healthy empty state, not corruption", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "shadow-history-missing-"));
+  const state = loadHistoryState(path.join(directory, "missing.json"));
+  assert.equal(state.healthy, true);
+  assert.equal(state.exists, false);
+  assert.deepEqual(state.records, []);
+});
+
+test("malformed JSON is reported unhealthy and loads no records", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "shadow-history-corrupt-"));
+  const file = path.join(directory, "history.json");
+  fs.writeFileSync(file, "{not-json", { mode: 0o600 });
+  const state = loadHistoryState(file);
+  assert.equal(state.healthy, false);
+  assert.equal(state.exists, true);
+  assert.equal(state.reason, "history_parse_failed");
+  assert.deepEqual(state.records, []);
+});
+
+test("structurally invalid history is reported unhealthy", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "shadow-history-invalid-"));
+  const file = path.join(directory, "history.json");
+  fs.writeFileSync(file, JSON.stringify([{ source_health: {} }]), { mode: 0o600 });
+  const state = loadHistoryState(file);
+  assert.equal(state.healthy, false);
+  assert.equal(state.reason, "history_record_invalid");
 });
 
 test("default tmp history is classified ephemeral and cannot support promotion", () => {
@@ -85,26 +115,19 @@ test("Railway volume mount is automatically used as durable candidate", () => {
 });
 
 test("explicit history path takes precedence over Railway volume mount", () => {
-  const env = {
-    SHADOW_HISTORY_PATH: "/custom/history.json",
-    RAILWAY_VOLUME_MOUNT_PATH: "/data",
-  };
+  const env = { SHADOW_HISTORY_PATH: "/custom/history.json", RAILWAY_VOLUME_MOUNT_PATH: "/data" };
   assert.equal(historyPath(env), "/custom/history.json");
   assert.equal(historyStorageStatus(env).source, "explicit_path");
 });
 
-test("public summary reports durability classification without exposing a path", () => {
+test("public summary reports storage health without exposing a path", () => {
   const summary = publicHistorySummary([
-    {
-      data_quality: "high",
-      source_health: { google: true, ga4: true, meta: true },
-      tracking: { reservation_start: true },
-    },
-  ], { durable: true, path_class: "durable_candidate", source: "railway_volume" });
+    { data_quality: "high", source_health: { google: true, ga4: true, meta: true }, tracking: { reservation_start: true } },
+  ], { durable: true, healthy: false, reason: "history_parse_failed", path_class: "durable_candidate", source: "railway_volume" });
   assert.equal(summary.total_runs, 1);
   assert.equal(summary.storage.durable, true);
-  assert.equal(summary.storage.path_class, "durable_candidate");
-  assert.equal(summary.storage.source, "railway_volume");
+  assert.equal(summary.storage.healthy, false);
+  assert.equal(summary.storage.reason, "history_parse_failed");
   assert.equal(summary.storage.path, undefined);
   assert.equal(summary.writes_allowed, false);
 });


### PR DESCRIPTION
Strengthens the durable-history gate so persistence integrity is required in addition to a durable path. Existing/malformed history is validated on load, successful saves are read-back verified, and any parse/structure/persist failure marks history storage unhealthy and blocks promotion while leaving the live Shadow report available. Missing history on a fresh volume is treated as a healthy empty baseline. Public output exposes only sanitized health/reason codes, never paths or contents. Includes adversarial corruption tests. No ad-platform mutation, activation, budget or spend change.