### PR TITLE
Add fail-closed GA4 funnel evidence gate

### DIFF
--- a/ga4-funnel-intelligence.js
+++ b/ga4-funnel-intelligence.js
@@ -59,6 +59,26 @@ function funnelCompleteness(funnel = {}, expectedEvents = []) {
   };
 }
 
+function buildFunnelEvidenceGate(funnel = {}, expectedEvents = []) {
+  const completeness = funnelCompleteness(funnel, expectedEvents);
+  const missingConfiguration = expectedEvents.filter((name) => !completeness.tracking[name]?.configured);
+  const missingObservation = expectedEvents.filter((name) => completeness.tracking[name]?.configured && !completeness.tracking[name]?.observed);
+  const blockers = [
+    ...missingConfiguration.map((name) => `event_not_configured:${name}`),
+    ...missingObservation.map((name) => `event_not_observed:${name}`),
+  ];
+  return {
+    ready: completeness.configuration_complete && completeness.observation_complete,
+    configuration_complete: completeness.configuration_complete,
+    observation_complete: completeness.observation_complete,
+    missing_configuration: missingConfiguration,
+    missing_observation: missingObservation,
+    blockers,
+    automation_safe: blockers.length === 0,
+    writes_allowed: false,
+  };
+}
+
 function safeRate(numerator, denominator) {
   const top = Number(numerator || 0);
   const bottom = Number(denominator || 0);
@@ -92,6 +112,7 @@ module.exports = {
   summarizeFunnel,
   funnelTrackingStatus,
   funnelCompleteness,
+  buildFunnelEvidenceGate,
   funnelRates,
   reconcileConversions,
 };

--- a/test/ga4-funnel-evidence-gate.test.js
+++ b/test/ga4-funnel-evidence-gate.test.js
@@ -1,0 +1,35 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {buildFunnelEvidenceGate,funnelRates}=require('../ga4-funnel-intelligence');
+const expected=['reservation_page_view','reservation_start','booking_completed'];
+
+test('gate is ready only when every required funnel event is configured and observed',()=>{
+ const funnel={event_names:expected,totals:{reservation_page_view:10,reservation_start:4,booking_completed:2}};
+ const gate=buildFunnelEvidenceGate(funnel,expected);
+ assert.equal(gate.ready,true);
+ assert.equal(gate.automation_safe,true);
+ assert.deepEqual(gate.blockers,[]);
+ assert.equal(gate.writes_allowed,false);
+});
+
+test('configured but unobserved events block automation with explicit evidence reasons',()=>{
+ const funnel={event_names:expected,totals:{reservation_page_view:0,reservation_start:0,booking_completed:2}};
+ const gate=buildFunnelEvidenceGate(funnel,expected);
+ assert.equal(gate.ready,false);
+ assert.equal(gate.configuration_complete,true);
+ assert.equal(gate.observation_complete,false);
+ assert.deepEqual(gate.missing_observation,['reservation_page_view','reservation_start']);
+ assert.deepEqual(gate.blockers,['event_not_observed:reservation_page_view','event_not_observed:reservation_start']);
+ assert.equal(gate.automation_safe,false);
+});
+
+test('missing configuration is distinct from missing observation',()=>{
+ const funnel={event_names:['booking_completed'],totals:{booking_completed:1}};
+ const gate=buildFunnelEvidenceGate(funnel,expected);
+ assert.deepEqual(gate.missing_configuration,['reservation_page_view','reservation_start']);
+ assert.deepEqual(gate.missing_observation,[]);
+});
+
+test('rates remain null when denominators have not been observed',()=>{
+ assert.deepEqual(funnelRates({totals:{reservation_page_view:0,reservation_start:0,booking_completed:2}}),{page_to_start:null,start_to_booking:null,page_to_booking:null});
+});


### PR DESCRIPTION
Superseded by #124, rebased on the current main after the live-pulse and root-cause diagnostics work.