### PR TITLE
Complete Google Ads Reader diagnostics

### DIFF
--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -78,7 +78,7 @@ jobs:
           done
           echo "intelligence=${success}; http=${code}"
           if [ "$code" = "200" ] && [ "$success" = "true" ]; then
-            jq '{success,mode,campaign_id,period_days,date_range,counts:{search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length)},top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
+            jq '{success,mode,campaign_id,period_days,date_range,counts:{overview:(.overview|length),ad_groups:(.ad_groups|length),search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length),rsa_ads:(.rsa_ads|length),rsa_analysis:(.rsa_analysis|length)},campaign_overview:(.overview|map(del(.campaign_id))),top_ad_groups:(.ad_groups|sort_by(-.clicks)|.[0:20]|map(del(.ad_group_id))),top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),rsa_diagnostics:(.rsa_analysis|map(del(.ad_id,.campaign))),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
           else
             jq '{success,error,writes_allowed,execution_allowed,spend_allowed}' intelligence.json 2>/dev/null || true
             exit 1

--- a/google-campaign-breakdowns.js
+++ b/google-campaign-breakdowns.js
@@ -2,6 +2,10 @@ function microsToEur(value) {
   return Number(value || 0) / 1_000_000;
 }
 
+function numberOrNull(value) {
+  return value == null ? null : Number(value);
+}
+
 function validateInput({ customer, campaignId, start, end }) {
   if (!customer || typeof customer.query !== "function") throw new TypeError("customer.query is required");
   if (!/^\d{1,20}$/.test(String(campaignId || ""))) throw new TypeError("campaignId is invalid");
@@ -32,6 +36,8 @@ async function collectCampaignSearchTerms({ customer, campaignId, start, end }) 
       AND segments.date BETWEEN '${start}' AND '${end}'
   `);
   return (rows || []).map((row) => ({
+    ad_group_id: String(row.ad_group?.id || ""),
+    ad_group: row.ad_group?.name || null,
     search_term: row.search_term_view?.search_term || null,
     matched_keyword: row.segments?.keyword?.info?.text || null,
     match_type: row.segments?.keyword?.info?.match_type || null,
@@ -42,7 +48,8 @@ async function collectCampaignSearchTerms({ customer, campaignId, start, end }) 
 async function collectCampaignKeywords({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT campaign.id, ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
+    SELECT campaign.id, ad_group.id, ad_group.name,
+      ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type,
       ad_group_criterion.status, metrics.impressions, metrics.clicks,
       metrics.cost_micros, metrics.conversions, metrics.conversions_value
     FROM keyword_view
@@ -51,6 +58,8 @@ async function collectCampaignKeywords({ customer, campaignId, start, end }) {
       AND segments.date BETWEEN '${start}' AND '${end}'
   `);
   return (rows || []).map((row) => ({
+    ad_group_id: String(row.ad_group?.id || ""),
+    ad_group: row.ad_group?.name || null,
     keyword: row.ad_group_criterion?.keyword?.text || null,
     match_type: row.ad_group_criterion?.keyword?.match_type || null,
     status: row.ad_group_criterion?.status || null,
@@ -103,10 +112,69 @@ async function collectCampaignGeography({ customer, campaignId, start, end }) {
   }));
 }
 
