### PR TITLE
Expose Google root-cause reasons and GA4 booking sources

### DIFF
--- a/.github/workflows/live-pulse-runtime.yml
+++ b/.github/workflows/live-pulse-runtime.yml
@@ -41,6 +41,7 @@ jobs:
           glb=$(jq -r '.today.google.delivery_diagnostics.limited_by_budget // 0' pulse.json)
           glr=$(jq -r '.today.google.delivery_diagnostics.high_rank_loss // 0' pulse.json)
           gls=$(jq -r '.today.google.delivery_diagnostics.not_eligible_or_limited // 0' pulse.json)
+          top_reason=$(jq -r '.today.google.delivery_diagnostics.primary_reason_counts // {} | to_entries | sort_by(-.value) | .[0].key // "none"' pulse.json)
           tmsp=$(jq -r '.today.meta.totals.spend_eur // 0' pulse.json)
           tmi=$(jq -r '.today.meta.totals.impressions // 0' pulse.json)
           tmc=$(jq -r '.today.meta.totals.clicks // 0' pulse.json)
@@ -48,21 +49,28 @@ jobs:
           tb=$(jq -r '.today.ga4.booking_completed // 0' pulse.json)
           bpu=$(jq -r '.today.ga4.booking_quality.events_per_user // 0' pulse.json)
           busers=$(jq -r '.today.ga4.booking_quality.users // 0' pulse.json)
+          gpaid=$(jq -r '.today.ga4.booking_sources.google_paid // 0' pulse.json)
+          mpaid=$(jq -r '.today.ga4.booking_sources.meta_paid // 0' pulse.json)
+          direct=$(jq -r '.today.ga4.booking_sources.direct // 0' pulse.json)
+          organic=$(jq -r '(.today.ga4.booking_sources.google_organic // 0)+(.today.ga4.booking_sources.meta_organic // 0)+(.today.ga4.booking_sources.organic_other // 0)' pulse.json)
+          referral=$(jq -r '.today.ga4.booking_sources.referral // 0' pulse.json)
+          other=$(jq -r '(.today.ga4.booking_sources.other // 0)+(.today.ga4.booking_sources.paid_other // 0)' pulse.json)
           g7=$(jq -r '.last_7d.google.totals.spend_eur // 0' pulse.json)
           m7=$(jq -r '.last_7d.meta.totals.spend_eur // 0' pulse.json)
           b7=$(jq -r '.last_7d.ga4.booking_completed // 0' pulse.json)
-          delivering=$(jq -r '.today.signals.ads_delivering // false' pulse.json)
-          traffic=$(jq -r '.today.signals.traffic_present // false' pulse.json)
-          bookings=$(jq -r '.today.signals.bookings_present // false' pulse.json)
           dup=$(jq -r '.today.signals.booking_event_duplication_risk // false' pulse.json)
           writes=$(jq -r 'if has("writes_allowed") then .writes_allowed else true end' pulse.json)
 
