### PR TITLE
Prepare bounded Meta Late Dinner draft profile

### DIFF
--- a/.github/workflows/meta-draft-inventory.yml
+++ b/.github/workflows/meta-draft-inventory.yml
@@ -1,10 +1,6 @@
 name: meta-draft-inventory
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/meta-draft-inventory.yml'
 jobs:
   inspect:
     runs-on: ubuntu-latest

--- a/meta-late-dinner.js
+++ b/meta-late-dinner.js
@@ -1,0 +1,58 @@
+const { buildPausedReservationDraft, assertPausedOnly } = require('./meta-paused-draft-next');
+
+const LATE_DINNER_PROFILE = Object.freeze({
+  label: 'Late Dinner',
+  start_hour: 20,
+  end_hour: 23,
+  radius_km: 3,
+  age_min: 23,
+  age_max: 60,
+  daily_budget_eur: 6,
+  duration_days: 14,
+  destination: 'https://www.parmaberlin.de/reservations',
+  platforms: ['instagram'],
+  positions: ['stream','story','reels'],
+  status: 'PAUSED',
+});
+
+function buildLateDinnerPausedDraft(input = {}) {
+  const draft = buildPausedReservationDraft({
+    ...input,
+    dailyBudgetEur: input.dailyBudgetEur ?? LATE_DINNER_PROFILE.daily_budget_eur,
+    durationDays: input.durationDays ?? LATE_DINNER_PROFILE.duration_days,
+    destinationUrl: LATE_DINNER_PROFILE.destination,
+  });
+  draft.campaign.name = draft.campaign.name.replace('Reservations', 'Late Dinner');
+  draft.adSet.name = draft.adSet.name.replace('Reservations', 'Late Dinner');
+  draft.adSet.adset_schedule = [{start_minute:20*60,end_minute:23*60,days:[0,1,2,3,4,5,6]}];
+  draft.ad.name = 'Parma | Late Dinner | Reel | Jetzt reservieren';
+  draft.creative.name = 'Parma | Late Dinner | Existing Reel | Reservations';
+  draft.policy.late_dinner = {
+    business_timezone:'Europe/Berlin',
+    start_hour:20,
+    end_hour:23,
+    may_activate:false,
+    requires_separate_activation_approval:true,
+  };
+  assertPausedOnly(draft);
+  return draft;
+}
+
+function lateDinnerPublicSummary(draft) {
+  assertPausedOnly(draft);
+  return {
+    profile:LATE_DINNER_PROFILE,
+    campaign_status:draft.campaign.status,
+    adset_status:draft.adSet.status,
+    ad_status:draft.ad.status,
+    daily_budget_eur:draft.budget.daily_eur,
+    maximum_total_eur:draft.budget.maximum_total_eur,
+    schedule:draft.adSet.adset_schedule,
+    destination:LATE_DINNER_PROFILE.destination,
+    reel_asset_configured:Boolean(draft.creative.source_instagram_media_id),
+    activation_allowed:false,
+    spend_allowed:false,
+  };
+}
+
+module.exports={LATE_DINNER_PROFILE,buildLateDinnerPausedDraft,lateDinnerPublicSummary};

--- a/test/meta-late-dinner.test.js
+++ b/test/meta-late-dinner.test.js
@@ -1,0 +1,27 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {buildLateDinnerPausedDraft,lateDinnerPublicSummary}=require('../meta-late-dinner');
+
+const input={pageId:'123',instagramUserId:'456',sourceInstagramMediaId:'789',latitude:52.5,longitude:13.44,startsAt:'2026-08-26T18:00:00.000Z',dsaBeneficiary:'Parma di Vinibenedetti',dsaPayor:'Parma di Vinibenedetti'};
+
+test('Late Dinner draft is complete, bounded and PAUSED only',()=>{
+ const draft=buildLateDinnerPausedDraft(input);
+ assert.match(draft.campaign.name,/Late Dinner/);
+ assert.equal(draft.campaign.status,'PAUSED');
+ assert.equal(draft.adSet.status,'PAUSED');
+ assert.equal(draft.ad.status,'PAUSED');
+ assert.equal(draft.budget.daily_eur,6);
+ assert.equal(draft.adSet.adset_schedule[0].start_minute,1200);
+ assert.equal(draft.adSet.adset_schedule[0].end_minute,1380);
+ assert.equal(draft.adSet.targeting.geo_locations.custom_locations[0].radius,3);
+ assert.deepEqual(draft.adSet.targeting.publisher_platforms,['instagram']);
+ assert.equal(JSON.stringify(draft).includes('ACTIVE'),false);
+});
+
+test('public summary cannot authorize activation or spend',()=>{
+ const summary=lateDinnerPublicSummary(buildLateDinnerPausedDraft(input));
+ assert.equal(summary.reel_asset_configured,true);
+ assert.equal(summary.activation_allowed,false);
+ assert.equal(summary.spend_allowed,false);
+ assert.equal(summary.daily_budget_eur,6);
+});


### PR DESCRIPTION
Adds a dedicated Late Dinner Meta profile for tomorrow: Instagram/Reels, 3 km local radius, 20:00–23:00 Berlin business window, €6/day default, existing Reel creative, reservations destination, and strict PAUSED-only / no-spend safety. Includes regression tests. This PR does not create, activate, or modify any Meta advertising object.