### PR TITLE
Make Google reader diagnostics human-readable

### DIFF
--- a/google-campaign-breakdowns.js
+++ b/google-campaign-breakdowns.js
@@ -6,6 +6,21 @@ function numberOrNull(value) {
   return value == null ? null : Number(value);
 }
 
+function enumName(value, names) {
+  if (value == null) return null;
+  if (typeof value === "string" && !/^\d+$/.test(value)) return value;
+  return names[Number(value)] || String(value);
+}
+
+const STATUS = {0:"UNSPECIFIED",1:"UNKNOWN",2:"ENABLED",3:"PAUSED",4:"REMOVED"};
+const PRIMARY_STATUS = {0:"UNSPECIFIED",1:"UNKNOWN",2:"ELIGIBLE",3:"PAUSED",4:"REMOVED",5:"ENDED",6:"PENDING",7:"MISCONFIGURED",8:"LIMITED",9:"LEARNING",10:"NOT_ELIGIBLE"};
+const CHANNEL = {0:"UNSPECIFIED",1:"UNKNOWN",2:"SEARCH",3:"DISPLAY",4:"SHOPPING",5:"HOTEL",6:"VIDEO",7:"MULTI_CHANNEL",8:"LOCAL",9:"SMART",10:"PERFORMANCE_MAX",11:"LOCAL_SERVICES",13:"TRAVEL",14:"DEMAND_GEN"};
+const AD_GROUP_TYPE = {0:"UNSPECIFIED",1:"UNKNOWN",2:"SEARCH_STANDARD",3:"DISPLAY_STANDARD",4:"SHOPPING_PRODUCT_ADS",6:"HOTEL_ADS",13:"SEARCH_DYNAMIC_ADS",16:"VIDEO_RESPONSIVE"};
+const KEYWORD_MATCH = {0:"UNSPECIFIED",1:"UNKNOWN",2:"EXACT",3:"PHRASE",4:"BROAD"};
+const DEVICE = {0:"UNSPECIFIED",1:"UNKNOWN",2:"MOBILE",3:"TABLET",4:"DESKTOP",5:"CONNECTED_TV",6:"OTHER"};
+const DAY = {0:"UNSPECIFIED",1:"UNKNOWN",2:"MONDAY",3:"TUESDAY",4:"WEDNESDAY",5:"THURSDAY",6:"FRIDAY",7:"SATURDAY",8:"SUNDAY"};
+const GEO_TYPE = {0:"UNSPECIFIED",1:"UNKNOWN",2:"AREA_OF_INTEREST",3:"LOCATION_OF_PRESENCE"};
+
 function validateInput({ customer, campaignId, start, end }) {
   if (!customer || typeof customer.query !== "function") throw new TypeError("customer.query is required");
   if (!/^\d{1,20}$/.test(String(campaignId || ""))) throw new TypeError("campaignId is invalid");
@@ -27,7 +42,7 @@ function metricFields(row) {
 async function collectCampaignSearchTerms({ customer, campaignId, start, end }) {
   validateInput({ customer, campaignId, start, end });
   const rows = await customer.query(`
-    SELECT campaign.id, ad_group.id, search_term_view.search_term,
+    SELECT campaign.id, ad_group.id, ad_group.name, search_term_view.search_term,
       segments.keyword.info.text, segments.keyword.info.match_type,
       metrics.impressions, metrics.clicks, metrics.cost_micros,
       metrics.conversions, metrics.conversions_value
@@ -40,7 +55,7 @@ async function collectCampaignSearchTerms({ customer, campaignId, start, end }) 
     ad_group: row.ad_group?.name || null,
     search_term: row.search_term_view?.search_term || null,
     matched_keyword: row.segments?.keyword?.info?.text || null,
-    match_type: row.segments?.keyword?.info?.match_type || null,
+    match_type: enumName(row.segments?.keyword?.info?.match_type, KEYWORD_MATCH),
     ...metricFields(row),
   }));
 }
@@ -61,8 +76,8 @@ async function collectCampaignKeywords({ customer, campaignId, start, end }) {
     ad_group_id: String(row.ad_group?.id || ""),
     ad_group: row.ad_group?.name || null,
     keyword: row.ad_group_criterion?.keyword?.text || null,
-    match_type: row.ad_group_criterion?.keyword?.match_type || null,
-    status: row.ad_group_criterion?.status || null,
+    match_type: enumName(row.ad_group_criterion?.keyword?.match_type, KEYWORD_MATCH),
+    status: enumName(row.ad_group_criterion?.status, STATUS),
     ...metricFields(row),
   }));
 }
@@ -76,7 +91,7 @@ async function collectCampaignDevices({ customer, campaignId, start, end }) {
     WHERE campaign.id = ${campaignId}
       AND segments.date BETWEEN '${start}' AND '${end}'
   `);
-  return (rows || []).map((row) => ({ device: row.segments?.device || "UNKNOWN", ...metricFields(row) }));
+  return (rows || []).map((row) => ({ device: enumName(row.segments?.device, DEVICE) || "UNKNOWN", ...metricFields(row) }));
 }
 
 async function collectCampaignHours({ customer, campaignId, start, end }) {
@@ -89,7 +104,7 @@ async function collectCampaignHours({ customer, campaignId, start, end }) {
       AND segments.date BETWEEN '${start}' AND '${end}'
   `);
   return (rows || []).map((row) => ({
-    day_of_week: row.segments?.day_of_week || null,
+    day_of_week: enumName(row.segments?.day_of_week, DAY),
     hour: Number(row.segments?.hour || 0),
     ...metricFields(row),
   }));
@@ -107,7 +122,7 @@ async function collectCampaignGeography({ customer, campaignId, start, end }) {
   `);
   return (rows || []).map((row) => ({
     country_criterion_id: String(row.geographic_view?.country_criterion_id || ""),
-    location_type: row.geographic_view?.location_type || null,
+    location_type: enumName(row.geographic_view?.location_type, GEO_TYPE),
     ...metricFields(row),
   }));
 }
@@ -132,10 +147,10 @@ async function collectCampaignOverview({ customer, campaignId, start, end }) {
   return (rows || []).map((row) => ({
     campaign_id: String(row.campaign?.id || ""),
     campaign: row.campaign?.name || null,
-    status: row.campaign?.status || null,
-    primary_status: row.campaign?.primary_status || null,
+    status: enumName(row.campaign?.status, STATUS),
+    primary_status: enumName(row.campaign?.primary_status, PRIMARY_STATUS),
     primary_status_reasons: row.campaign?.primary_status_reasons || [],
-    channel_type: row.campaign?.advertising_channel_type || null,
+    channel_type: enumName(row.campaign?.advertising_channel_type, CHANNEL),
     daily_budget_eur: microsToEur(row.campaign_budget?.amount_micros),
     ...metricFields(row),
     search_impression_share: numberOrNull(row.metrics?.search_impression_share),
@@ -161,10 +176,10 @@ async function collectCampaignAdGroups({ customer, campaignId, start, end }) {
   return (rows || []).map((row) => ({
     ad_group_id: String(row.ad_group?.id || ""),
     ad_group: row.ad_group?.name || null,
-    status: row.ad_group?.status || null,
-    primary_status: row.ad_group?.primary_status || null,
+    status: enumName(row.ad_group?.status, STATUS),
+    primary_status: enumName(row.ad_group?.primary_status, PRIMARY_STATUS),
     primary_status_reasons: row.ad_group?.primary_status_reasons || [],
-    type: row.ad_group?.type || null,
+    type: enumName(row.ad_group?.type, AD_GROUP_TYPE),
     ...metricFields(row),
   }));
 }

--- a/google-rsa-analysis.js
+++ b/google-rsa-analysis.js
@@ -1,5 +1,12 @@
 function normalizeAssets(values=[]){return (values||[]).map(v=>typeof v==="string"?v:v?.text).filter(Boolean).map(v=>String(v).trim()).filter(Boolean);}
 
+function normalizeAdStrength(value){
+  const names={0:"UNSPECIFIED",1:"UNKNOWN",2:"PENDING",3:"NO_ADS",4:"POOR",5:"AVERAGE",6:"GOOD",7:"EXCELLENT"};
+  if(value==null||value==="")return "";
+  if(typeof value==="string"&&!/^\d+$/.test(value))return value.toUpperCase();
+  return names[Number(value)]||String(value).toUpperCase();
+}
+
 function analyzeRsa(row={}, {minHeadlines=8,minDescriptions=3}={}){
   const headlines=normalizeAssets(row.headlines);
   const descriptions=normalizeAssets(row.descriptions);
@@ -10,7 +17,7 @@ function analyzeRsa(row={}, {minHeadlines=8,minDescriptions=3}={}){
   if(new Set(normalized).size<headlines.length)issues.push({code:"RSA_DUPLICATE_HEADLINES",severity:"medium",reason:"Duplicate or near-identical headline text reduces asset diversity."});
   const weak=headlines.filter(x=>x.length<12);
   if(weak.length>=Math.max(2,Math.ceil(headlines.length/3)))issues.push({code:"RSA_SHORT_HEADLINES",severity:"low",reason:"A large share of headlines are very short and may underuse available message space."});
-  const adStrength=String(row.ad_strength||row.adStrength||"").toUpperCase();
+  const adStrength=normalizeAdStrength(row.ad_strength??row.adStrength);
   if(["POOR","AVERAGE"].includes(adStrength))issues.push({code:"RSA_AD_STRENGTH_WEAK",severity:"medium",reason:`Google Ads reports RSA strength ${adStrength}.`});
   const clicks=Number(row.clicks||0),conversions=Number(row.conversions||0),impressions=Number(row.impressions||0);
   if(clicks>=20&&conversions===0)issues.push({code:"RSA_TRAFFIC_WITHOUT_CONVERSIONS",severity:"high",reason:"RSA has meaningful click volume without conversions; inspect intent and landing continuity before rewriting blindly."});

--- a/test/google-campaign-breakdowns.test.js
+++ b/test/google-campaign-breakdowns.test.js
@@ -45,6 +45,18 @@ test('overview maps budget and search impression share diagnostics', async () =>
   assert.equal(row.cost_eur,5);
 });
 
+test('numeric Google enums become readable diagnostic labels', async () => {
+  const capture=[];
+  const [overview]=await collectCampaignOverview({customer:customerWith({campaign:{id:'23276824770',status:2,primary_status:2,advertising_channel_type:2},metrics:{}},capture),...args});
+  const [device]=await collectCampaignDevices({customer:customerWith({segments:{device:2},metrics:{}},capture),...args});
+  const [hour]=await collectCampaignHours({customer:customerWith({segments:{day_of_week:6,hour:18},metrics:{}},capture),...args});
+  const [geo]=await collectCampaignGeography({customer:customerWith({geographic_view:{location_type:3},metrics:{}},capture),...args});
+  assert.deepEqual([overview.status,overview.primary_status,overview.channel_type],['ENABLED','ELIGIBLE','SEARCH']);
+  assert.equal(device.device,'MOBILE');
+  assert.equal(hour.day_of_week,'FRIDAY');
+  assert.equal(geo.location_type,'LOCATION_OF_PRESENCE');
+});
+
 test('ad groups, search terms and keywords retain their ad-group context', async () => {
   const source={ad_group:{id:'12',name:'Core',status:'ENABLED',primary_status:'ELIGIBLE',primary_status_reasons:[],type:'SEARCH_STANDARD'},search_term_view:{search_term:'pizza near me'},segments:{keyword:{info:{text:'pizza',match_type:'PHRASE'}}},ad_group_criterion:{keyword:{text:'pizza',match_type:'PHRASE'},status:'ENABLED'},metrics:{impressions:10,clicks:2,cost_micros:1000000,conversions:1,conversions_value:20}};
   const capture=[];

--- a/test/google-rsa-analysis.test.js
+++ b/test/google-rsa-analysis.test.js
@@ -23,3 +23,11 @@ test("RSA set prioritizes high severity issues",()=>{
   ]);
   assert.equal(rows[0].ad_id,"high");
 });
+
+test("RSA analyzer translates numeric Google ad strength enums",()=>{
+  const poor=analyzeRsa({ad_strength:4,headlines:Array(8).fill("Long headline"),descriptions:Array(3).fill("Description"),metrics:{}});
+  const good=analyzeRsa({ad_strength:6,headlines:Array(8).fill("Long headline"),descriptions:Array(3).fill("Description"),metrics:{}});
+  assert.equal(poor.ad_strength,"POOR");
+  assert.ok(poor.issues.some(issue=>issue.code==="RSA_AD_STRENGTH_WEAK"));
+  assert.equal(good.ad_strength,"GOOD");
+});


### PR DESCRIPTION
Normalizes numeric Google Ads enum values into readable status, channel, device, day, location, match-type and RSA strength labels. Also includes the ad-group name in search-term rows.

All 392 tests pass locally. Query-only; no campaign, budget, credential or spend changes.