### PR TITLE
Require explicit evidence kind for Shadow evaluation

### DIFF
--- a/shadow-evaluation.js
+++ b/shadow-evaluation.js
@@ -3,28 +3,43 @@ function number(value) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+const EVALUABLE_EVIDENCE_KINDS = new Set(["forecast_observation", "verified_action_outcome"]);
+
 function evaluateRecommendation(record = {}) {
-  if (record.safety_violation === true) return { status: 'unsafe', evaluable: true, correct: false };
-  if (record.outcome == null || record.expected_direction == null) return { status: 'unknown', evaluable: false, correct: null };
+  if (record.safety_violation === true) return { status: "unsafe", evaluable: true, correct: false, evidence_kind: "safety_violation" };
+  const evidenceKind = String(record.evidence_kind || "unclassified");
+  if (!EVALUABLE_EVIDENCE_KINDS.has(evidenceKind)) {
+    return { status: "unknown", evaluable: false, correct: null, evidence_kind: evidenceKind };
+  }
+  if (record.outcome == null || record.expected_direction == null || record.before == null || record.after == null) {
+    return { status: "unknown", evaluable: false, correct: null, evidence_kind: evidenceKind };
+  }
+  if (evidenceKind === "verified_action_outcome" && record.external_execution_verified !== true) {
+    return { status: "unknown", evaluable: false, correct: null, evidence_kind: evidenceKind };
+  }
   const before = number(record.before);
   const after = number(record.after);
   const delta = after - before;
-  const direction = delta === 0 ? 'flat' : delta > 0 ? 'up' : 'down';
-  const correct = record.expected_direction === direction || (record.expected_direction === 'non_worse' && delta >= 0);
-  return { status: correct ? 'correct' : 'false_positive', evaluable: true, correct, delta, direction };
+  const direction = delta === 0 ? "flat" : delta > 0 ? "up" : "down";
+  const correct = record.expected_direction === direction || (record.expected_direction === "non_worse" && delta >= 0);
+  return { status: correct ? "correct" : "false_positive", evaluable: true, correct, delta, direction, evidence_kind: evidenceKind };
 }
 
 function summarizeShadowHistory(records = []) {
   const evaluations = records.map((record) => ({ ...evaluateRecommendation(record), id: record.id || null }));
   const evaluable = evaluations.filter((evaluation) => evaluation.evaluable);
   const correct = evaluable.filter((evaluation) => evaluation.correct === true).length;
-  const falsePositives = evaluable.filter((evaluation) => evaluation.status === 'false_positive').length;
+  const falsePositives = evaluable.filter((evaluation) => evaluation.status === "false_positive").length;
   const safetyViolations = records.filter((record) => record.safety_violation === true).length;
-  const highQualityRuns = records.filter((record) => record.data_quality === 'high').length;
-  const highAttributionRuns = records.filter((record) => record.attribution_confidence === 'high').length;
+  const highQualityRuns = records.filter((record) => record.data_quality === "high").length;
+  const highAttributionRuns = records.filter((record) => record.attribution_confidence === "high").length;
+  const forecastEvaluations = evaluable.filter((evaluation) => evaluation.evidence_kind === "forecast_observation").length;
+  const verifiedActionOutcomes = evaluable.filter((evaluation) => evaluation.evidence_kind === "verified_action_outcome").length;
   return {
     total_runs: records.length,
     evaluable_decisions: evaluable.length,
+    forecast_evaluations: forecastEvaluations,
+    verified_action_outcomes: verifiedActionOutcomes,
     correct_decisions: correct,
     false_positives: falsePositives,
     precision: evaluable.length ? correct / evaluable.length : null,
@@ -47,13 +62,13 @@ function promotionAssessment(summary = {}, policy = {}) {
     min_high_attribution_ratio: policy.min_high_attribution_ratio ?? 0.8,
   };
   const blockers = [];
-  if (number(summary.total_runs) < thresholds.min_runs) blockers.push('insufficient_shadow_runs');
-  if (number(summary.evaluable_decisions) < thresholds.min_evaluable_decisions) blockers.push('insufficient_evaluable_decisions');
-  if (summary.false_positive_rate == null || summary.false_positive_rate > thresholds.max_false_positive_rate) blockers.push('false_positive_rate_too_high_or_unknown');
-  if (summary.precision == null || summary.precision < thresholds.min_precision) blockers.push('precision_too_low_or_unknown');
-  if (summary.high_data_quality_ratio == null || summary.high_data_quality_ratio < thresholds.min_high_data_quality_ratio) blockers.push('data_quality_history_insufficient');
-  if (summary.high_attribution_ratio == null || summary.high_attribution_ratio < thresholds.min_high_attribution_ratio) blockers.push('attribution_history_insufficient');
-  if (number(summary.safety_violations) > 0) blockers.push('safety_violation_history');
+  if (number(summary.total_runs) < thresholds.min_runs) blockers.push("insufficient_shadow_runs");
+  if (number(summary.evaluable_decisions) < thresholds.min_evaluable_decisions) blockers.push("insufficient_evaluable_decisions");
+  if (summary.false_positive_rate == null || summary.false_positive_rate > thresholds.max_false_positive_rate) blockers.push("false_positive_rate_too_high_or_unknown");
+  if (summary.precision == null || summary.precision < thresholds.min_precision) blockers.push("precision_too_low_or_unknown");
+  if (summary.high_data_quality_ratio == null || summary.high_data_quality_ratio < thresholds.min_high_data_quality_ratio) blockers.push("data_quality_history_insufficient");
+  if (summary.high_attribution_ratio == null || summary.high_attribution_ratio < thresholds.min_high_attribution_ratio) blockers.push("attribution_history_insufficient");
+  if (number(summary.safety_violations) > 0) blockers.push("safety_violation_history");
   return {
     candidate_for_supervised_low_risk: blockers.length === 0,
     blockers,
@@ -66,8 +81,8 @@ function promotionAssessment(summary = {}, policy = {}) {
 }
 
 function allowedAutonomyClass(assessment = {}) {
-  if (!assessment.candidate_for_supervised_low_risk) return 'observe_and_propose';
-  return 'supervised_reversible_candidate';
+  if (!assessment.candidate_for_supervised_low_risk) return "observe_and_propose";
+  return "supervised_reversible_candidate";
 }
 
-module.exports = { evaluateRecommendation, summarizeShadowHistory, promotionAssessment, allowedAutonomyClass };
+module.exports = { EVALUABLE_EVIDENCE_KINDS, evaluateRecommendation, summarizeShadowHistory, promotionAssessment, allowedAutonomyClass };

--- a/test/promotion-controller.test.js
+++ b/test/promotion-controller.test.js
@@ -6,27 +6,9 @@ function strongReadinessInput() {
   return {
     dataQuality: { sources_fresh: true, google_ready: true, meta_ready: true, ga4_ready: true },
     conversionIntegrity: { trusted: true },
-    safety: {
-      zero_write_default: true,
-      kill_switch_enforced: true,
-      idempotency_enforced: true,
-      human_approval_for_spend: true,
-      safe_orchestrator_mandatory: true,
-    },
-    reliability: {
-      last_known_good: true,
-      concurrent_refresh_guard: true,
-      fail_closed: true,
-      regression_suite_green: true,
-      post_action_verification_ready: true,
-    },
-    intelligence: {
-      daily_manager: true,
-      anomaly_detection: true,
-      search_term_analysis: true,
-      funnel_diagnostics: true,
-      decision_journal: true,
-    },
+    safety: { zero_write_default: true, kill_switch_enforced: true, idempotency_enforced: true, human_approval_for_spend: true, safe_orchestrator_mandatory: true },
+    reliability: { last_known_good: true, concurrent_refresh_guard: true, fail_closed: true, regression_suite_green: true, post_action_verification_ready: true },
+    intelligence: { daily_manager: true, anomaly_detection: true, search_term_analysis: true, funnel_diagnostics: true, decision_journal: true },
     operations: { google_live: true, ga4_live: true, meta_live: true, runtime_health: true },
   };
 }
@@ -43,6 +25,7 @@ function strongLiveInput() {
 function strongHistory(count = 20) {
   return Array.from({ length: count }, (_, index) => ({
     id: `run-${index + 1}`,
+    evidence_kind: "forecast_observation",
     before: 10,
     after: 11,
     outcome: "observed",
@@ -54,19 +37,10 @@ function strongHistory(count = 20) {
 }
 
 test("all three gates can nominate only supervised reversible autonomy", () => {
-  const decision = buildPromotionDecision({
-    readinessInput: strongReadinessInput(),
-    liveValidationInput: strongLiveInput(),
-    shadowRecords: strongHistory(),
-  });
-
+  const decision = buildPromotionDecision({ readinessInput: strongReadinessInput(), liveValidationInput: strongLiveInput(), shadowRecords: strongHistory() });
   assert.equal(decision.promotion_ready, true);
   assert.equal(decision.autonomy_class, "supervised_reversible_candidate");
-  assert.deepEqual(decision.gates, {
-    readiness: true,
-    live_validation: true,
-    shadow_history: true,
-  });
+  assert.deepEqual(decision.gates, { readiness: true, live_validation: true, shadow_history: true });
   assert.equal(decision.internal_reversible_candidate, true);
   assert.equal(decision.external_write_authorized, false);
   assert.equal(decision.spend_authorized, false);
@@ -80,12 +54,7 @@ test("all three gates can nominate only supervised reversible autonomy", () => {
 test("high readiness score cannot override missing live validation", () => {
   const live = strongLiveInput();
   live.meta.preflight_ready = false;
-  const decision = buildPromotionDecision({
-    readinessInput: strongReadinessInput(),
-    liveValidationInput: live,
-    shadowRecords: strongHistory(),
-  });
-
+  const decision = buildPromotionDecision({ readinessInput: strongReadinessInput(), liveValidationInput: live, shadowRecords: strongHistory() });
   assert.equal(decision.gates.readiness, true);
   assert.equal(decision.gates.shadow_history, true);
   assert.equal(decision.gates.live_validation, false);
@@ -95,12 +64,7 @@ test("high readiness score cannot override missing live validation", () => {
 });
 
 test("live validation cannot override insufficient Shadow history", () => {
-  const decision = buildPromotionDecision({
-    readinessInput: strongReadinessInput(),
-    liveValidationInput: strongLiveInput(),
-    shadowRecords: [],
-  });
-
+  const decision = buildPromotionDecision({ readinessInput: strongReadinessInput(), liveValidationInput: strongLiveInput(), shadowRecords: [] });
   assert.equal(decision.gates.readiness, true);
   assert.equal(decision.gates.live_validation, true);
   assert.equal(decision.gates.shadow_history, false);
@@ -112,12 +76,7 @@ test("live validation cannot override insufficient Shadow history", () => {
 test("one safety violation blocks promotion regardless of otherwise strong history", () => {
   const history = strongHistory();
   history[0].safety_violation = true;
-  const decision = buildPromotionDecision({
-    readinessInput: strongReadinessInput(),
-    liveValidationInput: strongLiveInput(),
-    shadowRecords: history,
-  });
-
+  const decision = buildPromotionDecision({ readinessInput: strongReadinessInput(), liveValidationInput: strongLiveInput(), shadowRecords: history });
   assert.equal(decision.promotion_ready, false);
   assert.ok(decision.blockers.includes("history:safety_violation_history"));
   assert.equal(decision.external_write_authorized, false);
@@ -126,12 +85,7 @@ test("one safety violation blocks promotion regardless of otherwise strong histo
 test("weak architecture readiness blocks promotion even with perfect live/history evidence", () => {
   const readiness = strongReadinessInput();
   readiness.safety.kill_switch_enforced = false;
-  const decision = buildPromotionDecision({
-    readinessInput: readiness,
-    liveValidationInput: strongLiveInput(),
-    shadowRecords: strongHistory(),
-  });
-
+  const decision = buildPromotionDecision({ readinessInput: readiness, liveValidationInput: strongLiveInput(), shadowRecords: strongHistory() });
   assert.equal(decision.promotion_ready, false);
   assert.ok(decision.blockers.includes("readiness:kill_switch_not_enforced"));
   assert.equal(decision.autonomy_class, "observe_and_propose");

--- a/test/promotion-status.test.js
+++ b/test/promotion-status.test.js
@@ -6,19 +6,8 @@ function healthyShadow() {
   const collectedAt = new Date().toISOString();
   return {
     generated_at: collectedAt,
-    data_quality: {
-      channel_ready: { google: true, meta: true },
-      sources: {
-        google: { state: "fresh" },
-        ga4: { state: "fresh" },
-        meta: { state: "fresh" },
-      },
-    },
-    live_sources: {
-      google: { access_ok: true, configuration_complete: true },
-      ga4: { access_ok: true, configuration_complete: true },
-      meta: { access_ok: true, configuration_complete: true },
-    },
+    data_quality: { channel_ready: { google: true, meta: true }, sources: { google: { state: "fresh" }, ga4: { state: "fresh" }, meta: { state: "fresh" } } },
+    live_sources: { google: { access_ok: true, configuration_complete: true }, ga4: { access_ok: true, configuration_complete: true }, meta: { access_ok: true, configuration_complete: true } },
     conversion_integrity: { status: "healthy", optimization_allowed: true },
   };
 }
@@ -26,6 +15,7 @@ function healthyShadow() {
 function goodHistory() {
   return Array.from({ length: 20 }, (_, index) => ({
     id: `r-${index}`,
+    evidence_kind: "forecast_observation",
     before: 1,
     after: 2,
     outcome: "observed",
@@ -44,14 +34,7 @@ test("source freshness requires all three live sources", () => {
 });
 
 test("runtime status fails closed when build validation and history are missing", () => {
-  const status = buildSanitizedPromotionStatus({
-    shadowResult: healthyShadow(),
-    metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
-    buildValidated: false,
-    shadowRecords: [],
-    historyDurable: false,
-    historyHealthy: true,
-  });
+  const status = buildSanitizedPromotionStatus({ shadowResult: healthyShadow(), metaPreflightState: { result: { read_only_ready: true, write_ready: false } }, buildValidated: false, shadowRecords: [], historyDurable: false, historyHealthy: true });
   assert.equal(status.promotion_ready, false);
   assert.equal(status.autonomy_class, "observe_and_propose");
   assert.ok(status.blockers.includes("readiness:regression_suite_not_verified"));
@@ -62,14 +45,7 @@ test("runtime status fails closed when build validation and history are missing"
 });
 
 test("missing Meta read preflight remains an independent live blocker", () => {
-  const status = buildSanitizedPromotionStatus({
-    shadowResult: healthyShadow(),
-    metaPreflightState: { result: { read_only_ready: false, write_ready: false } },
-    buildValidated: true,
-    shadowRecords: goodHistory(),
-    historyDurable: true,
-    historyHealthy: true,
-  });
+  const status = buildSanitizedPromotionStatus({ shadowResult: healthyShadow(), metaPreflightState: { result: { read_only_ready: false, write_ready: false } }, buildValidated: true, shadowRecords: goodHistory(), historyDurable: true, historyHealthy: true });
   assert.equal(status.gates.readiness, true);
   assert.equal(status.gates.live_validation, false);
   assert.ok(status.blockers.includes("live:meta_preflight_ready"));
@@ -77,14 +53,7 @@ test("missing Meta read preflight remains an independent live blocker", () => {
 });
 
 test("ephemeral history blocks promotion even when all other evidence is green", () => {
-  const status = buildSanitizedPromotionStatus({
-    shadowResult: healthyShadow(),
-    metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
-    buildValidated: true,
-    shadowRecords: goodHistory(),
-    historyDurable: false,
-    historyHealthy: true,
-  });
+  const status = buildSanitizedPromotionStatus({ shadowResult: healthyShadow(), metaPreflightState: { result: { read_only_ready: true, write_ready: false } }, buildValidated: true, shadowRecords: goodHistory(), historyDurable: false, historyHealthy: true });
   assert.equal(status.gates.readiness, true);
   assert.equal(status.gates.live_validation, true);
   assert.equal(status.gates.shadow_history, true);
@@ -95,14 +64,7 @@ test("ephemeral history blocks promotion even when all other evidence is green",
 });
 
 test("corrupt or unhealthy history blocks promotion independently of durability", () => {
-  const status = buildSanitizedPromotionStatus({
-    shadowResult: healthyShadow(),
-    metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
-    buildValidated: true,
-    shadowRecords: goodHistory(),
-    historyDurable: true,
-    historyHealthy: false,
-  });
+  const status = buildSanitizedPromotionStatus({ shadowResult: healthyShadow(), metaPreflightState: { result: { read_only_ready: true, write_ready: false } }, buildValidated: true, shadowRecords: goodHistory(), historyDurable: true, historyHealthy: false });
   assert.equal(status.gates.shadow_history, true);
   assert.equal(status.gates.history_storage, false);
   assert.ok(status.blockers.includes("history:storage_unhealthy"));
@@ -111,14 +73,7 @@ test("corrupt or unhealthy history blocks promotion independently of durability"
 });
 
 test("even fully green durable healthy evidence cannot authorize external execution", () => {
-  const status = buildSanitizedPromotionStatus({
-    shadowResult: healthyShadow(),
-    metaPreflightState: { result: { read_only_ready: true, write_ready: false } },
-    buildValidated: true,
-    shadowRecords: goodHistory(),
-    historyDurable: true,
-    historyHealthy: true,
-  });
+  const status = buildSanitizedPromotionStatus({ shadowResult: healthyShadow(), metaPreflightState: { result: { read_only_ready: true, write_ready: false } }, buildValidated: true, shadowRecords: goodHistory(), historyDurable: true, historyHealthy: true });
   assert.equal(status.promotion_ready, true);
   assert.equal(status.autonomy_class, "supervised_reversible_candidate");
   assert.equal(status.external_write_authorized, false);

--- a/test/shadow-evaluation.test.js
+++ b/test/shadow-evaluation.test.js
@@ -1,24 +1,27 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-const { summarizeShadowHistory, promotionAssessment, allowedAutonomyClass } = require('../shadow-evaluation');
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { evaluateRecommendation, summarizeShadowHistory, promotionAssessment, allowedAutonomyClass } = require("../shadow-evaluation");
 
 function successfulHistory(count = 20) {
   return Array.from({ length: count }, (_, index) => ({
     id: String(index),
+    evidence_kind: "forecast_observation",
     before: 1,
     after: 2,
     outcome: 2,
-    expected_direction: 'up',
-    data_quality: 'high',
-    attribution_confidence: 'high',
+    expected_direction: "up",
+    data_quality: "high",
+    attribution_confidence: "high",
     safety_violation: false,
   }));
 }
 
-test('history summary calculates precision and false-positive rate', () => {
-  const records = successfulHistory(19).concat([{ before: 2, after: 1, outcome: 1, expected_direction: 'up', data_quality: 'high', attribution_confidence: 'high' }]);
+test("history summary calculates precision only from explicitly classified evidence", () => {
+  const records = successfulHistory(19).concat([{ evidence_kind: "forecast_observation", before: 2, after: 1, outcome: 1, expected_direction: "up", data_quality: "high", attribution_confidence: "high" }]);
   const summary = summarizeShadowHistory(records);
   assert.equal(summary.evaluable_decisions, 20);
+  assert.equal(summary.forecast_evaluations, 20);
+  assert.equal(summary.verified_action_outcomes, 0);
   assert.equal(summary.correct_decisions, 19);
   assert.equal(summary.false_positives, 1);
   assert.equal(summary.precision, 0.95);
@@ -26,27 +29,39 @@ test('history summary calculates precision and false-positive rate', () => {
   assert.equal(summary.writes_allowed, false);
 });
 
-test('promotion remains blocked on insufficient history', () => {
-  const assessment = promotionAssessment(summarizeShadowHistory(successfulHistory(5)));
-  assert.equal(assessment.candidate_for_supervised_low_risk, false);
-  assert.ok(assessment.blockers.includes('insufficient_shadow_runs'));
-  assert.equal(allowedAutonomyClass(assessment), 'observe_and_propose');
+test("legacy or unclassified before-after records cannot inflate readiness", () => {
+  const evaluation = evaluateRecommendation({ before: 1, after: 2, outcome: 2, expected_direction: "up" });
+  assert.equal(evaluation.evaluable, false);
+  assert.equal(evaluation.evidence_kind, "unclassified");
 });
 
-test('promotion candidate still cannot authorize spend, new campaigns or activation', () => {
+test("verified action outcomes require explicit external execution verification", () => {
+  const record = { evidence_kind: "verified_action_outcome", before: 1, after: 2, outcome: 2, expected_direction: "up" };
+  assert.equal(evaluateRecommendation(record).evaluable, false);
+  assert.equal(evaluateRecommendation({ ...record, external_execution_verified: true }).evaluable, true);
+});
+
+test("promotion remains blocked on insufficient history", () => {
+  const assessment = promotionAssessment(summarizeShadowHistory(successfulHistory(5)));
+  assert.equal(assessment.candidate_for_supervised_low_risk, false);
+  assert.ok(assessment.blockers.includes("insufficient_shadow_runs"));
+  assert.equal(allowedAutonomyClass(assessment), "observe_and_propose");
+});
+
+test("promotion candidate still cannot authorize spend, new campaigns or activation", () => {
   const assessment = promotionAssessment(summarizeShadowHistory(successfulHistory(20)));
   assert.equal(assessment.candidate_for_supervised_low_risk, true);
   assert.equal(assessment.spend_changes_authorized, false);
   assert.equal(assessment.new_campaigns_authorized, false);
   assert.equal(assessment.activation_authorized, false);
   assert.equal(assessment.writes_allowed, false);
-  assert.equal(allowedAutonomyClass(assessment), 'supervised_reversible_candidate');
+  assert.equal(allowedAutonomyClass(assessment), "supervised_reversible_candidate");
 });
 
-test('any safety violation blocks promotion', () => {
+test("any safety violation blocks promotion", () => {
   const records = successfulHistory(20);
   records[0].safety_violation = true;
   const assessment = promotionAssessment(summarizeShadowHistory(records));
   assert.equal(assessment.candidate_for_supervised_low_risk, false);
-  assert.ok(assessment.blockers.includes('safety_violation_history'));
+  assert.ok(assessment.blockers.includes("safety_violation_history"));
 });


### PR DESCRIPTION
Prevents ordinary correlations or legacy before/after fields from being counted as evidence of decision quality. Only explicitly classified forecast observations are evaluable as forecasts; action-outcome records additionally require explicit external execution verification. Current live Shadow history remains non-evaluable, so this cannot inflate readiness. Safety violations remain evaluable failures. No ad writes, activation, delivery, budget or spend changes.