+async function collectCampaignOverview({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT campaign.id, campaign.name, campaign.status, campaign.primary_status,
+      campaign.primary_status_reasons, campaign.advertising_channel_type,
+      campaign_budget.amount_micros,
+      metrics.impressions, metrics.clicks, metrics.cost_micros,
+      metrics.conversions, metrics.conversions_value,
+      metrics.search_impression_share,
+      metrics.search_budget_lost_impression_share,
+      metrics.search_rank_lost_impression_share,
+      metrics.search_top_impression_share,
+      metrics.search_absolute_top_impression_share
+    FROM campaign
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    campaign_id: String(row.campaign?.id || ""),
+    campaign: row.campaign?.name || null,
+    status: row.campaign?.status || null,
+    primary_status: row.campaign?.primary_status || null,
+    primary_status_reasons: row.campaign?.primary_status_reasons || [],
+    channel_type: row.campaign?.advertising_channel_type || null,
+    daily_budget_eur: microsToEur(row.campaign_budget?.amount_micros),
+    ...metricFields(row),
+    search_impression_share: numberOrNull(row.metrics?.search_impression_share),
+    search_budget_lost_impression_share: numberOrNull(row.metrics?.search_budget_lost_impression_share),
+    search_rank_lost_impression_share: numberOrNull(row.metrics?.search_rank_lost_impression_share),
+    search_top_impression_share: numberOrNull(row.metrics?.search_top_impression_share),
+    search_absolute_top_impression_share: numberOrNull(row.metrics?.search_absolute_top_impression_share),
+  }));
+}
+
+async function collectCampaignAdGroups({ customer, campaignId, start, end }) {
+  validateInput({ customer, campaignId, start, end });
+  const rows = await customer.query(`
+    SELECT campaign.id, ad_group.id, ad_group.name, ad_group.status,
+      ad_group.primary_status, ad_group.primary_status_reasons, ad_group.type,
+      metrics.impressions, metrics.clicks, metrics.cost_micros,
+      metrics.conversions, metrics.conversions_value
+    FROM ad_group
+    WHERE campaign.id = ${campaignId}
+      AND ad_group.status != 'REMOVED'
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+  return (rows || []).map((row) => ({
+    ad_group_id: String(row.ad_group?.id || ""),
+    ad_group: row.ad_group?.name || null,
+    status: row.ad_group?.status || null,
+    primary_status: row.ad_group?.primary_status || null,
+    primary_status_reasons: row.ad_group?.primary_status_reasons || [],
+    type: row.ad_group?.type || null,
+    ...metricFields(row),
+  }));
+}
+
 module.exports = {
   collectCampaignSearchTerms,
   collectCampaignKeywords,
   collectCampaignDevices,
   collectCampaignHours,
   collectCampaignGeography,
+  collectCampaignOverview,
+  collectCampaignAdGroups,
 };

--- a/google-campaign-intelligence-route.js
+++ b/google-campaign-intelligence-route.js
@@ -4,7 +4,11 @@ const {
   collectCampaignDevices,
   collectCampaignHours,
   collectCampaignGeography,
+  collectCampaignOverview,
+  collectCampaignAdGroups,
 } = require("./google-campaign-breakdowns");
+const { collectResponsiveSearchAds } = require("./google-rsa-collector");
+const { analyzeRsaSet } = require("./google-rsa-analysis");
 
 function installGoogleCampaignIntelligenceRoute({
   app,
@@ -26,14 +30,17 @@ function installGoogleCampaignIntelligenceRoute({
     try {
       const customer = getGoogleCustomer();
       const { start, end } = getGoogleDateRange(days);
-      const [search_terms, keywords, devices, hours, geography] = await Promise.all([
+      const [overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads] = await Promise.all([
+        collectCampaignOverview({ customer, campaignId, start, end }),
+        collectCampaignAdGroups({ customer, campaignId, start, end }),
         collectCampaignSearchTerms({ customer, campaignId, start, end }),
         collectCampaignKeywords({ customer, campaignId, start, end }),
         collectCampaignDevices({ customer, campaignId, start, end }),
         collectCampaignHours({ customer, campaignId, start, end }),
         collectCampaignGeography({ customer, campaignId, start, end }),
+        collectResponsiveSearchAds({ customer, campaignId, start, end }),
       ]);
-      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", campaign_id:campaignId, period_days:days, date_range:{start,end}, search_terms, keywords, devices, hours, geography, writes_allowed:false, execution_allowed:false, spend_allowed:false });
+      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", campaign_id:campaignId, period_days:days, date_range:{start,end}, overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, rsa_analysis:analyzeRsaSet(rsa_ads), writes_allowed:false, execution_allowed:false, spend_allowed:false });
     } catch (error) {
       res.status(500).json({ success:false, source:"google_ads", campaign_id:campaignId, error:cleanGoogleError(error), writes_allowed:false, execution_allowed:false, spend_allowed:false });
     }

--- a/google-rsa-collector.js
+++ b/google-rsa-collector.js
@@ -1,6 +1,8 @@
-async function collectResponsiveSearchAds({customer,start,end}){
+async function collectResponsiveSearchAds({customer,campaignId,start,end}){
   if(!customer||typeof customer.query!=="function")throw new TypeError("customer.query is required");
+  if(campaignId!=null&&!/^\d{1,20}$/.test(String(campaignId)))throw new TypeError("campaignId is invalid");
   if(!/^\d{4}-\d{2}-\d{2}$/.test(String(start||""))||!/^\d{4}-\d{2}-\d{2}$/.test(String(end||"")))throw new TypeError("start and end must be YYYY-MM-DD");
+  const campaignFilter=campaignId==null?"":`\n      AND campaign.id = ${campaignId}`;
   const rows=await customer.query(`
     SELECT campaign.id, campaign.name, ad_group.id, ad_group.name,
       ad_group_ad.ad.id, ad_group_ad.status, ad_group_ad.ad_strength,
@@ -11,6 +13,7 @@ async function collectResponsiveSearchAds({customer,start,end}){
     FROM ad_group_ad
     WHERE ad_group_ad.ad.type = 'RESPONSIVE_SEARCH_AD'
       AND ad_group_ad.status != 'REMOVED'
+      ${campaignFilter}
       AND segments.date BETWEEN '${start}' AND '${end}'
   `);
   return (rows||[]).map(row=>({

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,6 +148,36 @@ paths:
       responses:
         "200":
           description: OK
+  /tools/google/campaign/{id}/intelligence:
+    get:
+      operationId: getGoogleCampaignIntelligence
+      summary: Get complete read-only Google Ads campaign diagnostics
+      description: Returns campaign status, daily budget, impression share, ad groups, search terms, keywords, devices, hours, geography and RSA analysis. It never changes campaigns, ads, budgets, configuration or spend.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: days
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
+      responses:
+        "200":
+          description: Complete read-only campaign intelligence
+        "400":
+          description: Invalid campaign id or date range
+        "401":
+          description: Unauthorized
+        "500":
+          description: Google Ads query failed safely
   /tools/campaign/{id}/metrics:
     get:
       operationId: getCampaignMetrics

--- a/scripts/google-campaign-intelligence-live.js
+++ b/scripts/google-campaign-intelligence-live.js
@@ -5,7 +5,11 @@ const {
   collectCampaignDevices,
   collectCampaignHours,
   collectCampaignGeography,
+  collectCampaignOverview,
+  collectCampaignAdGroups,
 } = require("../google-campaign-breakdowns");
+const { collectResponsiveSearchAds } = require("../google-rsa-collector");
+const { analyzeRsaSet } = require("../google-rsa-analysis");
 
 function normalize(value) { return String(value || "").replace(/\D/g, ""); }
 function date(value) { return value.toISOString().slice(0, 10); }
@@ -32,17 +36,20 @@ function top(rows, key, limit=12) {
   const cfg={customer_id:normalize(process.env.GOOGLE_CUSTOMER_ID),refresh_token:process.env.GOOGLE_REFRESH_TOKEN};
   const login=normalize(process.env.GOOGLE_LOGIN_CUSTOMER_ID); if(login) cfg.login_customer_id=login;
   const customer=api.Customer(cfg); const {start,end}=range(days);
-  const [searchTerms,keywords,devices,hours,geography]=await Promise.all([
+  const [overview,adGroups,searchTerms,keywords,devices,hours,geography,rsaAds]=await Promise.all([
+    collectCampaignOverview({customer,campaignId,start,end}), collectCampaignAdGroups({customer,campaignId,start,end}),
     collectCampaignSearchTerms({customer,campaignId,start,end}), collectCampaignKeywords({customer,campaignId,start,end}),
     collectCampaignDevices({customer,campaignId,start,end}), collectCampaignHours({customer,campaignId,start,end}),
-    collectCampaignGeography({customer,campaignId,start,end})
+    collectCampaignGeography({customer,campaignId,start,end}), collectResponsiveSearchAds({customer,campaignId,start,end})
   ]);
   const result={success:true,mode:"read_only",campaign_id:campaignId,days,date_range:{start,end},
-    counts:{search_terms:searchTerms.length,keywords:keywords.length,devices:devices.length,hours:hours.length,geography:geography.length},
+    counts:{overview:overview.length,ad_groups:adGroups.length,search_terms:searchTerms.length,keywords:keywords.length,devices:devices.length,hours:hours.length,geography:geography.length,rsa_ads:rsaAds.length},
     totals:{impressions:sum(devices,"impressions"),clicks:sum(devices,"clicks"),cost_eur:Number(sum(devices,"cost_eur").toFixed(2)),conversions:sum(devices,"conversions")},
+    overview:overview.map(({campaign_id,...row})=>row),top_ad_groups:top(adGroups,"ad_group",20),
     top_search_terms:top(searchTerms,"search_term"),top_keywords:top(keywords,"keyword"),devices:top(devices,"device",20),
     top_hours:[...hours].sort((a,b)=>Number(b.clicks||0)-Number(a.clicks||0)).slice(0,20),
     top_geography:[...geography].sort((a,b)=>Number(b.clicks||0)-Number(a.clicks||0)).slice(0,20),
+    rsa_diagnostics:analyzeRsaSet(rsaAds).map(({ad_id,campaign,...row})=>row),
     writes_allowed:false,execution_allowed:false,spend_allowed:false};
   console.log(JSON.stringify(result));
 })().catch(error=>{ console.error(JSON.stringify({success:false,mode:"read_only",error:String(error.message||error).slice(0,300),writes_allowed:false})); process.exit(1); });

--- a/test/google-campaign-breakdowns.test.js
+++ b/test/google-campaign-breakdowns.test.js
@@ -6,6 +6,8 @@ const {
   collectCampaignDevices,
   collectCampaignHours,
   collectCampaignGeography,
+  collectCampaignOverview,
+  collectCampaignAdGroups,
 } = require('../google-campaign-breakdowns');
 
 function customerWith(row, capture) {
@@ -15,13 +17,15 @@ const args = { campaignId:'23276824770', start:'2026-07-28', end:'2026-08-26' };
 
 test('all collectors are query-only and campaign scoped', async () => {
   const capture=[];
-  const customer=customerWith({metrics:{impressions:10,clicks:2,cost_micros:1500000,conversions:1,conversions_value:20},segments:{device:'MOBILE',hour:19,day_of_week:'WEDNESDAY',keyword:{info:{text:'pizza kreuzberg',match_type:'PHRASE'}}},search_term_view:{search_term:'pizza near me'},ad_group_criterion:{keyword:{text:'pizza kreuzberg',match_type:'PHRASE'},status:'ENABLED'},geographic_view:{country_criterion_id:'2276',location_type:'AREA_OF_INTEREST'}},capture);
+  const customer=customerWith({campaign:{id:'23276824770',name:'Dinner',status:'ENABLED'},campaign_budget:{amount_micros:25000000},ad_group:{id:'12',name:'Core',status:'ENABLED'},metrics:{impressions:10,clicks:2,cost_micros:1500000,conversions:1,conversions_value:20},segments:{device:'MOBILE',hour:19,day_of_week:'WEDNESDAY',keyword:{info:{text:'pizza kreuzberg',match_type:'PHRASE'}}},search_term_view:{search_term:'pizza near me'},ad_group_criterion:{keyword:{text:'pizza kreuzberg',match_type:'PHRASE'},status:'ENABLED'},geographic_view:{country_criterion_id:'2276',location_type:'AREA_OF_INTEREST'}},capture);
+  await collectCampaignOverview({customer,...args});
+  await collectCampaignAdGroups({customer,...args});
   await collectCampaignSearchTerms({customer,...args});
   await collectCampaignKeywords({customer,...args});
   await collectCampaignDevices({customer,...args});
   await collectCampaignHours({customer,...args});
   await collectCampaignGeography({customer,...args});
-  assert.equal(capture.length,5);
+  assert.equal(capture.length,7);
   for (const q of capture) {
     assert.match(q,/SELECT[\s\S]*campaign\.id[\s\S]*FROM/i);
     assert.match(q,/campaign\.id = 23276824770/);
@@ -29,6 +33,27 @@ test('all collectors are query-only and campaign scoped', async () => {
     assert.match(q,/2026-08-26/);
     assert.doesNotMatch(q,/\b(MUTATE|CREATE|UPDATE|REMOVE)\b/i);
   }
+});
+
+test('overview maps budget and search impression share diagnostics', async () => {
+  const capture=[];
+  const [row]=await collectCampaignOverview({customer:customerWith({campaign:{id:'23276824770',name:'Dinner',status:'ENABLED',primary_status:'ELIGIBLE',primary_status_reasons:[],advertising_channel_type:'SEARCH'},campaign_budget:{amount_micros:25000000},metrics:{impressions:100,clicks:10,cost_micros:5000000,conversions:2,conversions_value:40,search_impression_share:0.4,search_budget_lost_impression_share:0.15,search_rank_lost_impression_share:0.45,search_top_impression_share:0.3,search_absolute_top_impression_share:0.1}},capture),...args});
+  assert.equal(row.daily_budget_eur,25);
+  assert.equal(row.search_impression_share,0.4);
+  assert.equal(row.search_budget_lost_impression_share,0.15);
+  assert.equal(row.search_rank_lost_impression_share,0.45);
+  assert.equal(row.cost_eur,5);
+});
+
+test('ad groups, search terms and keywords retain their ad-group context', async () => {
+  const source={ad_group:{id:'12',name:'Core',status:'ENABLED',primary_status:'ELIGIBLE',primary_status_reasons:[],type:'SEARCH_STANDARD'},search_term_view:{search_term:'pizza near me'},segments:{keyword:{info:{text:'pizza',match_type:'PHRASE'}}},ad_group_criterion:{keyword:{text:'pizza',match_type:'PHRASE'},status:'ENABLED'},metrics:{impressions:10,clicks:2,cost_micros:1000000,conversions:1,conversions_value:20}};
+  const capture=[];
+  const [group]=await collectCampaignAdGroups({customer:customerWith(source,capture),...args});
+  const [term]=await collectCampaignSearchTerms({customer:customerWith(source,capture),...args});
+  const [keyword]=await collectCampaignKeywords({customer:customerWith(source,capture),...args});
+  assert.deepEqual([group.ad_group_id,group.ad_group],['12','Core']);
+  assert.deepEqual([term.ad_group_id,term.ad_group],['12','Core']);
+  assert.deepEqual([keyword.ad_group_id,keyword.ad_group],['12','Core']);
 });
 
 test('metrics convert micros to euros', async () => {

--- a/test/google-campaign-intelligence-registration.test.js
+++ b/test/google-campaign-intelligence-registration.test.js
@@ -20,3 +20,13 @@ test("Google campaign intelligence route reuses the protected read-only dependen
     /installGoogleCampaignIntelligenceRoute\(\{[\s\S]*?app,[\s\S]*?requireApiKey,[\s\S]*?checkGoogleConfig,[\s\S]*?getGoogleCustomer,[\s\S]*?cleanGoogleError,[\s\S]*?\}\);/
   );
 });
+
+test("Google campaign intelligence response includes the complete reader diagnostics", () => {
+  const route = fs.readFileSync(path.join(__dirname, "..", "google-campaign-intelligence-route.js"), "utf8");
+  for (const field of ["overview", "ad_groups", "search_terms", "keywords", "devices", "hours", "geography", "rsa_ads", "rsa_analysis"]) {
+    assert.ok(route.includes(field), `${field} missing from intelligence route`);
+  }
+  assert.ok(route.includes("writes_allowed:false"));
+  assert.ok(route.includes("execution_allowed:false"));
+  assert.ok(route.includes("spend_allowed:false"));
+});

--- a/test/google-rsa-collector.test.js
+++ b/test/google-rsa-collector.test.js
@@ -5,13 +5,21 @@ const {collectResponsiveSearchAds}=require("../google-rsa-collector");
 test("RSA collector uses query-only transport and maps assets",async()=>{
   const calls=[];
   const customer={query:async(q)=>{calls.push(q);return [{campaign:{id:1,name:"Dinner"},ad_group:{id:2,name:"Core"},ad_group_ad:{status:"ENABLED",ad_strength:"GOOD",ad:{id:3,responsive_search_ad:{headlines:[{text:"Bio Pizza Berlin"}],descriptions:[{text:"Reserve tonight"}]}}},metrics:{impressions:100,clicks:10,cost_micros:5000000,conversions:2}}];}};
-  const rows=await collectResponsiveSearchAds({customer,start:"2026-08-01",end:"2026-08-20"});
+  const rows=await collectResponsiveSearchAds({customer,campaignId:"23276824770",start:"2026-08-01",end:"2026-08-20"});
   assert.equal(calls.length,1);
   assert.match(calls[0],/FROM ad_group_ad/);
   assert.match(calls[0],/RESPONSIVE_SEARCH_AD/);
+  assert.match(calls[0],/campaign\.id = 23276824770/);
+  assert.doesNotMatch(calls[0],/\b(MUTATE|CREATE|UPDATE|REMOVE)\b/i);
   assert.deepEqual(rows[0].headlines,["Bio Pizza Berlin"]);
   assert.equal(rows[0].cost_eur,5);
   assert.equal(rows[0].conversions,2);
+});
+
+test("RSA collector rejects invalid campaign ids before querying",async()=>{
+  let called=false;
+  await assert.rejects(()=>collectResponsiveSearchAds({customer:{query:async()=>{called=true;return[];}},campaignId:"23 OR 1=1",start:"2026-08-01",end:"2026-08-20"}),/campaignId is invalid/);
+  assert.equal(called,false);
 });
 
 test("RSA collector rejects invalid dates before querying",async()=>{

--- a/test/openapi-contract.test.js
+++ b/test/openapi-contract.test.js
@@ -37,6 +37,13 @@ test("Google campaign metric routes are declared in OpenAPI and implemented by t
   assert.ok(server.includes("handleGoogleCampaignMetrics"), "shared Google campaign metric handler is missing");
 });
 
+test("complete Google campaign intelligence is declared as a protected read-only endpoint", () => {
+  assert.ok(openapi.includes("/tools/google/campaign/{id}/intelligence:"));
+  assert.ok(openapi.includes("operationId: getGoogleCampaignIntelligence"));
+  assert.ok(openapi.includes("complete read-only Google Ads campaign diagnostics"));
+  assert.ok(server.includes("installGoogleCampaignIntelligenceRoute"));
+});
+
 test("Meta campaign metrics remain on a distinct namespace", () => {
   assert.ok(openapi.includes("/tools/meta/campaign/{id}/metrics:"));
   assert.ok(openapi.includes("operationId: getMetaCampaignMetrics"));


### PR DESCRIPTION
Completes Module 1 read-only campaign diagnostics with campaign status/budget/impression share, ad-group breakdowns, campaign-scoped RSA collection and RSA analysis. Extends the protected intelligence endpoint, OpenAPI contract, sanitized live validation, and tests.

Safety: query-only Google Ads access; no campaign, ad, budget, credential or spend mutations.

Validation: `npm run check` and all 390 tests pass locally.