+          safe_reason=$(printf '%s' "$top_reason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-30)
           if [ "$writes" = "false" ]; then state="success"; else state="failure"; fi
-          context="pulse:g=${tga}:m=${tma}:lb=${glb}:lr=${glr}:ls=${gls}:dup=${dup}"
-          description="g€${tgsp} i${tgi} c${tgc} cv${tgcv}; Gdiag b${glb}/r${glr}/s${gls}; m€${tmsp} i${tmi} c${tmc}; b${tb}/u${busers}/epu${bpu}; 7d g€${g7} m€${m7} b${b7}"
+          context="pulse:g=${tga}:m=${tma}:reason=${safe_reason}:dup=${dup}"
+          description="g€${tgsp} i${tgi} c${tgc}; reason=${safe_reason}; m€${tmsp}; b${tb}: gP${gpaid} mP${mpaid} dir${direct} org${organic} ref${referral} oth${other}; 7d g€${g7} m€${m7} b${b7}"
           description=$(printf '%s' "$description" | cut -c1-140)
           context=$(printf '%s' "$context" | cut -c1-100)
           payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')
           curl --fail-with-body -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
+          echo "google_primary_status_counts=$(jq -c '.today.google.delivery_diagnostics.primary_status_counts // {}' pulse.json)"
+          echo "google_primary_reason_counts=$(jq -c '.today.google.delivery_diagnostics.primary_reason_counts // {}' pulse.json)"
+          echo "booking_sources=$(jq -c '.today.ga4.booking_sources // {}' pulse.json)"
           echo "$description"
           if [ "$state" != "success" ]; then exit 1; fi

--- a/ga4-shadow-data.js
+++ b/ga4-shadow-data.js
@@ -37,6 +37,21 @@ function bookingFilters(googleCpcOnly=false){
   return filters;
 }
 
+function classifyBookingSource(source, medium) {
+  const s=String(source||'').toLowerCase();
+  const m=String(medium||'').toLowerCase();
+  const paid=/cpc|ppc|paid|paid_social|display/.test(m);
+  if((s==='(direct)'||s==='direct')&&(m==='(none)'||m==='none'||!m))return'direct';
+  if(s==='google'&&paid)return'google_paid';
+  if(s==='google'&&/organic/.test(m))return'google_organic';
+  if(/facebook|instagram|meta/.test(s)&&paid)return'meta_paid';
+  if(/facebook|instagram|meta/.test(s))return'meta_organic';
+  if(/organic/.test(m))return'organic_other';
+  if(/referral/.test(m))return'referral';
+  if(paid)return'paid_other';
+  return'other';
+}
+
 async function runBookingReport({ accessToken, propertyId, start, end, googleCpcOnly = false }) {
   const body={dateRanges:[{startDate:start,endDate:end}],dimensions:[{name:"date"}],metrics:[{name:"eventCount"}],dimensionFilter:{andGroup:{expressions:bookingFilters(googleCpcOnly)}},orderBys:[{dimension:{dimensionName:"date",orderType:"ALPHANUMERIC"},desc:true}],limit:"1000"};
   const response=await axios.post(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,body,{headers:{authorization:`Bearer ${accessToken}`},timeout:20000});
@@ -47,44 +62,43 @@ async function runBookingReport({ accessToken, propertyId, start, end, googleCpc
 }
 
 async function runBookingQualityReport({accessToken,propertyId,start,end}){
-  const body={
-    dateRanges:[{startDate:start,endDate:end}],
-    metrics:[{name:"eventCount"},{name:"totalUsers"},{name:"sessions"}],
-    dimensionFilter:{andGroup:{expressions:bookingFilters(false)}},
-  };
+  const body={dateRanges:[{startDate:start,endDate:end}],metrics:[{name:"eventCount"},{name:"totalUsers"},{name:"sessions"}],dimensionFilter:{andGroup:{expressions:bookingFilters(false)}}};
   const response=await axios.post(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,body,{headers:{authorization:`Bearer ${accessToken}`},timeout:20000});
   const row=(response.data.rows||[])[0];
-  const eventCount=Number(row?.metricValues?.[0]?.value||0);
-  const users=Number(row?.metricValues?.[1]?.value||0);
-  const sessions=Number(row?.metricValues?.[2]?.value||0);
-  return {
-    event_count:eventCount,
-    users,
-    sessions,
-    events_per_user:users>0?Math.round((eventCount/users)*100)/100:null,
-    events_per_session:sessions>0?Math.round((eventCount/sessions)*100)/100:null,
-    duplication_risk:users>0&&eventCount/users>1.5,
-  };
+  const eventCount=Number(row?.metricValues?.[0]?.value||0); const users=Number(row?.metricValues?.[1]?.value||0); const sessions=Number(row?.metricValues?.[2]?.value||0);
+  return {event_count:eventCount,users,sessions,events_per_user:users>0?Math.round((eventCount/users)*100)/100:null,events_per_session:sessions>0?Math.round((eventCount/sessions)*100)/100:null,duplication_risk:users>0&&eventCount/users>1.5};
+}
+
+async function runBookingSourceReport({accessToken,propertyId,start,end}){
+  const body={dateRanges:[{startDate:start,endDate:end}],dimensions:[{name:"sessionSource"},{name:"sessionMedium"}],metrics:[{name:"eventCount"}],dimensionFilter:{andGroup:{expressions:bookingFilters(false)}},limit:"1000"};
+  const response=await axios.post(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,body,{headers:{authorization:`Bearer ${accessToken}`},timeout:20000});
+  const buckets={direct:0,google_paid:0,google_organic:0,meta_paid:0,meta_organic:0,organic_other:0,referral:0,paid_other:0,other:0};
+  for(const row of response.data.rows||[]){
+    const bucket=classifyBookingSource(row.dimensionValues?.[0]?.value,row.dimensionValues?.[1]?.value);
+    buckets[bucket]+=Number(row.metricValues?.[0]?.value||0);
+  }
+  return buckets;
 }
 
 async function collectGa4ShadowData({ env = process.env, days = 30, now = new Date(), startDate = null, endDate = null } = {}) {
   const collectedAt=now.toISOString();
-  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,funnel:null};
+  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null};
   const fallback=getDateRange(days,now); const start=startDate||fallback.start; const end=endDate||fallback.end;
   try{
     const accessToken=await getGoogleAccessToken(env);
     const eventNames=String(env.GA4_FUNNEL_EVENTS||DEFAULT_FUNNEL_EVENTS.join(",")).split(",").map((value)=>value.trim()).filter(Boolean);
-    const [allBookings,googleCpcBookings,bookingQuality,funnelRows]=await Promise.all([
+    const [allBookings,googleCpcBookings,bookingQuality,bookingSources,funnelRows]=await Promise.all([
       runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:false}),
       runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:true}),
       runBookingQualityReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
+      runBookingSourceReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
       runFunnelReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,eventNames}),
     ]);
     const summarized=summarizeFunnel(funnelRows,eventNames); const funnel={event_names:eventNames,...summarized};
