### PR TITLE
Expose fresh sanitized Google runtime blocker

### DIFF
--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -32,9 +32,10 @@ jobs:
             if [ "$code" = "200" ] && [ "$google" = "true" ]; then break; fi
             sleep 15
           done
-          safe_reason=$(printf '%s' "$reason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-32)
+          safe_reason=$(printf '%s' "$reason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-24)
           if [ "$code" = "200" ] && [ "$google" = "true" ]; then state="success"; description="Google live read access verified"; else state="failure"; description="Google live read blocked: ${safe_reason}"; fi
-          payload=$(jq -n --arg state "$state" --arg description "$description" '{state:$state,context:"google-live-access",description:$description}')
+          context="google-live-access:${safe_reason}"
+          payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')
           curl --fail-with-body -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
           echo "google=${google}; reason=${safe_reason}; http=${code}"
           if [ "$state" != "success" ]; then exit 1; fi


### PR DESCRIPTION
Diagnostic-only change: embeds the already-sanitized Google live blocker reason in the GitHub status context so current runtime failures can be distinguished without exposing secrets. No ad-platform writes or spend changes.