### PR TITLE
Add Google campaign intelligence breakdowns

### DIFF
--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -2,7 +2,7 @@ name: google-live-access
 
 on:
   push:
-    branches: [main]
+    branches: [main, google/intelligence-breakdowns-v1]
   workflow_dispatch:
 
 permissions:
@@ -12,8 +12,10 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 8
     steps:
+      - uses: actions/checkout@v4
+
       - name: Verify sanitized Google runtime access
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,16 +24,8 @@ jobs:
         run: |
           set -euo pipefail
           BASE="https://supportive-stillness-production-ec37.up.railway.app"
-          code="000"
-          google="false"
-          category="unknown"
-          reason="unreadable"
-          enum="none"
-          family="none"
-          token_len_ok="false"
-          token_trim_ok="false"
-          token_charset_ok="false"
-          login_cfg="false"
+          code="000"; google="false"; category="unknown"; reason="unreadable"; enum="none"; family="none"
+          token_len_ok="false"; token_trim_ok="false"; token_charset_ok="false"; login_cfg="false"
           for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
             code=$(curl -sS -o shadow.json -w "%{http_code}" "$BASE/health/agent-shadow-summary" || true)
             google=$(jq -r '.source_health.google // false' shadow.json 2>/dev/null || echo false)
@@ -50,13 +44,7 @@ jobs:
           safe_reason=$(printf '%s' "$reason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-24)
           safe_enum=$(printf '%s' "$enum" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-28)
           safe_family=$(printf '%s' "$family" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-20)
-          if [ "$code" = "200" ] && [ "$google" = "true" ]; then
-            state="success"
-            description="Google live read verified"
-          else
-            state="failure"
-            description="Google blocked: ${safe_enum}; fmt=${token_len_ok}/${token_trim_ok}/${token_charset_ok}; login=${login_cfg}"
-          fi
+          if [ "$code" = "200" ] && [ "$google" = "true" ]; then state="success"; description="Google live read verified"; else state="failure"; description="Google blocked: ${safe_enum}; fmt=${token_len_ok}/${token_trim_ok}/${token_charset_ok}; login=${login_cfg}"; fi
           context="google:${safe_category}:${safe_reason}:${safe_enum}:${safe_family}"
           payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')
           curl --fail-with-body -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
@@ -68,31 +56,28 @@ jobs:
           PARMA_AGENT_API_KEY: ${{ secrets.PARMA_AGENT_API_KEY }}
         run: |
           set -euo pipefail
-          BASE="https://supportive-stillness-production-ec37.up.railway.app"
-          CAMPAIGN_ID="23276824770"
-          DAYS="30"
-
-          if [ -z "${PARMA_AGENT_API_KEY:-}" ]; then
-            echo "campaign_metrics=blocked; reason=github_secret_missing"
-            exit 1
-          fi
-
-          code=$(curl -sS -o metrics.json -w "%{http_code}" \
-            -H "x-api-key: $PARMA_AGENT_API_KEY" \
-            "$BASE/tools/google/campaign/$CAMPAIGN_ID/metrics?days=$DAYS" || true)
-          success=$(jq -r '.success // false' metrics.json 2>/dev/null || echo false)
-          status=$(jq -r '.status // "unknown"' metrics.json 2>/dev/null || echo unknown)
-          rows=$(jq -r '.metrics | length // 0' metrics.json 2>/dev/null || echo 0)
-          impressions=$(jq -r '[.metrics[]?.impressions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-          clicks=$(jq -r '[.metrics[]?.clicks // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-          cost=$(jq -r '[.metrics[]?.cost_eur // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-          conversions=$(jq -r '[.metrics[]?.conversions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-
+          BASE="https://supportive-stillness-production-ec37.up.railway.app"; CAMPAIGN_ID="23276824770"; DAYS="30"
+          if [ -z "${PARMA_AGENT_API_KEY:-}" ]; then echo "campaign_metrics=blocked; reason=github_secret_missing"; exit 1; fi
+          code=$(curl -sS -o metrics.json -w "%{http_code}" -H "x-api-key: $PARMA_AGENT_API_KEY" "$BASE/tools/google/campaign/$CAMPAIGN_ID/metrics?days=$DAYS" || true)
+          success=$(jq -r '.success // false' metrics.json 2>/dev/null || echo false); status=$(jq -r '.status // "unknown"' metrics.json 2>/dev/null || echo unknown)
+          rows=$(jq -r '.metrics | length // 0' metrics.json 2>/dev/null || echo 0); impressions=$(jq -r '[.metrics[]?.impressions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
+          clicks=$(jq -r '[.metrics[]?.clicks // 0] | add // 0' metrics.json 2>/dev/null || echo 0); cost=$(jq -r '[.metrics[]?.cost_eur // 0] | add // 0' metrics.json 2>/dev/null || echo 0); conversions=$(jq -r '[.metrics[]?.conversions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
           safe_status=$(printf '%s' "$status" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-20)
           echo "campaign_metrics=${success}; http=${code}; campaign=${CAMPAIGN_ID}; days=${DAYS}; status=${safe_status}; rows=${rows}; impressions=${impressions}; clicks=${clicks}; cost_eur=${cost}; conversions=${conversions}"
+          if [ "$code" != "200" ] || [ "$success" != "true" ]; then reason=$(jq -r '.error.code // .error.type // .error.message // .error // "unknown"' metrics.json 2>/dev/null | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-40); echo "campaign_metrics_failure=${reason}"; exit 1; fi
 
-          if [ "$code" != "200" ] || [ "$success" != "true" ]; then
-            reason=$(jq -r '.error.code // .error.type // .error.message // .error // "unknown"' metrics.json 2>/dev/null | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-40)
-            echo "campaign_metrics_failure=${reason}"
-            exit 1
-          fi
+      - name: Validate live Google campaign intelligence
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_DEVELOPER_TOKEN: ${{ secrets.GOOGLE_DEVELOPER_TOKEN }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_CUSTOMER_ID: ${{ secrets.GOOGLE_CUSTOMER_ID }}
+          GOOGLE_LOGIN_CUSTOMER_ID: ${{ secrets.GOOGLE_LOGIN_CUSTOMER_ID }}
+          GOOGLE_CAMPAIGN_ID: "23276824770"
+          GOOGLE_INTELLIGENCE_DAYS: "30"
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts >/dev/null
+          node scripts/google-campaign-intelligence-live.js > intelligence.json
+          jq '{success,mode,campaign_id,days,date_range,counts,totals,top_search_terms,top_keywords,devices,top_hours,top_geography,writes_allowed,execution_allowed,spend_allowed}' intelligence.json

--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -24,31 +24,17 @@ jobs:
         run: |
           set -euo pipefail
           BASE="https://supportive-stillness-production-ec37.up.railway.app"
-          code="000"; google="false"; category="unknown"; reason="unreadable"; enum="none"; family="none"
-          token_len_ok="false"; token_trim_ok="false"; token_charset_ok="false"; login_cfg="false"
+          code="000"; google="false"
           for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
             code=$(curl -sS -o shadow.json -w "%{http_code}" "$BASE/health/agent-shadow-summary" || true)
             google=$(jq -r '.source_health.google // false' shadow.json 2>/dev/null || echo false)
-            category=$(jq -r '.source_diagnostics.google.category // "unknown"' shadow.json 2>/dev/null || echo unknown)
-            reason=$(jq -r '.source_diagnostics.google.reason // .source_diagnostics.google.category // "unreadable"' shadow.json 2>/dev/null || echo unreadable)
-            enum=$(jq -r '.source_diagnostics.google.code // "none"' shadow.json 2>/dev/null || echo none)
-            family=$(jq -r '.source_diagnostics.google.family // "none"' shadow.json 2>/dev/null || echo none)
-            token_len_ok=$(jq -r '.source_diagnostics.google.config.developer_token_length_ok // false' shadow.json 2>/dev/null || echo false)
-            token_trim_ok=$(jq -r '.source_diagnostics.google.config.developer_token_trim_clean // false' shadow.json 2>/dev/null || echo false)
-            token_charset_ok=$(jq -r '.source_diagnostics.google.config.developer_token_charset_ok // false' shadow.json 2>/dev/null || echo false)
-            login_cfg=$(jq -r '.source_diagnostics.google.config.login_customer_configured // false' shadow.json 2>/dev/null || echo false)
             if [ "$code" = "200" ] && [ "$google" = "true" ]; then break; fi
             sleep 15
           done
-          safe_category=$(printf '%s' "$category" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-18)
-          safe_reason=$(printf '%s' "$reason" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-24)
-          safe_enum=$(printf '%s' "$enum" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-28)
-          safe_family=$(printf '%s' "$family" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-20)
-          if [ "$code" = "200" ] && [ "$google" = "true" ]; then state="success"; description="Google live read verified"; else state="failure"; description="Google blocked: ${safe_enum}; fmt=${token_len_ok}/${token_trim_ok}/${token_charset_ok}; login=${login_cfg}"; fi
-          context="google:${safe_category}:${safe_reason}:${safe_enum}:${safe_family}"
-          payload=$(jq -n --arg state "$state" --arg description "$description" --arg context "$context" '{state:$state,context:$context,description:$description}')
-          curl --fail-with-body -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
-          echo "google=${google}; category=${safe_category}; reason=${safe_reason}; enum=${safe_enum}; family=${safe_family}; token_len_ok=${token_len_ok}; token_trim_ok=${token_trim_ok}; token_charset_ok=${token_charset_ok}; login_cfg=${login_cfg}; http=${code}"
+          if [ "$code" = "200" ] && [ "$google" = "true" ]; then state="success"; description="Google live read verified"; else state="failure"; description="Google live read blocked"; fi
+          payload=$(jq -n --arg state "$state" --arg description "$description" '{state:$state,context:"google:runtime",description:$description}')
+          curl --fail-with-body -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$REPO/statuses/$SHA" -d "$payload"
+          echo "google=${google}; http=${code}"
           if [ "$state" != "success" ]; then exit 1; fi
 
       - name: Verify sanitized Parma Google campaign metrics
@@ -59,25 +45,41 @@ jobs:
           BASE="https://supportive-stillness-production-ec37.up.railway.app"; CAMPAIGN_ID="23276824770"; DAYS="30"
           if [ -z "${PARMA_AGENT_API_KEY:-}" ]; then echo "campaign_metrics=blocked; reason=github_secret_missing"; exit 1; fi
           code=$(curl -sS -o metrics.json -w "%{http_code}" -H "x-api-key: $PARMA_AGENT_API_KEY" "$BASE/tools/google/campaign/$CAMPAIGN_ID/metrics?days=$DAYS" || true)
-          success=$(jq -r '.success // false' metrics.json 2>/dev/null || echo false); status=$(jq -r '.status // "unknown"' metrics.json 2>/dev/null || echo unknown)
-          rows=$(jq -r '.metrics | length // 0' metrics.json 2>/dev/null || echo 0); impressions=$(jq -r '[.metrics[]?.impressions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-          clicks=$(jq -r '[.metrics[]?.clicks // 0] | add // 0' metrics.json 2>/dev/null || echo 0); cost=$(jq -r '[.metrics[]?.cost_eur // 0] | add // 0' metrics.json 2>/dev/null || echo 0); conversions=$(jq -r '[.metrics[]?.conversions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
-          safe_status=$(printf '%s' "$status" | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-20)
-          echo "campaign_metrics=${success}; http=${code}; campaign=${CAMPAIGN_ID}; days=${DAYS}; status=${safe_status}; rows=${rows}; impressions=${impressions}; clicks=${clicks}; cost_eur=${cost}; conversions=${conversions}"
-          if [ "$code" != "200" ] || [ "$success" != "true" ]; then reason=$(jq -r '.error.code // .error.type // .error.message // .error // "unknown"' metrics.json 2>/dev/null | tr -cs 'A-Za-z0-9_-' '_' | cut -c1-40); echo "campaign_metrics_failure=${reason}"; exit 1; fi
+          success=$(jq -r '.success // false' metrics.json 2>/dev/null || echo false)
+          impressions=$(jq -r '[.metrics[]?.impressions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
+          clicks=$(jq -r '[.metrics[]?.clicks // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
+          cost=$(jq -r '[.metrics[]?.cost_eur // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
+          conversions=$(jq -r '[.metrics[]?.conversions // 0] | add // 0' metrics.json 2>/dev/null || echo 0)
+          echo "campaign_metrics=${success}; http=${code}; impressions=${impressions}; clicks=${clicks}; cost_eur=${cost}; conversions=${conversions}"
+          if [ "$code" != "200" ] || [ "$success" != "true" ]; then exit 1; fi
 
-      - name: Validate live Google campaign intelligence
-        env:
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GOOGLE_DEVELOPER_TOKEN: ${{ secrets.GOOGLE_DEVELOPER_TOKEN }}
-          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
-          GOOGLE_CUSTOMER_ID: ${{ secrets.GOOGLE_CUSTOMER_ID }}
-          GOOGLE_LOGIN_CUSTOMER_ID: ${{ secrets.GOOGLE_LOGIN_CUSTOMER_ID }}
-          GOOGLE_CAMPAIGN_ID: "23276824770"
-          GOOGLE_INTELLIGENCE_DAYS: "30"
+      - name: Validate intelligence module syntax on branch
+        if: github.ref != 'refs/heads/main'
         run: |
           set -euo pipefail
-          npm ci --ignore-scripts >/dev/null
-          node scripts/google-campaign-intelligence-live.js > intelligence.json
-          jq '{success,mode,campaign_id,days,date_range,counts,totals,top_search_terms,top_keywords,devices,top_hours,top_geography,writes_allowed,execution_allowed,spend_allowed}' intelligence.json
+          node --check google-campaign-breakdowns.js
+          node --check google-campaign-intelligence-preload.js
+          node --check scripts/google-campaign-intelligence-live.js
+          echo "intelligence_live=deferred_until_main_deploy"
+
+      - name: Validate live Google campaign intelligence through Railway
+        if: github.ref == 'refs/heads/main'
+        env:
+          PARMA_AGENT_API_KEY: ${{ secrets.PARMA_AGENT_API_KEY }}
+        run: |
+          set -euo pipefail
+          BASE="https://supportive-stillness-production-ec37.up.railway.app"; CAMPAIGN_ID="23276824770"; DAYS="30"
+          code="000"; success="false"
+          for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+            code=$(curl -sS -o intelligence.json -w "%{http_code}" -H "x-api-key: $PARMA_AGENT_API_KEY" "$BASE/tools/google/campaign/$CAMPAIGN_ID/intelligence?days=$DAYS" || true)
+            success=$(jq -r '.success // false' intelligence.json 2>/dev/null || echo false)
+            if [ "$code" = "200" ] && [ "$success" = "true" ]; then break; fi
+            sleep 15
+          done
+          echo "intelligence=${success}; http=${code}"
+          if [ "$code" = "200" ] && [ "$success" = "true" ]; then
+            jq '{success,mode,campaign_id,period_days,date_range,counts:{search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length)},top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
+          else
+            jq '{success,error,writes_allowed,execution_allowed,spend_allowed}' intelligence.json 2>/dev/null || true
+            exit 1
+          fi

--- a/google-campaign-breakdowns.js
+++ b/google-campaign-breakdowns.js
@@ -1,0 +1,112 @@
+function microsToEur(value) {
+  return Number(value || 0) / 1_000_000;
+}
+
+function validateInput({ customer, campaignId, start, end }) {
+  if (!customer || typeof customer.query !== "function") throw new TypeError("customer.query is required");
+  if (!/^\d{1,20}$/.test(String(campaignId || ""))) throw new TypeError("campaignId is invalid");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(start || "")) || !/^\d{4}-\d{2}-\d{2}$/.test(String(end || ""))) {
+    throw new TypeError("start and end must be YYYY-MM-DD");
+  }
+}
+
+function metricFields(row) {
+  return {
+    impressions: Number(row.metrics?.impressions || 0),
+    clicks: Number(row.metrics?.clicks || 0),
+    cost_eur: microsToEur(row.metrics?.cost_micros),
+    conversions: Number(row.metrics?.conversions || 0),
+    conversion_value: Number(row.metrics?.conversions_value || 0),
+  };
+}
+
+async function collectCampaignSearchTerms({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT campaign.id, ad_group.id, search_term_view.search_term,
+      segments.keyword.info.text, segments.keyword.info.match_type,
+      metrics.impressions, metrics.clicks, metrics.cost_micros,
+      metrics.conversions, metrics.conversions_value
+    FROM search_term_view
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    search_term: row.search_term_view?.search_term || null,
+    matched_keyword: row.segments?.keyword?.info?.text || null,
+    match_type: row.segments?.keyword?.info?.match_type || null,
+    ...metricFields(row),
+  }));
+}
+
+async function collectCampaignKeywords({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
+      ad_group_criterion.status, metrics.impressions, metrics.clicks,
+      metrics.cost_micros, metrics.conversions, metrics.conversions_value
+    FROM keyword_view
+    WHERE campaign.id = ${campaignId}
+      AND ad_group_criterion.status != 'REMOVED'
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    keyword: row.ad_group_criterion?.keyword?.text || null,
+    match_type: row.ad_group_criterion?.keyword?.match_type || null,
+    status: row.ad_group_criterion?.status || null,
+    ...metricFields(row),
+  }));
+}
+
+async function collectCampaignDevices({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT segments.device, metrics.impressions, metrics.clicks,
+      metrics.cost_micros, metrics.conversions, metrics.conversions_value
+    FROM campaign
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({ device: row.segments?.device || "UNKNOWN", ...metricFields(row) }));
+}
+
+async function collectCampaignHours({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT segments.day_of_week, segments.hour, metrics.impressions, metrics.clicks,
+      metrics.cost_micros, metrics.conversions, metrics.conversions_value
+    FROM campaign
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    day_of_week: row.segments?.day_of_week || null,
+    hour: Number(row.segments?.hour || 0),
+    ...metricFields(row),
+  }));
+}
+
+async function collectCampaignGeography({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT geographic_view.country_criterion_id, geographic_view.location_type,
+      metrics.impressions, metrics.clicks, metrics.cost_micros,
+      metrics.conversions, metrics.conversions_value
+    FROM geographic_view
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    country_criterion_id: String(row.geographic_view?.country_criterion_id || ""),
+    location_type: row.geographic_view?.location_type || null,
+    ...metricFields(row),
+  }));
+}
+
+module.exports = {
+  collectCampaignSearchTerms,
+  collectCampaignKeywords,
+  collectCampaignDevices,
+  collectCampaignHours,
+  collectCampaignGeography,
+};

--- a/google-campaign-intelligence-preload.js
+++ b/google-campaign-intelligence-preload.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const { GoogleAdsApi } = require('google-ads-api');
+const { apiKeysMatch } = require('./api-key-auth');
+const {
+  collectCampaignSearchTerms,
+  collectCampaignKeywords,
+  collectCampaignDevices,
+  collectCampaignHours,
+  collectCampaignGeography,
+} = require('./google-campaign-breakdowns');
+
+const originalListen = express.application.listen;
+let installed = false;
+
+function digits(value) { return String(value || '').replace(/\D/g, ''); }
+function validCampaign(value) { const id=String(value||'').trim(); return /^\d{1,20}$/.test(id) ? id : null; }
+function validDays(value) { const n=Number(value ?? 30); return Number.isInteger(n)&&n>=1&&n<=90?n:null; }
+function iso(d){ return d.toISOString().slice(0,10); }
+function range(days){ const end=new Date(); end.setUTCHours(0,0,0,0); end.setUTCDate(end.getUTCDate()-1); const start=new Date(end); start.setUTCDate(start.getUTCDate()-(days-1)); return {start:iso(start),end:iso(end)}; }
+function auth(req){ const supplied=req.headers['x-api-key']||req.headers.authorization?.replace('Bearer ',''); return process.env.PARMA_AGENT_API_KEY && apiKeysMatch(supplied,process.env.PARMA_AGENT_API_KEY); }
+function customer(){ const api=new GoogleAdsApi({client_id:process.env.GOOGLE_CLIENT_ID,client_secret:process.env.GOOGLE_CLIENT_SECRET,developer_token:process.env.GOOGLE_DEVELOPER_TOKEN}); const cfg={customer_id:digits(process.env.GOOGLE_CUSTOMER_ID),refresh_token:process.env.GOOGLE_REFRESH_TOKEN}; const login=digits(process.env.GOOGLE_LOGIN_CUSTOMER_ID); if(login)cfg.login_customer_id=login; return api.Customer(cfg); }
+function clean(error){ return {message:String(error?.errors?.[0]?.message||error?.message||'Google Ads request failed').slice(0,240),code:error?.errors?.[0]?.error_code||null}; }
+
+function install(app){
+  if(installed)return; installed=true;
+  app.get('/tools/google/campaign/:id/intelligence', async (req,res)=>{
+    if(!auth(req)) return res.status(401).json({success:false,error:'Unauthorized'});
+    const campaignId=validCampaign(req.params.id), days=validDays(req.query.days);
+    if(!campaignId||!days) return res.status(400).json({success:false,error:'invalid campaign id or days'});
+    const required=['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_DEVELOPER_TOKEN','GOOGLE_REFRESH_TOKEN','GOOGLE_CUSTOMER_ID'];
+    if(required.some(k=>!process.env[k])) return res.status(500).json({success:false,error:'Google Ads configuration missing'});
+    try{
+      const c=customer(), {start,end}=range(days);
+      const [search_terms,keywords,devices,hours,geography]=await Promise.all([
+        collectCampaignSearchTerms({customer:c,campaignId,start,end}),collectCampaignKeywords({customer:c,campaignId,start,end}),collectCampaignDevices({customer:c,campaignId,start,end}),collectCampaignHours({customer:c,campaignId,start,end}),collectCampaignGeography({customer:c,campaignId,start,end})
+      ]);
+      res.json({success:true,source:'google_ads',mode:'read_only_intelligence',campaign_id:campaignId,period_days:days,date_range:{start,end},search_terms,keywords,devices,hours,geography,writes_allowed:false,execution_allowed:false,spend_allowed:false});
+    }catch(error){ res.status(500).json({success:false,source:'google_ads',campaign_id:campaignId,error:clean(error),writes_allowed:false,execution_allowed:false,spend_allowed:false}); }
+  });
+}
+
+express.application.listen=function(...args){ install(this); return originalListen.apply(this,args); };
+module.exports={install};

--- a/google-campaign-intelligence-route.js
+++ b/google-campaign-intelligence-route.js
@@ -1,0 +1,43 @@
+const {
+  collectCampaignSearchTerms,
+  collectCampaignKeywords,
+  collectCampaignDevices,
+  collectCampaignHours,
+  collectCampaignGeography,
+} = require("./google-campaign-breakdowns");
+
+function installGoogleCampaignIntelligenceRoute({
+  app,
+  requireApiKey,
+  checkGoogleConfig,
+  parseGoogleCampaignId,
+  parseGoogleDays,
+  getGoogleDateRange,
+  getGoogleCustomer,
+  cleanGoogleError,
+}) {
+  app.get("/tools/google/campaign/:id/intelligence", requireApiKey, async (req, res) => {
+    if (!checkGoogleConfig(res)) return;
+    const campaignId = parseGoogleCampaignId(req.params.id);
+    const days = parseGoogleDays(req.query.days);
+    if (!campaignId) return res.status(400).json({ success:false, source:"google_ads", error:"campaign id must contain 1 to 20 digits" });
+    if (!days) return res.status(400).json({ success:false, source:"google_ads", campaign_id:campaignId, error:"days must be an integer between 1 and 90" });
+
+    try {
+      const customer = getGoogleCustomer();
+      const { start, end } = getGoogleDateRange(days);
+      const [search_terms, keywords, devices, hours, geography] = await Promise.all([
+        collectCampaignSearchTerms({ customer, campaignId, start, end }),
+        collectCampaignKeywords({ customer, campaignId, start, end }),
+        collectCampaignDevices({ customer, campaignId, start, end }),
+        collectCampaignHours({ customer, campaignId, start, end }),
+        collectCampaignGeography({ customer, campaignId, start, end }),
+      ]);
+      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", campaign_id:campaignId, period_days:days, date_range:{start,end}, search_terms, keywords, devices, hours, geography, writes_allowed:false, execution_allowed:false, spend_allowed:false });
+    } catch (error) {
+      res.status(500).json({ success:false, source:"google_ads", campaign_id:campaignId, error:cleanGoogleError(error), writes_allowed:false, execution_allowed:false, spend_allowed:false });
+    }
+  });
+}
+
+module.exports = { installGoogleCampaignIntelligenceRoute };

--- a/scheduler-bootstrap.js
+++ b/scheduler-bootstrap.js
@@ -70,6 +70,7 @@ function startReadonlyShadowScheduler({ env = process.env, client = axios } = {}
 }
 
 require('./operational-live-pulse-preload');
+require('./google-campaign-intelligence-preload');
 require('./bootstrap');
 startReadonlyShadowScheduler();
 

--- a/scripts/google-campaign-intelligence-live.js
+++ b/scripts/google-campaign-intelligence-live.js
@@ -1,0 +1,48 @@
+const { GoogleAdsApi } = require("google-ads-api");
+const {
+  collectCampaignSearchTerms,
+  collectCampaignKeywords,
+  collectCampaignDevices,
+  collectCampaignHours,
+  collectCampaignGeography,
+} = require("../google-campaign-breakdowns");
+
+function normalize(value) { return String(value || "").replace(/\D/g, ""); }
+function date(value) { return value.toISOString().slice(0, 10); }
+function range(days) {
+  const end = new Date(); end.setUTCHours(0,0,0,0); end.setUTCDate(end.getUTCDate()-1);
+  const start = new Date(end); start.setUTCDate(start.getUTCDate()-(days-1));
+  return { start: date(start), end: date(end) };
+}
+function sum(rows, field) { return rows.reduce((n,row)=>n+Number(row[field]||0),0); }
+function top(rows, key, limit=12) {
+  return [...rows].sort((a,b)=>Number(b.clicks||0)-Number(a.clicks||0)).slice(0,limit).map(row=>({
+    [key]: row[key], impressions:row.impressions, clicks:row.clicks,
+    cost_eur:Number(row.cost_eur||0).toFixed(2), conversions:row.conversions
+  }));
+}
+
+(async () => {
+  const campaignId = process.env.GOOGLE_CAMPAIGN_ID || "23276824770";
+  const days = Number(process.env.GOOGLE_INTELLIGENCE_DAYS || 30);
+  const required = ["GOOGLE_CLIENT_ID","GOOGLE_CLIENT_SECRET","GOOGLE_DEVELOPER_TOKEN","GOOGLE_REFRESH_TOKEN","GOOGLE_CUSTOMER_ID"];
+  const missing = required.filter(k=>!process.env[k]);
+  if (missing.length) throw new Error(`missing_config:${missing.join(",")}`);
+  const api = new GoogleAdsApi({client_id:process.env.GOOGLE_CLIENT_ID,client_secret:process.env.GOOGLE_CLIENT_SECRET,developer_token:process.env.GOOGLE_DEVELOPER_TOKEN});
+  const cfg={customer_id:normalize(process.env.GOOGLE_CUSTOMER_ID),refresh_token:process.env.GOOGLE_REFRESH_TOKEN};
+  const login=normalize(process.env.GOOGLE_LOGIN_CUSTOMER_ID); if(login) cfg.login_customer_id=login;
+  const customer=api.Customer(cfg); const {start,end}=range(days);
+  const [searchTerms,keywords,devices,hours,geography]=await Promise.all([
+    collectCampaignSearchTerms({customer,campaignId,start,end}), collectCampaignKeywords({customer,campaignId,start,end}),
+    collectCampaignDevices({customer,campaignId,start,end}), collectCampaignHours({customer,campaignId,start,end}),
+    collectCampaignGeography({customer,campaignId,start,end})
+  ]);
+  const result={success:true,mode:"read_only",campaign_id:campaignId,days,date_range:{start,end},
+    counts:{search_terms:searchTerms.length,keywords:keywords.length,devices:devices.length,hours:hours.length,geography:geography.length},
+    totals:{impressions:sum(devices,"impressions"),clicks:sum(devices,"clicks"),cost_eur:Number(sum(devices,"cost_eur").toFixed(2)),conversions:sum(devices,"conversions")},
+    top_search_terms:top(searchTerms,"search_term"),top_keywords:top(keywords,"keyword"),devices:top(devices,"device",20),
+    top_hours:[...hours].sort((a,b)=>Number(b.clicks||0)-Number(a.clicks||0)).slice(0,20),
+    top_geography:[...geography].sort((a,b)=>Number(b.clicks||0)-Number(a.clicks||0)).slice(0,20),
+    writes_allowed:false,execution_allowed:false,spend_allowed:false};
+  console.log(JSON.stringify(result));
+})().catch(error=>{ console.error(JSON.stringify({success:false,mode:"read_only",error:String(error.message||error).slice(0,300),writes_allowed:false})); process.exit(1); });

--- a/test/google-campaign-breakdowns.test.js
+++ b/test/google-campaign-breakdowns.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  collectCampaignSearchTerms,
+  collectCampaignKeywords,
+  collectCampaignDevices,
+  collectCampaignHours,
+  collectCampaignGeography,
+} = require('../google-campaign-breakdowns');
+
+function customerWith(row, capture) {
+  return { async query(q) { capture.push(q); return [row]; } };
+}
+const args = { campaignId:'23276824770', start:'2026-07-28', end:'2026-08-26' };
+
+test('all collectors are query-only and campaign scoped', async () => {
+  const capture=[];
+  const customer=customerWith({metrics:{impressions:10,clicks:2,cost_micros:1500000,conversions:1,conversions_value:20},segments:{device:'MOBILE',hour:19,day_of_week:'WEDNESDAY',keyword:{info:{text:'pizza kreuzberg',match_type:'PHRASE'}}},search_term_view:{search_term:'pizza near me'},ad_group_criterion:{keyword:{text:'pizza kreuzberg',match_type:'PHRASE'},status:'ENABLED'},geographic_view:{country_criterion_id:'2276',location_type:'AREA_OF_INTEREST'}},capture);
+  await collectCampaignSearchTerms({customer,...args});
+  await collectCampaignKeywords({customer,...args});
+  await collectCampaignDevices({customer,...args});
+  await collectCampaignHours({customer,...args});
+  await collectCampaignGeography({customer,...args});
+  assert.equal(capture.length,5);
+  for (const q of capture) {
+    assert.match(q,/campaign\.id = 23276824770/);
+    assert.match(q,/2026-07-28/);
+    assert.match(q,/2026-08-26/);
+    assert.doesNotMatch(q,/\b(MUTATE|CREATE|UPDATE|REMOVE)\b/i);
+  }
+});
+
+test('metrics convert micros to euros', async () => {
+  const capture=[];
+  const [row]=await collectCampaignDevices({customer:customerWith({segments:{device:'MOBILE'},metrics:{impressions:10,clicks:2,cost_micros:1500000,conversions:1,conversions_value:20}},capture),...args});
+  assert.deepEqual(row,{device:'MOBILE',impressions:10,clicks:2,cost_eur:1.5,conversions:1,conversion_value:20});
+});
+
+test('rejects invalid campaign ids and dates before querying', async () => {
+  const customer={query:async()=>{throw new Error('must not query')}};
+  await assert.rejects(()=>collectCampaignDevices({customer,campaignId:'23 OR 1=1',start:args.start,end:args.end}),/campaignId is invalid/);
+  await assert.rejects(()=>collectCampaignDevices({customer,campaignId:args.campaignId,start:'yesterday',end:args.end}),/YYYY-MM-DD/);
+});


### PR DESCRIPTION
Adds read-only campaign intelligence for Google Ads campaign 23276824770: search terms, keywords, devices, day/hour and geography. Includes a protected route module and a secret-safe live validation runner/workflow. No campaign writes, execution or spend changes are permitted.