-    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)}};
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,booking_sources:bookingSources,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)}};
   }catch(error){
-    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,funnel:null};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null};
   }
 }
 
-module.exports={ga4Configured,collectGa4ShadowData,parseGa4Date,runBookingQualityReport,DEFAULT_FUNNEL_EVENTS};
+module.exports={ga4Configured,collectGa4ShadowData,parseGa4Date,runBookingQualityReport,runBookingSourceReport,classifyBookingSource,DEFAULT_FUNNEL_EVENTS};

--- a/operational-live-pulse.js
+++ b/operational-live-pulse.js
@@ -2,78 +2,31 @@ const { collectGoogleShadowData, collectMetaShadowData } = require('./live-shado
 const { collectGa4ShadowData } = require('./ga4-shadow-data');
 const { assertPublicPayloadSafe } = require('./public-output-safety');
 
-function berlinDate(date = new Date()) {
-  const parts = new Intl.DateTimeFormat('en-GB', { timeZone:'Europe/Berlin', year:'numeric', month:'2-digit', day:'2-digit' }).formatToParts(date);
-  const map = Object.fromEntries(parts.map((part) => [part.type, part.value]));
-  return `${map.year}-${map.month}-${map.day}`;
-}
-function shiftDays(date, days) { return new Date(date.getTime() + days * 86400000); }
-function round(value, decimals = 2) { const factor=10**decimals; return Math.round((Number(value||0)+Number.EPSILON)*factor)/factor; }
+function berlinDate(date = new Date()) { const parts=new Intl.DateTimeFormat('en-GB',{timeZone:'Europe/Berlin',year:'numeric',month:'2-digit',day:'2-digit'}).formatToParts(date); const map=Object.fromEntries(parts.map((part)=>[part.type,part.value])); return `${map.year}-${map.month}-${map.day}`; }
+function shiftDays(date,days){return new Date(date.getTime()+days*86400000);}
+function round(value,decimals=2){const factor=10**decimals;return Math.round((Number(value||0)+Number.EPSILON)*factor)/factor;}
 
-function sanitizeGoogleCampaign(campaign = {}) {
-  return {
-    name: campaign.campaign_name || null,
-    status: campaign.status || null,
-    primary_status: campaign.primary_status || null,
-    primary_status_reasons: Array.isArray(campaign.primary_status_reasons) ? campaign.primary_status_reasons.slice(0,8) : [],
-    channel_type: campaign.channel_type || null,
-    bidding_strategy_type: campaign.bidding_strategy_type || null,
-    daily_budget_eur: round(campaign.daily_budget_eur),
-    spend_eur: round(campaign.cost_eur),
-    impressions: Number(campaign.impressions || 0),
-    clicks: Number(campaign.clicks || 0),
-    ctr_percent: campaign.impressions ? round((Number(campaign.clicks||0)/Number(campaign.impressions||0))*100,2) : 0,
-    cpc_eur: round(campaign.average_cpc_eur,2),
-    conversions: round(campaign.conversions,2),
-    search_impression_share_percent: campaign.search_impression_share == null ? null : round(Number(campaign.search_impression_share)*100,1),
-    search_budget_lost_impression_share_percent: campaign.search_budget_lost_impression_share == null ? null : round(Number(campaign.search_budget_lost_impression_share)*100,1),
-    search_rank_lost_impression_share_percent: campaign.search_rank_lost_impression_share == null ? null : round(Number(campaign.search_rank_lost_impression_share)*100,1),
-  };
+function sanitizeGoogleCampaign(campaign={}){return{name:campaign.campaign_name||null,status:campaign.status||null,primary_status:campaign.primary_status||null,primary_status_reasons:Array.isArray(campaign.primary_status_reasons)?campaign.primary_status_reasons.slice(0,8):[],channel_type:campaign.channel_type||null,bidding_strategy_type:campaign.bidding_strategy_type||null,daily_budget_eur:round(campaign.daily_budget_eur),spend_eur:round(campaign.cost_eur),impressions:Number(campaign.impressions||0),clicks:Number(campaign.clicks||0),ctr_percent:campaign.impressions?round((Number(campaign.clicks||0)/Number(campaign.impressions||0))*100,2):0,cpc_eur:round(campaign.average_cpc_eur,2),conversions:round(campaign.conversions,2),search_impression_share_percent:campaign.search_impression_share==null?null:round(Number(campaign.search_impression_share)*100,1),search_budget_lost_impression_share_percent:campaign.search_budget_lost_impression_share==null?null:round(Number(campaign.search_budget_lost_impression_share)*100,1),search_rank_lost_impression_share_percent:campaign.search_rank_lost_impression_share==null?null:round(Number(campaign.search_rank_lost_impression_share)*100,1)};}
+function sanitizeMetaCampaign(campaign={}){const metrics=campaign.metrics||{};return{name:campaign.name||null,delivery_status:campaign.delivery_status||null,status:campaign.status||null,spend_eur:round(metrics.spend_eur),impressions:Number(metrics.impressions||0),reach:Number(metrics.reach||0),clicks:Number(metrics.clicks||0),ctr_percent:round(metrics.ctr_percent,2),cpc_eur:round(metrics.cpc_eur,2),cpm_eur:round(metrics.cpm_eur,2),frequency:round(metrics.frequency,2)};}
+
+function countCodes(values=[]){const counts={};for(const value of values){const code=String(value||'unknown').replace(/[^A-Za-z0-9_.:-]/g,'_').slice(0,64)||'unknown';counts[code]=(counts[code]||0)+1;}return counts;}
+
+function summarizeGoogle(source={}){
+ const totals=source.totals||{};const campaigns=(source.campaigns||[]).map(sanitizeGoogleCampaign);const active=campaigns.filter((campaign)=>campaign.status==='ENABLED'||campaign.status===2);
+ const limitedByBudget=active.filter((campaign)=>campaign.primary_status_reasons.some((reason)=>/BUDGET/i.test(reason))).length;
+ const limitedByRank=active.filter((campaign)=>Number(campaign.search_rank_lost_impression_share_percent||0)>=20).length;
+ const notServing=active.filter((campaign)=>campaign.primary_status&&!/ELIGIBLE/i.test(String(campaign.primary_status))).length;
+ const statusCounts=countCodes(active.map((campaign)=>campaign.primary_status||'unknown'));
+ const reasonCounts=countCodes(active.flatMap((campaign)=>campaign.primary_status_reasons));
+ return{access_ok:source.access_ok===true,active_campaigns:active.length,delivery_diagnostics:{limited_by_budget:limitedByBudget,high_rank_loss:limitedByRank,not_eligible_or_limited:notServing,primary_status_counts:statusCounts,primary_reason_counts:reasonCounts},totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),clicks:Number(totals.clicks||0),ctr_percent:totals.impressions?round((Number(totals.clicks||0)/Number(totals.impressions||0))*100,2):0,cpc_eur:round(totals.cpc_eur,2),conversions:round(totals.conversions,2),cost_per_conversion_eur:Number(totals.conversions||0)>0?round(Number(totals.spend_eur||0)/Number(totals.conversions),2):null},campaigns:active};
 }
 
