### PR TITLE
Add fail-closed GA4 funnel evidence gate on current main

### DIFF
--- a/ga4-funnel-intelligence.js
+++ b/ga4-funnel-intelligence.js
@@ -59,6 +59,26 @@ function funnelCompleteness(funnel = {}, expectedEvents = []) {
   };
 }
 
+function buildFunnelEvidenceGate(funnel = {}, expectedEvents = []) {
+  const completeness = funnelCompleteness(funnel, expectedEvents);
+  const missingConfiguration = expectedEvents.filter((name) => !completeness.tracking[name]?.configured);
+  const missingObservation = expectedEvents.filter((name) => completeness.tracking[name]?.configured && !completeness.tracking[name]?.observed);
+  const blockers = [
+    ...missingConfiguration.map((name) => `event_not_configured:${name}`),
+    ...missingObservation.map((name) => `event_not_observed:${name}`),
+  ];
+  return {
+    ready: completeness.configuration_complete && completeness.observation_complete,
+    configuration_complete: completeness.configuration_complete,
+    observation_complete: completeness.observation_complete,
+    missing_configuration: missingConfiguration,
+    missing_observation: missingObservation,
+    blockers,
+    automation_safe: blockers.length === 0,
+    writes_allowed: false,
+  };
+}
+
 function safeRate(numerator, denominator) {
   const top = Number(numerator || 0);
   const bottom = Number(denominator || 0);
@@ -92,6 +112,7 @@ module.exports = {
   summarizeFunnel,
   funnelTrackingStatus,
   funnelCompleteness,
+  buildFunnelEvidenceGate,
   funnelRates,
   reconcileConversions,
 };

--- a/test/ga4-funnel-evidence-gate-v2.test.js
+++ b/test/ga4-funnel-evidence-gate-v2.test.js
@@ -1,0 +1,19 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {buildFunnelEvidenceGate}=require('../ga4-funnel-intelligence');
+const expected=['reservation_page_view','reservation_start','booking_completed'];
+
+test('all required events must be configured and observed',()=>{
+ const ready=buildFunnelEvidenceGate({event_names:expected,totals:{reservation_page_view:10,reservation_start:4,booking_completed:2}},expected);
+ assert.equal(ready.ready,true);assert.equal(ready.automation_safe,true);assert.equal(ready.writes_allowed,false);
+});
+
+test('configured but unobserved events remain explicit blockers',()=>{
+ const gate=buildFunnelEvidenceGate({event_names:expected,totals:{reservation_page_view:0,reservation_start:0,booking_completed:2}},expected);
+ assert.equal(gate.ready,false);assert.deepEqual(gate.missing_observation,['reservation_page_view','reservation_start']);assert.ok(gate.blockers.includes('event_not_observed:reservation_start'));assert.equal(gate.automation_safe,false);
+});
+
+test('missing configuration is distinct from missing observation',()=>{
+ const gate=buildFunnelEvidenceGate({event_names:['booking_completed'],totals:{booking_completed:1}},expected);
+ assert.deepEqual(gate.missing_configuration,['reservation_page_view','reservation_start']);assert.deepEqual(gate.missing_observation,[]);
+});


### PR DESCRIPTION
Rebased version of the GA4 evidence gate on current main. Autonomous optimization remains blocked until reservation_page_view, reservation_start, and booking_completed are each both configured and observed. Missing configuration and missing observation stay distinct. No writes or spend changes.