### PR TITLE
Fix Google intelligence campaign-scoped SELECT fields

### DIFF
--- a/google-campaign-breakdowns.js
+++ b/google-campaign-breakdowns.js
@@ -42,7 +42,7 @@ async function collectCampaignSearchTerms({ customer, campaignId, start, end }) 
 async function collectCampaignKeywords({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
+    SELECT campaign.id, ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
       ad_group_criterion.status, metrics.impressions, metrics.clicks,
       metrics.cost_micros, metrics.conversions, metrics.conversions_value
     FROM keyword_view
@@ -61,7 +61,7 @@ async function collectCampaignKeywords({ customer, campaignId, start, end }) {
 async function collectCampaignDevices({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT segments.device, metrics.impressions, metrics.clicks,
+    SELECT campaign.id, segments.device, metrics.impressions, metrics.clicks,
       metrics.cost_micros, metrics.conversions, metrics.conversions_value
     FROM campaign
     WHERE campaign.id = ${campaignId}
@@ -73,7 +73,7 @@ async function collectCampaignDevices({ customer, campaignId, start, end }) {
 async function collectCampaignHours({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT segments.day_of_week, segments.hour, metrics.impressions, metrics.clicks,
+    SELECT campaign.id, segments.day_of_week, segments.hour, metrics.impressions, metrics.clicks,
       metrics.cost_micros, metrics.conversions, metrics.conversions_value
     FROM campaign
     WHERE campaign.id = ${campaignId}
@@ -89,7 +89,7 @@ async function collectCampaignHours({ customer, campaignId, start, end }) {
 async function collectCampaignGeography({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT geographic_view.country_criterion_id, geographic_view.location_type,
+    SELECT campaign.id, geographic_view.country_criterion_id, geographic_view.location_type,
       metrics.impressions, metrics.clicks, metrics.cost_micros,
       metrics.conversions, metrics.conversions_value
     FROM geographic_view

--- a/test/google-campaign-breakdowns.test.js
+++ b/test/google-campaign-breakdowns.test.js
@@ -23,6 +23,7 @@ test('all collectors are query-only and campaign scoped', async () => {
   await collectCampaignGeography({customer,...args});
   assert.equal(capture.length,5);
   for (const q of capture) {
+    assert.match(q,/SELECT[\s\S]*campaign\.id[\s\S]*FROM/i);
     assert.match(q,/campaign\.id = 23276824770/);
     assert.match(q,/2026-07-28/);
     assert.match(q,/2026-08-26/);


### PR DESCRIPTION
Adds campaign.id to every Google Ads intelligence SELECT that filters by campaign.id, resolving QUERY_ERROR 16 from the live endpoint. Extends the query-only regression test. Local validation: npm run check; targeted tests 5/5; full suite 385/385. Read-only only; no campaign, budget, credential, or spend changes.