-function sanitizeMetaCampaign(campaign = {}) {
-  const metrics = campaign.metrics || {};
-  return { name:campaign.name||null, delivery_status:campaign.delivery_status||null, status:campaign.status||null, spend_eur:round(metrics.spend_eur), impressions:Number(metrics.impressions||0), reach:Number(metrics.reach||0), clicks:Number(metrics.clicks||0), ctr_percent:round(metrics.ctr_percent,2), cpc_eur:round(metrics.cpc_eur,2), cpm_eur:round(metrics.cpm_eur,2), frequency:round(metrics.frequency,2) };
-}
+function summarizeMeta(source={}){const overview=source.overview||{};const totals=overview.totals||{};const campaigns=(overview.campaigns||[]).map(sanitizeMetaCampaign);const active=campaigns.filter((campaign)=>['active','active_unverified'].includes(campaign.delivery_status));return{access_ok:source.access_ok===true,active_campaigns:active.length,campaign_counts:overview.campaign_counts||{},totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),reach:Number(totals.reach_sum||0),clicks:Number(totals.clicks||0),ctr_percent:round(totals.ctr_percent,2),cpc_eur:round(totals.cpc_eur,2),cpm_eur:round(totals.cpm_eur,2)},campaigns:active};}
 
-function summarizeGoogle(source = {}) {
-  const totals=source.totals||{};
-  const campaigns=(source.campaigns||[]).map(sanitizeGoogleCampaign);
-  const active=campaigns.filter((campaign)=>campaign.status==='ENABLED'||campaign.status===2);
-  const limitedByBudget=active.filter((campaign)=>campaign.primary_status_reasons.some((reason)=>/BUDGET/i.test(reason))).length;
-  const limitedByRank=active.filter((campaign)=>Number(campaign.search_rank_lost_impression_share_percent||0)>=20).length;
-  const notServing=active.filter((campaign)=>campaign.primary_status && !/ELIGIBLE/i.test(String(campaign.primary_status))).length;
-  return {
-    access_ok:source.access_ok===true,
-    active_campaigns:active.length,
-    delivery_diagnostics:{limited_by_budget:limitedByBudget,high_rank_loss:limitedByRank,not_eligible_or_limited:notServing},
-    totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),clicks:Number(totals.clicks||0),ctr_percent:totals.impressions?round((Number(totals.clicks||0)/Number(totals.impressions||0))*100,2):0,cpc_eur:round(totals.cpc_eur,2),conversions:round(totals.conversions,2),cost_per_conversion_eur:Number(totals.conversions||0)>0?round(Number(totals.spend_eur||0)/Number(totals.conversions),2):null},
-    campaigns:active,
-  };
-}
+function summarizeGa4(source={}){const funnel=source.funnel||{};const totals=funnel.totals||{};return{access_ok:source.access_ok===true,booking_completed:Number(source.total_booking_completed||0),google_cpc_booking_completed:Number(source.google_cpc_booking_completed||0),booking_quality:source.booking_quality||null,booking_sources:source.booking_sources||{},funnel:{reservation_page_view:Number(totals.reservation_page_view||0),reservation_start:Number(totals.reservation_start||0),booking_completed:Number(totals.booking_completed||0),rates:funnel.rates||{page_to_start:null,start_to_booking:null,page_to_booking:null},configuration_complete:funnel.completeness?.configuration_complete===true,observation_complete:funnel.completeness?.observation_complete===true}};}
 
