### PR TITLE
Version Google reader live validation

### DIFF
--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -73,13 +73,13 @@ jobs:
           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
             code=$(curl -sS -o intelligence.json -w "%{http_code}" -H "x-api-key: $PARMA_AGENT_API_KEY" "$BASE/tools/google/campaign/$CAMPAIGN_ID/intelligence?days=$DAYS" || true)
             success=$(jq -r '.success // false' intelligence.json 2>/dev/null || echo false)
-            complete=$(jq -r '(.success == true) and ((.overview|type) == "array") and ((.ad_groups|type) == "array") and ((.rsa_ads|type) == "array") and ((.rsa_analysis|type) == "array")' intelligence.json 2>/dev/null || echo false)
+            complete=$(jq -r '(.success == true) and (.reader_version == 2) and ((.overview|type) == "array") and ((.ad_groups|type) == "array") and ((.rsa_ads|type) == "array") and ((.rsa_analysis|type) == "array")' intelligence.json 2>/dev/null || echo false)
             if [ "$code" = "200" ] && [ "$complete" = "true" ]; then break; fi
             sleep 15
           done
           echo "intelligence=${success}; complete_reader=${complete}; http=${code}"
           if [ "$code" = "200" ] && [ "$complete" = "true" ]; then
-            jq '{success,mode,campaign_id,period_days,date_range,counts:{overview:(.overview|length),ad_groups:(.ad_groups|length),search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length),rsa_ads:(.rsa_ads|length),rsa_analysis:(.rsa_analysis|length)},campaign_overview:(.overview|map(del(.campaign_id))),top_ad_groups:(.ad_groups|sort_by(-.clicks)|.[0:20]|map(del(.ad_group_id))),top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),rsa_diagnostics:(.rsa_analysis|map(del(.ad_id,.campaign))),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
+            jq '{success,mode,reader_version,campaign_id,period_days,date_range,counts:{overview:(.overview|length),ad_groups:(.ad_groups|length),search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length),rsa_ads:(.rsa_ads|length),rsa_analysis:(.rsa_analysis|length)},campaign_overview:(.overview|map(del(.campaign_id))),top_ad_groups:(.ad_groups|sort_by(-.clicks)|.[0:20]|map(del(.ad_group_id))),top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),rsa_diagnostics:(.rsa_analysis|map(del(.ad_id,.campaign))),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
           else
             jq '{success,error,writes_allowed,execution_allowed,spend_allowed}' intelligence.json 2>/dev/null || true
             exit 1

--- a/google-campaign-intelligence-route.js
+++ b/google-campaign-intelligence-route.js
@@ -40,7 +40,7 @@ function installGoogleCampaignIntelligenceRoute({
         collectCampaignGeography({ customer, campaignId, start, end }),
         collectResponsiveSearchAds({ customer, campaignId, start, end }),
       ]);
-      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", campaign_id:campaignId, period_days:days, date_range:{start,end}, overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, rsa_analysis:analyzeRsaSet(rsa_ads), writes_allowed:false, execution_allowed:false, spend_allowed:false });
+      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", reader_version:2, campaign_id:campaignId, period_days:days, date_range:{start,end}, overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, rsa_analysis:analyzeRsaSet(rsa_ads), writes_allowed:false, execution_allowed:false, spend_allowed:false });
     } catch (error) {
       res.status(500).json({ success:false, source:"google_ads", campaign_id:campaignId, error:cleanGoogleError(error), writes_allowed:false, execution_allowed:false, spend_allowed:false });
     }

--- a/test/google-campaign-intelligence-registration.test.js
+++ b/test/google-campaign-intelligence-registration.test.js
@@ -29,4 +29,5 @@ test("Google campaign intelligence response includes the complete reader diagnos
   assert.ok(route.includes("writes_allowed:false"));
   assert.ok(route.includes("execution_allowed:false"));
   assert.ok(route.includes("spend_allowed:false"));
+  assert.ok(route.includes("reader_version:2"));
 });


### PR DESCRIPTION
Adds `reader_version: 2` to the complete intelligence response and makes the Railway validation wait for that exact version. This removes the last deployment race between compatible response shapes.

Read-only; no advertising, budget, credential or spend changes.