### PR TITLE
Diagnose Google under-delivery and GA4 booking quality

### DIFF
--- a/.github/workflows/live-pulse-runtime.yml
+++ b/.github/workflows/live-pulse-runtime.yml
@@ -38,22 +38,28 @@ jobs:
           tgc=$(jq -r '.today.google.totals.clicks // 0' pulse.json)
           tgcv=$(jq -r '.today.google.totals.conversions // 0' pulse.json)
           tga=$(jq -r '.today.google.active_campaigns // 0' pulse.json)
+          glb=$(jq -r '.today.google.delivery_diagnostics.limited_by_budget // 0' pulse.json)
+          glr=$(jq -r '.today.google.delivery_diagnostics.high_rank_loss // 0' pulse.json)
+          gls=$(jq -r '.today.google.delivery_diagnostics.not_eligible_or_limited // 0' pulse.json)
           tmsp=$(jq -r '.today.meta.totals.spend_eur // 0' pulse.json)
           tmi=$(jq -r '.today.meta.totals.impressions // 0' pulse.json)
           tmc=$(jq -r '.today.meta.totals.clicks // 0' pulse.json)
           tma=$(jq -r '.today.meta.active_campaigns // 0' pulse.json)
           tb=$(jq -r '.today.ga4.booking_completed // 0' pulse.json)
+          bpu=$(jq -r '.today.ga4.booking_quality.events_per_user // 0' pulse.json)
+          busers=$(jq -r '.today.ga4.booking_quality.users // 0' pulse.json)
           g7=$(jq -r '.last_7d.google.totals.spend_eur // 0' pulse.json)
           m7=$(jq -r '.last_7d.meta.totals.spend_eur // 0' pulse.json)
           b7=$(jq -r '.last_7d.ga4.booking_completed // 0' pulse.json)
           delivering=$(jq -r '.today.signals.ads_delivering // false' pulse.json)
           traffic=$(jq -r '.today.signals.traffic_present // false' pulse.json)
           bookings=$(jq -r '.today.signals.bookings_present // false' pulse.json)
+          dup=$(jq -r '.today.signals.booking_event_duplication_risk // false' pulse.json)
           writes=$(jq -r 'if has("writes_allowed") then .writes_allowed else true end' pulse.json)
 
           if [ "$writes" = "false" ]; then state="success"; else state="failure"; fi
-          context="live-pulse:g=${tga}:m=${tma}:del=${delivering}:traf=${traffic}:book=${bookings}"
-          description="today g€${tgsp} i${tgi} c${tgc} cv${tgcv}; m€${tmsp} i${tmi} c${tmc}; b${tb}; 7d g€${g7} m€${m7} b${b7}"
+          context="pulse:g=${tga}:m=${tma}:lb=${glb}:lr=${glr}:ls=${gls}:dup=${dup}"
+          description="g€${tgsp} i${tgi} c${tgc} cv${tgcv}; Gdiag b${glb}/r${glr}/s${gls}; m€${tmsp} i${tmi} c${tmc}; b${tb}/u${busers}/epu${bpu}; 7d g€${g7} m€${m7} b${b7}"
           description=$(printf '%s' "$description" | cut -c1-140)
           context=$(printf '%s' "$context" | cut -c1-100)
           payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')