-function summarizeMeta(source = {}) {
-  const overview=source.overview||{}; const totals=overview.totals||{}; const campaigns=(overview.campaigns||[]).map(sanitizeMetaCampaign); const active=campaigns.filter((campaign)=>['active','active_unverified'].includes(campaign.delivery_status));
-  return {access_ok:source.access_ok===true,active_campaigns:active.length,campaign_counts:overview.campaign_counts||{},totals:{spend_eur:round(totals.spend_eur),impressions:Number(totals.impressions||0),reach:Number(totals.reach_sum||0),clicks:Number(totals.clicks||0),ctr_percent:round(totals.ctr_percent,2),cpc_eur:round(totals.cpc_eur,2),cpm_eur:round(totals.cpm_eur,2)},campaigns:active};
-}
+function deriveSignals(period={}){const google=period.google||{};const meta=period.meta||{};const ga4=period.ga4||{};const adSpend=Number(google.totals?.spend_eur||0)+Number(meta.totals?.spend_eur||0);const clicks=Number(google.totals?.clicks||0)+Number(meta.totals?.clicks||0);const bookings=Number(ga4.booking_completed||0);const bookingEventsPerUser=Number(ga4.booking_quality?.events_per_user||0);const paidBookings=Number(ga4.booking_sources?.google_paid||0)+Number(ga4.booking_sources?.meta_paid||0)+Number(ga4.booking_sources?.paid_other||0);return{ads_delivering:adSpend>0||clicks>0,traffic_present:clicks>0,bookings_present:bookings>0,spend_without_bookings:adSpend>0&&bookings===0,clicks_without_bookings:clicks>0&&bookings===0,funnel_intermediate_events_observed:Number(ga4.funnel?.reservation_page_view||0)>0&&Number(ga4.funnel?.reservation_start||0)>0,booking_event_duplication_risk:bookingEventsPerUser>1.5,google_delivery_limited:Number(google.delivery_diagnostics?.limited_by_budget||0)>0||Number(google.delivery_diagnostics?.high_rank_loss||0)>0||Number(google.delivery_diagnostics?.not_eligible_or_limited||0)>0,paid_attributed_bookings:paidBookings,paid_booking_share:bookings>0?round(paidBookings/bookings,3):null};}
 
