### PR TITLE
Fix Google intelligence route registration order

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,6 +4,9 @@ const axios = require("axios");
 const { randomUUID } = require("crypto");
 const { apiKeysMatch } = require("./api-key-auth");
 const { GoogleAdsApi } = require("google-ads-api");
+const {
+  installGoogleCampaignIntelligenceRoute,
+} = require("./google-campaign-intelligence-route");
 const { buildGoogleReadiness, buildMetaOverview } = require("./reporting");
 const { buildMetaDinnerProposal } = require("./proposals");
 const {
@@ -1870,6 +1873,17 @@ app.get(
   requireApiKey,
   handleGoogleCampaignMetrics
 );
+
+installGoogleCampaignIntelligenceRoute({
+  app,
+  requireApiKey,
+  checkGoogleConfig,
+  parseGoogleCampaignId,
+  parseGoogleDays,
+  getGoogleDateRange,
+  getGoogleCustomer,
+  cleanGoogleError,
+});
 
 /*
  * Backward-compatible route.

--- a/test/google-campaign-intelligence-registration.test.js
+++ b/test/google-campaign-intelligence-registration.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const server = fs.readFileSync(path.join(__dirname, "..", "server.js"), "utf8");
+
+test("Google campaign intelligence route is registered before the 404 fallback", () => {
+  const registration = server.indexOf("installGoogleCampaignIntelligenceRoute({");
+  const fallback = server.indexOf("app.use((req, res) => {");
+
+  assert.notEqual(registration, -1);
+  assert.notEqual(fallback, -1);
+  assert.ok(registration < fallback);
+});
+
+test("Google campaign intelligence route reuses the protected read-only dependencies", () => {
+  assert.match(
+    server,
+    /installGoogleCampaignIntelligenceRoute\(\{[\s\S]*?app,[\s\S]*?requireApiKey,[\s\S]*?checkGoogleConfig,[\s\S]*?getGoogleCustomer,[\s\S]*?cleanGoogleError,[\s\S]*?\}\);/
+  );
+});


### PR DESCRIPTION
Registers the protected Google campaign intelligence route directly in server.js before the generic 404 fallback. Adds regression tests for route ordering and protected read-only dependencies. Local validation: npm run check; targeted tests 8/8; full suite 385/385. No campaign writes, execution, budget changes, credential changes, or spend activation.