--- a/ga4-shadow-data.js
+++ b/ga4-shadow-data.js
@@ -10,134 +10,81 @@ const {
 const DEFAULT_FUNNEL_EVENTS = ["reservation_page_view", "reservation_start", "booking_completed"];
 
 function ga4Configured(env = process.env) {
-  return Boolean(
-    env.GA4_PROPERTY_ID &&
-    env.GOOGLE_CLIENT_ID &&
-    env.GOOGLE_CLIENT_SECRET &&
-    env.GOOGLE_REFRESH_TOKEN
-  );
+  return Boolean(env.GA4_PROPERTY_ID && env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET && env.GOOGLE_REFRESH_TOKEN);
 }
 
 function sanitizeGoogleError(error, fallback) {
-  return (
-    error?.response?.data?.error_description ||
-    error?.response?.data?.error?.message ||
-    error?.response?.data?.error ||
-    error?.message ||
-    fallback
-  );
+  return error?.response?.data?.error_description || error?.response?.data?.error?.message || error?.response?.data?.error || error?.message || fallback;
 }
 
 async function getGoogleAccessToken(env = process.env) {
-  const body = new URLSearchParams({
-    client_id: env.GOOGLE_CLIENT_ID,
-    client_secret: env.GOOGLE_CLIENT_SECRET,
-    refresh_token: env.GOOGLE_REFRESH_TOKEN,
-    grant_type: "refresh_token",
-  });
-  const response = await axios.post("https://oauth2.googleapis.com/token", body, {
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    timeout: 20000,
-  });
+  const body = new URLSearchParams({ client_id:env.GOOGLE_CLIENT_ID, client_secret:env.GOOGLE_CLIENT_SECRET, refresh_token:env.GOOGLE_REFRESH_TOKEN, grant_type:"refresh_token" });
+  const response = await axios.post("https://oauth2.googleapis.com/token", body, { headers:{"content-type":"application/x-www-form-urlencoded"}, timeout:20000 });
   return response.data.access_token;
 }
 
 function parseGa4Date(value) {
-  const text = String(value || "");
-  if (!/^\d{8}$/.test(text)) return null;
+  const text=String(value||"");
+  if(!/^\d{8}$/.test(text))return null;
   return `${text.slice(0,4)}-${text.slice(4,6)}-${text.slice(6,8)}T12:00:00.000Z`;
 }
 
-async function runBookingReport({ accessToken, propertyId, start, end, googleCpcOnly = false }) {
-  const filters = [
-    { filter: { fieldName: "eventName", stringFilter: { matchType: "EXACT", value: "booking_completed" } } },
-  ];
-  if (googleCpcOnly) {
-    filters.push(
-      { filter: { fieldName: "sessionSource", stringFilter: { matchType: "EXACT", value: "google", caseSensitive: false } } },
-      { filter: { fieldName: "sessionMedium", stringFilter: { matchType: "EXACT", value: "cpc", caseSensitive: false } } }
-    );
+function bookingFilters(googleCpcOnly=false){
+  const filters=[{filter:{fieldName:"eventName",stringFilter:{matchType:"EXACT",value:"booking_completed"}}}];
+  if(googleCpcOnly){
+    filters.push({filter:{fieldName:"sessionSource",stringFilter:{matchType:"EXACT",value:"google",caseSensitive:false}}},{filter:{fieldName:"sessionMedium",stringFilter:{matchType:"EXACT",value:"cpc",caseSensitive:false}}});
   }
-  const body = {
-    dateRanges: [{ startDate: start, endDate: end }],
-    dimensions: [{ name: "date" }],
-    metrics: [{ name: "eventCount" }],
-    dimensionFilter: { andGroup: { expressions: filters } },
-    orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" }, desc: true }],
-    limit: "1000",
+  return filters;
+}
+
+async function runBookingReport({ accessToken, propertyId, start, end, googleCpcOnly = false }) {
+  const body={dateRanges:[{startDate:start,endDate:end}],dimensions:[{name:"date"}],metrics:[{name:"eventCount"}],dimensionFilter:{andGroup:{expressions:bookingFilters(googleCpcOnly)}},orderBys:[{dimension:{dimensionName:"date",orderType:"ALPHANUMERIC"},desc:true}],limit:"1000"};
+  const response=await axios.post(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,body,{headers:{authorization:`Bearer ${accessToken}`},timeout:20000});
+  const rows=response.data.rows||[];
+  const total=rows.reduce((sum,row)=>sum+Number(row.metricValues?.[0]?.value||0),0);
+  const latest=rows.find((row)=>Number(row.metricValues?.[0]?.value||0)>0);
+  return {event_count:total,last_seen_at:latest?parseGa4Date(latest.dimensionValues?.[0]?.value):null};
+}
+
+async function runBookingQualityReport({accessToken,propertyId,start,end}){
+  const body={
+    dateRanges:[{startDate:start,endDate:end}],
+    metrics:[{name:"eventCount"},{name:"totalUsers"},{name:"sessions"}],
+    dimensionFilter:{andGroup:{expressions:bookingFilters(false)}},
   };
-  const response = await axios.post(
-    `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
-    body,
-    { headers: { authorization: `Bearer ${accessToken}` }, timeout: 20000 }
-  );
-  const rows = response.data.rows || [];
-  const total = rows.reduce((sum, row) => sum + Number(row.metricValues?.[0]?.value || 0), 0);
-  const latest = rows.find((row) => Number(row.metricValues?.[0]?.value || 0) > 0);
+  const response=await axios.post(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,body,{headers:{authorization:`Bearer ${accessToken}`},timeout:20000});
+  const row=(response.data.rows||[])[0];
+  const eventCount=Number(row?.metricValues?.[0]?.value||0);
+  const users=Number(row?.metricValues?.[1]?.value||0);
+  const sessions=Number(row?.metricValues?.[2]?.value||0);
   return {
-    event_count: total,
-    last_seen_at: latest ? parseGa4Date(latest.dimensionValues?.[0]?.value) : null,
+    event_count:eventCount,
+    users,
+    sessions,
+    events_per_user:users>0?Math.round((eventCount/users)*100)/100:null,
+    events_per_session:sessions>0?Math.round((eventCount/sessions)*100)/100:null,
+    duplication_risk:users>0&&eventCount/users>1.5,
   };
 }
 
 async function collectGa4ShadowData({ env = process.env, days = 30, now = new Date(), startDate = null, endDate = null } = {}) {
-  const collectedAt = now.toISOString();
-  if (!ga4Configured(env)) {
-    return {
-      access_ok: false,
-      configuration_complete: false,
-      collected_at: collectedAt,
-      error: "ga4_configuration_incomplete",
-      required_variable: "GA4_PROPERTY_ID",
-      total_booking_completed: null,
-      google_cpc_booking_completed: null,
-      last_seen_at: null,
-      funnel: null,
-    };
-  }
-  const fallback = getDateRange(days, now);
-  const start = startDate || fallback.start;
-  const end = endDate || fallback.end;
-  try {
-    const accessToken = await getGoogleAccessToken(env);
-    const eventNames = String(env.GA4_FUNNEL_EVENTS || DEFAULT_FUNNEL_EVENTS.join(","))
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean);
-    const [allBookings, googleCpcBookings, funnelRows] = await Promise.all([
-      runBookingReport({ accessToken, propertyId: env.GA4_PROPERTY_ID, start, end, googleCpcOnly: false }),
-      runBookingReport({ accessToken, propertyId: env.GA4_PROPERTY_ID, start, end, googleCpcOnly: true }),
-      runFunnelReport({ accessToken, propertyId: env.GA4_PROPERTY_ID, start, end, eventNames }),
+  const collectedAt=now.toISOString();
+  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,funnel:null};
+  const fallback=getDateRange(days,now); const start=startDate||fallback.start; const end=endDate||fallback.end;
+  try{
+    const accessToken=await getGoogleAccessToken(env);
+    const eventNames=String(env.GA4_FUNNEL_EVENTS||DEFAULT_FUNNEL_EVENTS.join(",")).split(",").map((value)=>value.trim()).filter(Boolean);
+    const [allBookings,googleCpcBookings,bookingQuality,funnelRows]=await Promise.all([
+      runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:false}),
+      runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:true}),
+      runBookingQualityReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
+      runFunnelReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,eventNames}),
     ]);
-    const summarized = summarizeFunnel(funnelRows, eventNames);
-    const funnel = { event_names: eventNames, ...summarized };
-    return {
-      access_ok: true,
-      configuration_complete: true,
-      collected_at: collectedAt,
-      period: { start, end },
-      event_name: "booking_completed",
-      total_booking_completed: allBookings.event_count,
-      google_cpc_booking_completed: googleCpcBookings.event_count,
-      last_seen_at: googleCpcBookings.last_seen_at || allBookings.last_seen_at,
-      funnel: {
-        ...funnel,
-        completeness: funnelCompleteness(funnel, DEFAULT_FUNNEL_EVENTS),
-        rates: funnelRates(funnel),
-      },
-    };
-  } catch (error) {
-    return {
-      access_ok: false,
-      configuration_complete: true,
-      collected_at: collectedAt,
-      error: sanitizeGoogleError(error, "ga4_read_failed"),
-      total_booking_completed: null,
-      google_cpc_booking_completed: null,
-      last_seen_at: null,
-      funnel: null,
-    };
+    const summarized=summarizeFunnel(funnelRows,eventNames); const funnel={event_names:eventNames,...summarized};
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)}};
+  }catch(error){
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,funnel:null};
   }
 }
 
-module.exports = { ga4Configured, collectGa4ShadowData, parseGa4Date, DEFAULT_FUNNEL_EVENTS };
+module.exports={ga4Configured,collectGa4ShadowData,parseGa4Date,runBookingQualityReport,DEFAULT_FUNNEL_EVENTS};

--- a/live-shadow-data.js
+++ b/live-shadow-data.js
@@ -50,6 +50,11 @@ function cleanGoogleDiagnostic(error) {
 function sanitizeMetaIssues(issues) { if (!Array.isArray(issues)) return []; return issues.slice(0,20).map((issue)=>({ level:String(issue?.level||"unknown").slice(0,40), code:issue?.error_code == null ? null : String(issue.error_code).slice(0,40), summary:String(issue?.error_summary||issue?.title||"meta_delivery_issue").replace(/[\r\n\t]+/g," ").slice(0,180), message:String(issue?.error_message||issue?.message||"").replace(/[\r\n\t]+/g," ").slice(0,300) })); }
 function buildGoogleCustomer(env) { const client=new GoogleAdsApi({client_id:env.GOOGLE_CLIENT_ID,client_secret:env.GOOGLE_CLIENT_SECRET,developer_token:env.GOOGLE_DEVELOPER_TOKEN}); return client.Customer({customer_id:normalizeGoogleCustomerId(env.GOOGLE_CUSTOMER_ID),refresh_token:env.GOOGLE_REFRESH_TOKEN,...(env.GOOGLE_LOGIN_CUSTOMER_ID?{login_customer_id:normalizeGoogleCustomerId(env.GOOGLE_LOGIN_CUSTOMER_ID)}:{})}); }
 
+function normalizePrimaryStatusReasons(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item)).slice(0, 8);
+}
+
 async function collectGoogleShadowData({env=process.env,days=30,now=new Date(),startDate=null,endDate=null,includeSearchIntelligence=true}={}) {
   const collectedAt = now.toISOString();
   if(!googleConfigured(env)) return {access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"google_configuration_incomplete",campaigns:[],totals:null,search_terms:[],keywords:[],search_intelligence_ok:false};
@@ -58,8 +63,18 @@ async function collectGoogleShadowData({env=process.env,days=30,now=new Date(),s
   const start=startDate||fallback.start;
   const end=endDate||fallback.end;
   try {
-    const rows=await customer.query(`SELECT campaign.id, campaign.name, campaign.status, campaign.advertising_channel_type, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.average_cpc, metrics.conversions, metrics.conversions_value FROM campaign WHERE campaign.status != 'REMOVED' AND segments.date BETWEEN '${start}' AND '${end}'`);
-    const campaigns=(rows||[]).map(row=>({campaign_id:String(row.campaign.id),campaign_name:row.campaign.name,status:row.campaign.status,channel_type:row.campaign.advertising_channel_type,impressions:Number(row.metrics.impressions||0),clicks:Number(row.metrics.clicks||0),cost_eur:Number(row.metrics.cost_micros||0)/1_000_000,average_cpc_eur:Number(row.metrics.average_cpc||0)/1_000_000,conversions:Number(row.metrics.conversions||0),conversion_value:Number(row.metrics.conversions_value||0)}));
+    const rows=await customer.query(`SELECT campaign.id, campaign.name, campaign.status, campaign.primary_status, campaign.primary_status_reasons, campaign.advertising_channel_type, campaign.bidding_strategy_type, campaign_budget.amount_micros, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.average_cpc, metrics.conversions, metrics.conversions_value, metrics.search_impression_share, metrics.search_budget_lost_impression_share, metrics.search_rank_lost_impression_share FROM campaign WHERE campaign.status != 'REMOVED' AND segments.date BETWEEN '${start}' AND '${end}'`);
+    const campaigns=(rows||[]).map(row=>({
+      campaign_id:String(row.campaign.id),campaign_name:row.campaign.name,status:row.campaign.status,
+      primary_status:row.campaign.primary_status||null,primary_status_reasons:normalizePrimaryStatusReasons(row.campaign.primary_status_reasons),
+      channel_type:row.campaign.advertising_channel_type,bidding_strategy_type:row.campaign.bidding_strategy_type||null,
+      daily_budget_eur:Number(row.campaign_budget?.amount_micros||0)/1_000_000,
+      impressions:Number(row.metrics.impressions||0),clicks:Number(row.metrics.clicks||0),cost_eur:Number(row.metrics.cost_micros||0)/1_000_000,
+      average_cpc_eur:Number(row.metrics.average_cpc||0)/1_000_000,conversions:Number(row.metrics.conversions||0),conversion_value:Number(row.metrics.conversions_value||0),
+      search_impression_share:row.metrics.search_impression_share==null?null:Number(row.metrics.search_impression_share),
+      search_budget_lost_impression_share:row.metrics.search_budget_lost_impression_share==null?null:Number(row.metrics.search_budget_lost_impression_share),
+      search_rank_lost_impression_share:row.metrics.search_rank_lost_impression_share==null?null:Number(row.metrics.search_rank_lost_impression_share),
+    }));
     const totals=campaigns.reduce((a,r)=>({impressions:a.impressions+r.impressions,clicks:a.clicks+r.clicks,spend_eur:a.spend_eur+r.cost_eur,conversions:a.conversions+r.conversions}),{impressions:0,clicks:0,spend_eur:0,conversions:0});
     totals.cpc_eur=totals.clicks?totals.spend_eur/totals.clicks:0;
     let searchTerms=[];let keywords=[];let searchIntelligenceOk=false;let searchIntelligenceDiagnostic=null;
@@ -131,4 +146,4 @@ async function collectLiveShadowInput({env=process.env,days=30,now=new Date()}={
   };
 }
 
-module.exports={collectGoogleShadowData,collectMetaPages,collectMetaShadowData,collectLiveShadowInput,getDateRange,googleConfigured,metaConfigured,flattenGoogleErrorCode,googleDiagnosticReason,cleanGoogleDiagnostic,sanitizeMetaIssues};
+module.exports={collectGoogleShadowData,collectMetaPages,collectMetaShadowData,collectLiveShadowInput,getDateRange,googleConfigured,metaConfigured,flattenGoogleErrorCode,googleDiagnosticReason,cleanGoogleDiagnostic,sanitizeMetaIssues,normalizePrimaryStatusReasons};

--- a/operational-live-pulse.js
+++ b/operational-live-pulse.js
@@ -3,177 +3,77 @@ const { collectGa4ShadowData } = require('./ga4-shadow-data');
 const { assertPublicPayloadSafe } = require('./public-output-safety');
 
 function berlinDate(date = new Date()) {
-  const parts = new Intl.DateTimeFormat('en-GB', {
-    timeZone: 'Europe/Berlin', year: 'numeric', month: '2-digit', day: '2-digit'
-  }).formatToParts(date);
+  const parts = new Intl.DateTimeFormat('en-GB', { timeZone:'Europe/Berlin', year:'numeric', month:'2-digit', day:'2-digit' }).formatToParts(date);
   const map = Object.fromEntries(parts.map((part) => [part.type, part.value]));
   return `${map.year}-${map.month}-${map.day}`;
 }
-
-function shiftDays(date, days) {
-  return new Date(date.getTime() + days * 86400000);
-}
-
-function round(value, decimals = 2) {
-  const factor = 10 ** decimals;
-  return Math.round((Number(value || 0) + Number.EPSILON) * factor) / factor;
-}
+function shiftDays(date, days) { return new Date(date.getTime() + days * 86400000); }
+function round(value, decimals = 2) { const factor=10**decimals; return Math.round((Number(value||0)+Number.EPSILON)*factor)/factor; }
 
 function sanitizeGoogleCampaign(campaign = {}) {
   return {
     name: campaign.campaign_name || null,
     status: campaign.status || null,
+    primary_status: campaign.primary_status || null,
+    primary_status_reasons: Array.isArray(campaign.primary_status_reasons) ? campaign.primary_status_reasons.slice(0,8) : [],
     channel_type: campaign.channel_type || null,
+    bidding_strategy_type: campaign.bidding_strategy_type || null,
+    daily_budget_eur: round(campaign.daily_budget_eur),
     spend_eur: round(campaign.cost_eur),
     impressions: Number(campaign.impressions || 0),
     clicks: Number(campaign.clicks || 0),
-    ctr_percent: campaign.impressions ? round((Number(campaign.clicks || 0) / Number(campaign.impressions || 0)) * 100, 2) : 0,
-    cpc_eur: round(campaign.average_cpc_eur, 2),
-    conversions: round(campaign.conversions, 2),
+    ctr_percent: campaign.impressions ? round((Number(campaign.clicks||0)/Number(campaign.impressions||0))*100,2) : 0,
+    cpc_eur: round(campaign.average_cpc_eur,2),
+    conversions: round(campaign.conversions,2),
+    search_impression_share_percent: campaign.search_impression_share == null ? null : round(Number(campaign.search_impression_share)*100,1),
+    search_budget_lost_impression_share_percent: campaign.search_budget_lost_impression_share == null ? null : round(Number(campaign.search_budget_lost_impression_share)*100,1),
+    search_rank_lost_impression_share_percent: campaign.search_rank_lost_impression_share == null ? null : round(Number(campaign.search_rank_lost_impression_share)*100,1),
   };
 }
 
 function sanitizeMetaCampaign(campaign = {}) {
   const metrics = campaign.metrics || {};
-  return {
-    name: campaign.name || null,
-    delivery_status: campaign.delivery_status || null,
-    status: campaign.status || null,
-    spend_eur: round(metrics.spend_eur),
-    impressions: Number(metrics.impressions || 0),
-    reach: Number(metrics.reach || 0),
-    clicks: Number(metrics.clicks || 0),
-    ctr_percent: round(metrics.ctr_percent, 2),
-    cpc_eur: round(metrics.cpc_eur, 2),
-    cpm_eur: round(metrics.cpm_eur, 2),
-    frequency: round(metrics.frequency, 2),
-  };
+  return { name:campaign.name||null, delivery_status:campaign.delivery_status||null, status:campaign.status||null, spend_eur:round(metrics.spend_eur), impressions:Number(metrics.impressions||0), reach:Number(metrics.reach||0), clicks:Number(metrics.clicks||0), ctr_percent:round(metrics.ctr_percent,2), cpc_eur:round(metrics.cpc_eur,2), cpm_eur:round(metrics.cpm_eur,2), frequency:round(metrics.frequency,2) };
 }
 
 function summarizeGoogle(source = {}) {
-  const totals = source.totals || {};
-  const campaigns = (source.campaigns || []).map(sanitizeGoogleCampaign);
-  const active = campaigns.filter((campaign) => campaign.status === 'ENABLED' || campaign.status === 2);
+  const totals=source.totals||{};
+  const campaigns=(source.campaigns||[]).map(sanitizeGoogleCampaign);
+  const active=campaigns.filter((campaign)=>campaign.status==='ENABLED'||campaign.status===2);
+  const limitedByBudget=active.filter((campaign)=>campaign.primary_status_reasons.some((reason)=>/BUDGET/i.test(reason))).length;
+  const limitedByRank=active.filter((campaign)=>Number(campaign.search_rank_lost_impression_share_percent||0)>=20).length;
+  const notServing=active.filter((campaign)=>campaign.primary_status && !/ELIGIBLE/i.test(String(campaign.primary_status))).length;
   return {
-    access_ok: source.access_ok === true,
-    active_campaigns: active.length,
-    totals: {
-      spend_eur: round(totals.spend_eur),
-      impressions: Number(totals.impressions || 0),
-      clicks: Number(totals.clicks || 0),
-      ctr_percent: totals.impressions ? round((Number(totals.clicks || 0) / Number(totals.impressions || 0)) * 100, 2) : 0,
-      cpc_eur: round(totals.cpc_eur, 2),
-      conversions: round(totals.conversions, 2),
-      cost_per_conversion_eur: Number(totals.conversions || 0) > 0 ? round(Number(totals.spend_eur || 0) / Number(totals.conversions), 2) : null,
-    },
-    campaigns: active,
+    access_ok:source.access_ok===true,
+    active_campaigns:active.length,
+    delivery_diagnostics:{limited_by_budget:limitedByBudget,high_rank_loss:limitedByRank,not_eligible_or_limited:notServing},
+    totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),clicks:Number(totals.clicks||0),ctr_percent:totals.impressions?round((Number(totals.clicks||0)/Number(totals.impressions||0))*100,2):0,cpc_eur:round(totals.cpc_eur,2),conversions:round(totals.conversions,2),cost_per_conversion_eur:Number(totals.conversions||0)>0?round(Number(totals.spend_eur||0)/Number(totals.conversions),2):null},
+    campaigns:active,
   };
 }
 
 function summarizeMeta(source = {}) {
-  const overview = source.overview || {};
-  const totals = overview.totals || {};
-  const campaigns = (overview.campaigns || []).map(sanitizeMetaCampaign);
-  const active = campaigns.filter((campaign) => ['active','active_unverified'].includes(campaign.delivery_status));
-  return {
-    access_ok: source.access_ok === true,
-    active_campaigns: active.length,
-    campaign_counts: overview.campaign_counts || {},
-    totals: {
-      spend_eur: round(totals.spend_eur),
-      impressions: Number(totals.impressions || 0),
-      reach: Number(totals.reach_sum || 0),
-      clicks: Number(totals.clicks || 0),
-      ctr_percent: round(totals.ctr_percent, 2),
-      cpc_eur: round(totals.cpc_eur, 2),
-      cpm_eur: round(totals.cpm_eur, 2),
-    },
-    campaigns: active,
-  };
+  const overview=source.overview||{}; const totals=overview.totals||{}; const campaigns=(overview.campaigns||[]).map(sanitizeMetaCampaign); const active=campaigns.filter((campaign)=>['active','active_unverified'].includes(campaign.delivery_status));
+  return {access_ok:source.access_ok===true,active_campaigns:active.length,campaign_counts:overview.campaign_counts||{},totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),reach:Number(totals.reach_sum||0),clicks:Number(totals.clicks||0),ctr_percent:round(totals.ctr_percent,2),cpc_eur:round(totals.cpc_eur,2),cpm_eur:round(totals.cpm_eur,2)},campaigns:active};
 }
 
 function summarizeGa4(source = {}) {
-  const funnel = source.funnel || {};
-  const totals = funnel.totals || {};
-  return {
-    access_ok: source.access_ok === true,
-    booking_completed: Number(source.total_booking_completed || 0),
-    google_cpc_booking_completed: Number(source.google_cpc_booking_completed || 0),
-    funnel: {
-      reservation_page_view: Number(totals.reservation_page_view || 0),
-      reservation_start: Number(totals.reservation_start || 0),
-      booking_completed: Number(totals.booking_completed || 0),
-      rates: funnel.rates || { page_to_start: null, start_to_booking: null, page_to_booking: null },
-      configuration_complete: funnel.completeness?.configuration_complete === true,
-      observation_complete: funnel.completeness?.observation_complete === true,
-    },
-  };
+  const funnel=source.funnel||{}; const totals=funnel.totals||{};
+  return {access_ok:source.access_ok===true,booking_completed:Number(source.total_booking_completed||0),google_cpc_booking_completed:Number(source.google_cpc_booking_completed||0),booking_quality:source.booking_quality||null,funnel:{reservation_page_view:Number(totals.reservation_page_view||0),reservation_start:Number(totals.reservation_start||0),booking_completed:Number(totals.booking_completed||0),rates:funnel.rates||{page_to_start:null,start_to_booking:null,page_to_booking:null},configuration_complete:funnel.completeness?.configuration_complete===true,observation_complete:funnel.completeness?.observation_complete===true}};
 }
 
 function deriveSignals(period = {}) {
-  const google = period.google || {};
-  const meta = period.meta || {};
-  const ga4 = period.ga4 || {};
-  const adSpend = Number(google.totals?.spend_eur || 0) + Number(meta.totals?.spend_eur || 0);
-  const clicks = Number(google.totals?.clicks || 0) + Number(meta.totals?.clicks || 0);
-  const bookings = Number(ga4.booking_completed || 0);
-  return {
-    ads_delivering: adSpend > 0 || clicks > 0,
-    traffic_present: clicks > 0,
-    bookings_present: bookings > 0,
-    spend_without_bookings: adSpend > 0 && bookings === 0,
-    clicks_without_bookings: clicks > 0 && bookings === 0,
-    funnel_intermediate_events_observed: Number(ga4.funnel?.reservation_page_view || 0) > 0 && Number(ga4.funnel?.reservation_start || 0) > 0,
-  };
+  const google=period.google||{}; const meta=period.meta||{}; const ga4=period.ga4||{}; const adSpend=Number(google.totals?.spend_eur||0)+Number(meta.totals?.spend_eur||0); const clicks=Number(google.totals?.clicks||0)+Number(meta.totals?.clicks||0); const bookings=Number(ga4.booking_completed||0); const bookingEventsPerUser=Number(ga4.booking_quality?.events_per_user||0);
+  return {ads_delivering:adSpend>0||clicks>0,traffic_present:clicks>0,bookings_present:bookings>0,spend_without_bookings:adSpend>0&&bookings===0,clicks_without_bookings:clicks>0&&bookings===0,funnel_intermediate_events_observed:Number(ga4.funnel?.reservation_page_view||0)>0&&Number(ga4.funnel?.reservation_start||0)>0,booking_event_duplication_risk:bookingEventsPerUser>1.5,google_delivery_limited:Number(google.delivery_diagnostics?.limited_by_budget||0)>0||Number(google.delivery_diagnostics?.high_rank_loss||0)>0||Number(google.delivery_diagnostics?.not_eligible_or_limited||0)>0};
 }
 
-async function collectOperationalLivePulse({ env = process.env, now = new Date() } = {}) {
-  const today = berlinDate(now);
-  const sevenStart = berlinDate(shiftDays(now, -6));
-  const [googleToday, google7d, metaToday, meta7d, ga4Today, ga47d] = await Promise.all([
-    collectGoogleShadowData({ env, now, startDate: today, endDate: today, includeSearchIntelligence: false }),
-    collectGoogleShadowData({ env, now, startDate: sevenStart, endDate: today, includeSearchIntelligence: false }),
-    collectMetaShadowData({ env, now, datePreset: 'today' }),
-    collectMetaShadowData({ env, now, datePreset: 'last_7d' }),
-    collectGa4ShadowData({ env, now, startDate: today, endDate: today }),
-    collectGa4ShadowData({ env, now, startDate: sevenStart, endDate: today }),
+async function collectOperationalLivePulse({ env=process.env, now=new Date() }={}) {
+  const today=berlinDate(now); const sevenStart=berlinDate(shiftDays(now,-6));
+  const [googleToday,google7d,metaToday,meta7d,ga4Today,ga47d]=await Promise.all([
+    collectGoogleShadowData({env,now,startDate:today,endDate:today,includeSearchIntelligence:false}),collectGoogleShadowData({env,now,startDate:sevenStart,endDate:today,includeSearchIntelligence:false}),collectMetaShadowData({env,now,datePreset:'today'}),collectMetaShadowData({env,now,datePreset:'last_7d'}),collectGa4ShadowData({env,now,startDate:today,endDate:today}),collectGa4ShadowData({env,now,startDate:sevenStart,endDate:today})
   ]);
-
-  const result = {
-    generated_at: now.toISOString(),
-    timezone: 'Europe/Berlin',
-    mode: 'read_only_live_pulse',
-    today: {
-      date: today,
-      google: summarizeGoogle(googleToday),
-      meta: summarizeMeta(metaToday),
-      ga4: summarizeGa4(ga4Today),
-    },
-    last_7d: {
-      start: sevenStart,
-      end: today,
-      google: summarizeGoogle(google7d),
-      meta: summarizeMeta(meta7d),
-      ga4: summarizeGa4(ga47d),
-    },
-    writes_allowed: false,
-    execution_allowed: false,
-    spend_allowed: false,
-  };
-  result.today.signals = deriveSignals(result.today);
-  result.last_7d.signals = deriveSignals(result.last_7d);
-  return assertPublicPayloadSafe(result);
+  const result={generated_at:now.toISOString(),timezone:'Europe/Berlin',mode:'read_only_live_pulse',today:{date:today,google:summarizeGoogle(googleToday),meta:summarizeMeta(metaToday),ga4:summarizeGa4(ga4Today)},last_7d:{start:sevenStart,end:today,google:summarizeGoogle(google7d),meta:summarizeMeta(meta7d),ga4:summarizeGa4(ga47d)},writes_allowed:false,execution_allowed:false,spend_allowed:false};
+  result.today.signals=deriveSignals(result.today); result.last_7d.signals=deriveSignals(result.last_7d); return assertPublicPayloadSafe(result);
 }
 
-module.exports = {
-  berlinDate,
-  shiftDays,
-  round,
-  sanitizeGoogleCampaign,
-  sanitizeMetaCampaign,
-  summarizeGoogle,
-  summarizeMeta,
-  summarizeGa4,
-  deriveSignals,
-  collectOperationalLivePulse,
-};
+module.exports={berlinDate,shiftDays,round,sanitizeGoogleCampaign,sanitizeMetaCampaign,summarizeGoogle,summarizeMeta,summarizeGa4,deriveSignals,collectOperationalLivePulse};

--- a/test/operational-live-pulse.test.js
+++ b/test/operational-live-pulse.test.js
@@ -3,46 +3,29 @@ const assert=require('node:assert/strict');
 const {berlinDate,summarizeGoogle,summarizeMeta,summarizeGa4,deriveSignals}=require('../operational-live-pulse');
 const {publicPulse}=require('../operational-live-pulse-preload');
 
-test('Berlin date uses the business timezone',()=>{
- assert.equal(berlinDate(new Date('2026-08-25T22:30:00Z')),'2026-08-26');
-});
+test('Berlin date uses the business timezone',()=>{assert.equal(berlinDate(new Date('2026-08-25T22:30:00Z')),'2026-08-26');});
 
-test('Google pulse exposes aggregate economics and active campaigns without IDs',()=>{
- const result=summarizeGoogle({access_ok:true,totals:{spend_eur:6,impressions:1000,clicks:20,cpc_eur:.3,conversions:2},campaigns:[{campaign_id:'123456789012',campaign_name:'Dinner Search',status:'ENABLED',impressions:1000,clicks:20,cost_eur:6,average_cpc_eur:.3,conversions:2}]});
- assert.equal(result.active_campaigns,1);
- assert.equal(result.totals.ctr_percent,2);
- assert.equal(result.totals.cost_per_conversion_eur,3);
- assert.equal(result.campaigns[0].campaign_id,undefined);
+test('Google pulse exposes aggregate economics, active campaigns and delivery diagnostics without IDs',()=>{
+ const result=summarizeGoogle({access_ok:true,totals:{spend_eur:6,impressions:1000,clicks:20,cpc_eur:.3,conversions:2},campaigns:[{campaign_id:'123456789012',campaign_name:'Dinner Search',status:'ENABLED',primary_status:'ELIGIBLE',primary_status_reasons:['CAMPAIGN_BUDGET_CONSTRAINED'],channel_type:'SEARCH',daily_budget_eur:3.5,impressions:1000,clicks:20,cost_eur:6,average_cpc_eur:.3,conversions:2,search_rank_lost_impression_share:.25}]});
+ assert.equal(result.active_campaigns,1);assert.equal(result.totals.ctr_percent,2);assert.equal(result.totals.cost_per_conversion_eur,3);assert.equal(result.campaigns[0].campaign_id,undefined);assert.equal(result.delivery_diagnostics.limited_by_budget,1);assert.equal(result.delivery_diagnostics.high_rank_loss,1);
 });
 
 test('Meta pulse keeps only actively delivering rows',()=>{
  const result=summarizeMeta({access_ok:true,overview:{totals:{spend_eur:4,impressions:500,reach_sum:400,clicks:10,ctr_percent:2,cpc_eur:.4,cpm_eur:8},campaign_counts:{active:1},campaigns:[{id:'999999999999',name:'Dinner Reel',status:'ACTIVE',delivery_status:'active',metrics:{spend_eur:4,impressions:500,reach:400,clicks:10,ctr_percent:2,cpc_eur:.4,cpm_eur:8,frequency:1.25}},{id:'8',name:'Old',status:'PAUSED',delivery_status:'paused'}]}});
- assert.equal(result.active_campaigns,1);
- assert.equal(result.campaigns.length,1);
- assert.equal(result.campaigns[0].id,undefined);
+ assert.equal(result.active_campaigns,1);assert.equal(result.campaigns.length,1);assert.equal(result.campaigns[0].id,undefined);
 });
 
-test('GA4 pulse reports observed funnel counts',()=>{
- const result=summarizeGa4({access_ok:true,total_booking_completed:3,google_cpc_booking_completed:1,funnel:{totals:{reservation_page_view:10,reservation_start:4,booking_completed:3},rates:{page_to_start:.4,start_to_booking:.75,page_to_booking:.3},completeness:{configuration_complete:true,observation_complete:true}}});
- assert.equal(result.booking_completed,3);
- assert.equal(result.funnel.reservation_start,4);
- assert.equal(result.funnel.observation_complete,true);
+test('GA4 pulse reports observed funnel counts and booking quality',()=>{
+ const result=summarizeGa4({access_ok:true,total_booking_completed:3,google_cpc_booking_completed:1,booking_quality:{event_count:3,users:2,sessions:2,events_per_user:1.5,duplication_risk:false},funnel:{totals:{reservation_page_view:10,reservation_start:4,booking_completed:3},rates:{page_to_start:.4,start_to_booking:.75,page_to_booking:.3},completeness:{configuration_complete:true,observation_complete:true}}});
+ assert.equal(result.booking_completed,3);assert.equal(result.booking_quality.users,2);assert.equal(result.funnel.reservation_start,4);assert.equal(result.funnel.observation_complete,true);
 });
 
-test('signals distinguish delivery from conversion weakness',()=>{
- const signals=deriveSignals({google:{totals:{spend_eur:5,clicks:12}},meta:{totals:{spend_eur:0,clicks:0}},ga4:{booking_completed:0,funnel:{reservation_page_view:5,reservation_start:2}}});
- assert.equal(signals.ads_delivering,true);
- assert.equal(signals.traffic_present,true);
- assert.equal(signals.bookings_present,false);
- assert.equal(signals.spend_without_bookings,true);
- assert.equal(signals.funnel_intermediate_events_observed,true);
+test('signals distinguish delivery weakness and booking duplication risk',()=>{
+ const signals=deriveSignals({google:{totals:{spend_eur:5,clicks:12},delivery_diagnostics:{limited_by_budget:1}},meta:{totals:{spend_eur:0,clicks:0}},ga4:{booking_completed:3,booking_quality:{events_per_user:3},funnel:{reservation_page_view:5,reservation_start:2}}});
+ assert.equal(signals.ads_delivering,true);assert.equal(signals.traffic_present,true);assert.equal(signals.bookings_present,true);assert.equal(signals.funnel_intermediate_events_observed,true);assert.equal(signals.booking_event_duplication_risk,true);assert.equal(signals.google_delivery_limited,true);
 });
 
 test('public pulse strips campaign rows and remains zero-write',()=>{
  const result=publicPulse({generated_at:'2026-08-25T18:00:00Z',timezone:'Europe/Berlin',today:{date:'2026-08-25',google:{campaigns:[{name:'secret internal campaign'}],totals:{}},meta:{campaigns:[{name:'internal'}],totals:{}},ga4:{},signals:{}},last_7d:{start:'2026-08-19',end:'2026-08-25',google:{campaigns:[],totals:{}},meta:{campaigns:[],totals:{}},ga4:{},signals:{}}});
- assert.equal(result.today.google.campaigns,undefined);
- assert.equal(result.today.meta.campaigns,undefined);
- assert.equal(result.writes_allowed,false);
- assert.equal(result.execution_allowed,false);
- assert.equal(result.spend_allowed,false);
+ assert.equal(result.today.google.campaigns,undefined);assert.equal(result.today.meta.campaigns,undefined);assert.equal(result.writes_allowed,false);assert.equal(result.execution_allowed,false);assert.equal(result.spend_allowed,false);
 });


### PR DESCRIPTION
Adds read-only Google delivery diagnostics (primary status/reasons, daily budget, bidding type, search impression share and lost impression share) and GA4 booking quality diagnostics (event count, users, sessions, events per user/session, duplication risk). Live pulse surfaces only sanitized aggregates publicly and keeps writes/spend disabled. Includes regression tests and compact runtime status output.