-function summarizeGa4(source = {}) {
-  const funnel=source.funnel||{}; const totals=funnel.totals||{};
-  return {access_ok:source.access_ok===true,booking_completed:Number(source.total_booking_completed||0),google_cpc_booking_completed:Number(source.google_cpc_booking_completed||0),booking_quality:source.booking_quality||null,funnel:{reservation_page_view:Number(totals.reservation_page_view||0),reservation_start:Number(totals.reservation_start||0),booking_completed:Number(totals.booking_completed||0),rates:funnel.rates||{page_to_start:null,start_to_booking:null,page_to_booking:null},configuration_complete:funnel.completeness?.configuration_complete===true,observation_complete:funnel.completeness?.observation_complete===true}};
-}
+async function collectOperationalLivePulse({env=process.env,now=new Date()}={}){const today=berlinDate(now);const sevenStart=berlinDate(shiftDays(now,-6));const[googleToday,google7d,metaToday,meta7d,ga4Today,ga47d]=await Promise.all([collectGoogleShadowData({env,now,startDate:today,endDate:today,includeSearchIntelligence:false}),collectGoogleShadowData({env,now,startDate:sevenStart,endDate:today,includeSearchIntelligence:false}),collectMetaShadowData({env,now,datePreset:'today'}),collectMetaShadowData({env,now,datePreset:'last_7d'}),collectGa4ShadowData({env,now,startDate:today,endDate:today}),collectGa4ShadowData({env,now,startDate:sevenStart,endDate:today})]);const result={generated_at:now.toISOString(),timezone:'Europe/Berlin',mode:'read_only_live_pulse',today:{date:today,google:summarizeGoogle(googleToday),meta:summarizeMeta(metaToday),ga4:summarizeGa4(ga4Today)},last_7d:{start:sevenStart,end:today,google:summarizeGoogle(google7d),meta:summarizeMeta(meta7d),ga4:summarizeGa4(ga47d)},writes_allowed:false,execution_allowed:false,spend_allowed:false};result.today.signals=deriveSignals(result.today);result.last_7d.signals=deriveSignals(result.last_7d);return assertPublicPayloadSafe(result);}
 
-function deriveSignals(period = {}) {
-  const google=period.google||{}; const meta=period.meta||{}; const ga4=period.ga4||{}; const adSpend=Number(google.totals?.spend_eur||0)+Number(meta.totals?.spend_eur||0); const clicks=Number(google.totals?.clicks||0)+Number(meta.totals?.clicks||0); const bookings=Number(ga4.booking_completed||0); const bookingEventsPerUser=Number(ga4.booking_quality?.events_per_user||0);
-  return {ads_delivering:adSpend>0||clicks>0,traffic_present:clicks>0,bookings_present:bookings>0,spend_without_bookings:adSpend>0&&bookings===0,clicks_without_bookings:clicks>0&&bookings===0,funnel_intermediate_events_observed:Number(ga4.funnel?.reservation_page_view||0)>0&&Number(ga4.funnel?.reservation_start||0)>0,booking_event_duplication_risk:bookingEventsPerUser>1.5,google_delivery_limited:Number(google.delivery_diagnostics?.limited_by_budget||0)>0||Number(google.delivery_diagnostics?.high_rank_loss||0)>0||Number(google.delivery_diagnostics?.not_eligible_or_limited||0)>0};
-}
-
-async function collectOperationalLivePulse({ env=process.env, now=new Date() }={}) {
-  const today=berlinDate(now); const sevenStart=berlinDate(shiftDays(now,-6));
-  const [googleToday,google7d,metaToday,meta7d,ga4Today,ga47d]=await Promise.all([
-    collectGoogleShadowData({env,now,startDate:today,endDate:today,includeSearchIntelligence:false}),collectGoogleShadowData({env,now,startDate:sevenStart,endDate:today,includeSearchIntelligence:false}),collectMetaShadowData({env,now,datePreset:'today'}),collectMetaShadowData({env,now,datePreset:'last_7d'}),collectGa4ShadowData({env,now,startDate:today,endDate:today}),collectGa4ShadowData({env,now,startDate:sevenStart,endDate:today})
-  ]);
-  const result={generated_at:now.toISOString(),timezone:'Europe/Berlin',mode:'read_only_live_pulse',today:{date:today,google:summarizeGoogle(googleToday),meta:summarizeMeta(metaToday),ga4:summarizeGa4(ga4Today)},last_7d:{start:sevenStart,end:today,google:summarizeGoogle(google7d),meta:summarizeMeta(meta7d),ga4:summarizeGa4(ga47d)},writes_allowed:false,execution_allowed:false,spend_allowed:false};
-  result.today.signals=deriveSignals(result.today); result.last_7d.signals=deriveSignals(result.last_7d); return assertPublicPayloadSafe(result);
-}
-
-module.exports={berlinDate,shiftDays,round,sanitizeGoogleCampaign,sanitizeMetaCampaign,summarizeGoogle,summarizeMeta,summarizeGa4,deriveSignals,collectOperationalLivePulse};
+module.exports={berlinDate,shiftDays,round,countCodes,sanitizeGoogleCampaign,sanitizeMetaCampaign,summarizeGoogle,summarizeMeta,summarizeGa4,deriveSignals,collectOperationalLivePulse};

--- a/test/ga4-booking-source-classification.test.js
+++ b/test/ga4-booking-source-classification.test.js
@@ -1,0 +1,19 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {classifyBookingSource}=require('../ga4-shadow-data');
+
+test('classifies Google paid and organic separately',()=>{
+ assert.equal(classifyBookingSource('google','cpc'),'google_paid');
+ assert.equal(classifyBookingSource('google','organic'),'google_organic');
+});
+
+test('classifies Meta paid and organic separately',()=>{
+ assert.equal(classifyBookingSource('instagram','paid_social'),'meta_paid');
+ assert.equal(classifyBookingSource('facebook.com','referral'),'meta_organic');
+});
+
+test('classifies direct and other acquisition without exposing raw source values',()=>{
+ assert.equal(classifyBookingSource('(direct)','(none)'),'direct');
+ assert.equal(classifyBookingSource('newsletter','email'),'other');
+ assert.equal(classifyBookingSource('partner.example','referral'),'referral');
+});

--- a/test/operational-live-pulse.test.js
+++ b/test/operational-live-pulse.test.js
@@ -5,9 +5,9 @@ const {publicPulse}=require('../operational-live-pulse-preload');
 
 test('Berlin date uses the business timezone',()=>{assert.equal(berlinDate(new Date('2026-08-25T22:30:00Z')),'2026-08-26');});
 
-test('Google pulse exposes aggregate economics, active campaigns and delivery diagnostics without IDs',()=>{
- const result=summarizeGoogle({access_ok:true,totals:{spend_eur:6,impressions:1000,clicks:20,cpc_eur:.3,conversions:2},campaigns:[{campaign_id:'123456789012',campaign_name:'Dinner Search',status:'ENABLED',primary_status:'ELIGIBLE',primary_status_reasons:['CAMPAIGN_BUDGET_CONSTRAINED'],channel_type:'SEARCH',daily_budget_eur:3.5,impressions:1000,clicks:20,cost_eur:6,average_cpc_eur:.3,conversions:2,search_rank_lost_impression_share:.25}]});
- assert.equal(result.active_campaigns,1);assert.equal(result.totals.ctr_percent,2);assert.equal(result.totals.cost_per_conversion_eur,3);assert.equal(result.campaigns[0].campaign_id,undefined);assert.equal(result.delivery_diagnostics.limited_by_budget,1);assert.equal(result.delivery_diagnostics.high_rank_loss,1);
+test('Google pulse aggregates primary status and reason codes without IDs',()=>{
+ const result=summarizeGoogle({access_ok:true,totals:{spend_eur:6,impressions:1000,clicks:20,cpc_eur:.3,conversions:2},campaigns:[{campaign_id:'123456789012',campaign_name:'Dinner Search',status:'ENABLED',primary_status:'LIMITED',primary_status_reasons:['CAMPAIGN_BUDGET_CONSTRAINED','ADS_LIMITED_BY_POLICY'],channel_type:'SEARCH',daily_budget_eur:3.5,impressions:1000,clicks:20,cost_eur:6,average_cpc_eur:.3,conversions:2,search_rank_lost_impression_share:.25}]});
+ assert.equal(result.active_campaigns,1);assert.equal(result.campaigns[0].campaign_id,undefined);assert.equal(result.delivery_diagnostics.primary_status_counts.LIMITED,1);assert.equal(result.delivery_diagnostics.primary_reason_counts.ADS_LIMITED_BY_POLICY,1);assert.equal(result.delivery_diagnostics.limited_by_budget,1);assert.equal(result.delivery_diagnostics.high_rank_loss,1);
 });
 
 test('Meta pulse keeps only actively delivering rows',()=>{
@@ -15,17 +15,17 @@ test('Meta pulse keeps only actively delivering rows',()=>{
  assert.equal(result.active_campaigns,1);assert.equal(result.campaigns.length,1);assert.equal(result.campaigns[0].id,undefined);
 });
 
-test('GA4 pulse reports observed funnel counts and booking quality',()=>{
- const result=summarizeGa4({access_ok:true,total_booking_completed:3,google_cpc_booking_completed:1,booking_quality:{event_count:3,users:2,sessions:2,events_per_user:1.5,duplication_risk:false},funnel:{totals:{reservation_page_view:10,reservation_start:4,booking_completed:3},rates:{page_to_start:.4,start_to_booking:.75,page_to_booking:.3},completeness:{configuration_complete:true,observation_complete:true}}});
- assert.equal(result.booking_completed,3);assert.equal(result.booking_quality.users,2);assert.equal(result.funnel.reservation_start,4);assert.equal(result.funnel.observation_complete,true);
+test('GA4 pulse reports booking quality and classified sources',()=>{
+ const result=summarizeGa4({access_ok:true,total_booking_completed:3,google_cpc_booking_completed:1,booking_quality:{event_count:3,users:3,sessions:3,events_per_user:1,duplication_risk:false},booking_sources:{google_paid:1,direct:2},funnel:{totals:{reservation_page_view:10,reservation_start:4,booking_completed:3},rates:{page_to_start:.4,start_to_booking:.75,page_to_booking:.3},completeness:{configuration_complete:true,observation_complete:true}}});
+ assert.equal(result.booking_completed,3);assert.equal(result.booking_quality.users,3);assert.equal(result.booking_sources.google_paid,1);assert.equal(result.funnel.reservation_start,4);
 });
 
-test('signals distinguish delivery weakness and booking duplication risk',()=>{
- const signals=deriveSignals({google:{totals:{spend_eur:5,clicks:12},delivery_diagnostics:{limited_by_budget:1}},meta:{totals:{spend_eur:0,clicks:0}},ga4:{booking_completed:3,booking_quality:{events_per_user:3},funnel:{reservation_page_view:5,reservation_start:2}}});
- assert.equal(signals.ads_delivering,true);assert.equal(signals.traffic_present,true);assert.equal(signals.bookings_present,true);assert.equal(signals.funnel_intermediate_events_observed,true);assert.equal(signals.booking_event_duplication_risk,true);assert.equal(signals.google_delivery_limited,true);
+test('signals calculate paid attribution and delivery limitations',()=>{
+ const signals=deriveSignals({google:{totals:{spend_eur:5,clicks:12},delivery_diagnostics:{not_eligible_or_limited:1}},meta:{totals:{spend_eur:0,clicks:0}},ga4:{booking_completed:4,booking_quality:{events_per_user:1},booking_sources:{google_paid:1,meta_paid:1,direct:2},funnel:{reservation_page_view:5,reservation_start:2}}});
+ assert.equal(signals.ads_delivering,true);assert.equal(signals.google_delivery_limited,true);assert.equal(signals.paid_attributed_bookings,2);assert.equal(signals.paid_booking_share,.5);assert.equal(signals.booking_event_duplication_risk,false);
 });
 
 test('public pulse strips campaign rows and remains zero-write',()=>{
- const result=publicPulse({generated_at:'2026-08-25T18:00:00Z',timezone:'Europe/Berlin',today:{date:'2026-08-25',google:{campaigns:[{name:'secret internal campaign'}],totals:{}},meta:{campaigns:[{name:'internal'}],totals:{}},ga4:{},signals:{}},last_7d:{start:'2026-08-19',end:'2026-08-25',google:{campaigns:[],totals:{}},meta:{campaigns:[],totals:{}},ga4:{},signals:{}}});
+ const result=publicPulse({generated_at:'2026-08-25T18:00:00Z',timezone:'Europe/Berlin',today:{date:'2026-08-25',google:{campaigns:[{name:'internal'}],totals:{}},meta:{campaigns:[{name:'internal'}],totals:{}},ga4:{},signals:{}},last_7d:{start:'2026-08-19',end:'2026-08-25',google:{campaigns:[],totals:{}},meta:{campaigns:[],totals:{}},ga4:{},signals:{}}});
  assert.equal(result.today.google.campaigns,undefined);assert.equal(result.today.meta.campaigns,undefined);assert.equal(result.writes_allowed,false);assert.equal(result.execution_allowed,false);assert.equal(result.spend_allowed,false);
 });


### PR DESCRIPTION
Adds sanitized aggregate Google primary-status/reason counts and classifies GA4 booking_completed events into direct, Google paid/organic, Meta paid/organic, other paid, referral and other buckets. This closes the read-only root-cause analysis for current under-delivery and lets us separate ad-attributed bookings from bookings generated elsewhere. No raw source strings, campaign IDs, credentials, writes, activation, or spend changes.