### PR TITLE
Add Google Ads conversion-action diagnostics

### DIFF
--- a/.github/workflows/google-live-access.yml
+++ b/.github/workflows/google-live-access.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           node --check google-campaign-breakdowns.js
+          node --check google-conversion-action-breakdown.js
           node --check google-campaign-intelligence-preload.js
           node --check scripts/google-campaign-intelligence-live.js
           echo "intelligence_live=deferred_until_main_deploy"
@@ -73,13 +74,13 @@ jobs:
           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
             code=$(curl -sS -o intelligence.json -w "%{http_code}" -H "x-api-key: $PARMA_AGENT_API_KEY" "$BASE/tools/google/campaign/$CAMPAIGN_ID/intelligence?days=$DAYS" || true)
             success=$(jq -r '.success // false' intelligence.json 2>/dev/null || echo false)
-            complete=$(jq -r '(.success == true) and (.reader_version == 2) and ((.overview|type) == "array") and ((.ad_groups|type) == "array") and ((.rsa_ads|type) == "array") and ((.rsa_analysis|type) == "array")' intelligence.json 2>/dev/null || echo false)
+            complete=$(jq -r '(.success == true) and (.reader_version == 3) and ((.overview|type) == "array") and ((.ad_groups|type) == "array") and ((.rsa_ads|type) == "array") and ((.rsa_analysis|type) == "array") and ((.conversion_actions|type) == "array")' intelligence.json 2>/dev/null || echo false)
             if [ "$code" = "200" ] && [ "$complete" = "true" ]; then break; fi
             sleep 15
           done
           echo "intelligence=${success}; complete_reader=${complete}; http=${code}"
           if [ "$code" = "200" ] && [ "$complete" = "true" ]; then
-            jq '{success,mode,reader_version,campaign_id,period_days,date_range,counts:{overview:(.overview|length),ad_groups:(.ad_groups|length),search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length),rsa_ads:(.rsa_ads|length),rsa_analysis:(.rsa_analysis|length)},campaign_overview:(.overview|map(del(.campaign_id))),top_ad_groups:(.ad_groups|sort_by(-.clicks)|.[0:20]|map(del(.ad_group_id))),top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),rsa_diagnostics:(.rsa_analysis|map(del(.ad_id,.campaign))),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
+            jq '{success,mode,reader_version,campaign_id,period_days,date_range,counts:{overview:(.overview|length),ad_groups:(.ad_groups|length),search_terms:(.search_terms|length),keywords:(.keywords|length),devices:(.devices|length),hours:(.hours|length),geography:(.geography|length),rsa_ads:(.rsa_ads|length),rsa_analysis:(.rsa_analysis|length),conversion_actions:(.conversion_actions|length)},campaign_overview:(.overview|map(del(.campaign_id))),conversion_actions:(.conversion_actions|map(del(.conversion_action_resource))),top_ad_groups:(.ad_groups|sort_by(-.clicks)|.[0:20]|map(del(.ad_group_id))),top_search_terms:(.search_terms|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),top_keywords:(.keywords|sort_by(-.clicks)|.[0:12]|map(del(.ad_group_id))),devices,top_hours:(.hours|sort_by(-.clicks)|.[0:20]),top_geography:(.geography|sort_by(-.clicks)|.[0:20]),rsa_diagnostics:(.rsa_analysis|map(del(.ad_id,.campaign))),writes_allowed,execution_allowed,spend_allowed}' intelligence.json
           else
             jq '{success,error,writes_allowed,execution_allowed,spend_allowed}' intelligence.json 2>/dev/null || true
             exit 1

--- a/google-campaign-intelligence-route.js
+++ b/google-campaign-intelligence-route.js
@@ -7,6 +7,7 @@ const {
   collectCampaignOverview,
   collectCampaignAdGroups,
 } = require("./google-campaign-breakdowns");
+const { collectCampaignConversionActions } = require("./google-conversion-action-breakdown");
 const { collectResponsiveSearchAds } = require("./google-rsa-collector");
 const { analyzeRsaSet } = require("./google-rsa-analysis");
 
@@ -30,7 +31,7 @@ function installGoogleCampaignIntelligenceRoute({
     try {
       const customer = getGoogleCustomer();
       const { start, end } = getGoogleDateRange(days);
-      const [overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads] = await Promise.all([
+      const [overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, conversion_actions] = await Promise.all([
         collectCampaignOverview({ customer, campaignId, start, end }),
         collectCampaignAdGroups({ customer, campaignId, start, end }),
         collectCampaignSearchTerms({ customer, campaignId, start, end }),
@@ -39,8 +40,9 @@ function installGoogleCampaignIntelligenceRoute({
         collectCampaignHours({ customer, campaignId, start, end }),
         collectCampaignGeography({ customer, campaignId, start, end }),
         collectResponsiveSearchAds({ customer, campaignId, start, end }),
+        collectCampaignConversionActions({ customer, campaignId, start, end }),
       ]);
-      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", reader_version:2, campaign_id:campaignId, period_days:days, date_range:{start,end}, overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, rsa_analysis:analyzeRsaSet(rsa_ads), writes_allowed:false, execution_allowed:false, spend_allowed:false });
+      res.json({ success:true, source:"google_ads", mode:"read_only_intelligence", reader_version:3, campaign_id:campaignId, period_days:days, date_range:{start,end}, overview, ad_groups, search_terms, keywords, devices, hours, geography, rsa_ads, rsa_analysis:analyzeRsaSet(rsa_ads), conversion_actions, writes_allowed:false, execution_allowed:false, spend_allowed:false });
     } catch (error) {
       res.status(500).json({ success:false, source:"google_ads", campaign_id:campaignId, error:cleanGoogleError(error), writes_allowed:false, execution_allowed:false, spend_allowed:false });
     }

--- a/google-conversion-action-breakdown.js
+++ b/google-conversion-action-breakdown.js
@@ -1,0 +1,36 @@
+function numberOrZero(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+async function collectCampaignConversionActions({ customer, campaignId, start, end }) {
+  if (!customer || typeof customer.query !== "function") throw new TypeError("customer.query is required");
+  if (!/^\d{1,20}$/.test(String(campaignId || ""))) throw new TypeError("campaignId is invalid");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(start || "")) || !/^\d{4}-\d{2}-\d{2}$/.test(String(end || ""))) {
+    throw new TypeError("start and end must be YYYY-MM-DD");
+  }
+
+  const rows = await customer.query(`
+    SELECT campaign.id,
+      segments.conversion_action,
+      segments.conversion_action_name,
+      metrics.conversions,
+      metrics.all_conversions,
+      metrics.conversions_value,
+      metrics.all_conversions_value
+    FROM campaign
+    WHERE campaign.id = ${campaignId}
+      AND segments.date BETWEEN '${start}' AND '${end}'
+  `);
+
+  return (rows || []).map((row) => ({
+    conversion_action_resource: row.segments?.conversion_action || null,
+    conversion_action_name: row.segments?.conversion_action_name || null,
+    conversions: numberOrZero(row.metrics?.conversions),
+    all_conversions: numberOrZero(row.metrics?.all_conversions),
+    conversion_value: numberOrZero(row.metrics?.conversions_value),
+    all_conversion_value: numberOrZero(row.metrics?.all_conversions_value),
+  })).filter((row) => row.conversions !== 0 || row.all_conversions !== 0 || row.conversion_value !== 0 || row.all_conversion_value !== 0);
+}
+
+module.exports = { collectCampaignConversionActions };

--- a/test/google-campaign-intelligence-registration.test.js
+++ b/test/google-campaign-intelligence-registration.test.js
@@ -23,11 +23,11 @@ test("Google campaign intelligence route reuses the protected read-only dependen
 
 test("Google campaign intelligence response includes the complete reader diagnostics", () => {
   const route = fs.readFileSync(path.join(__dirname, "..", "google-campaign-intelligence-route.js"), "utf8");
-  for (const field of ["overview", "ad_groups", "search_terms", "keywords", "devices", "hours", "geography", "rsa_ads", "rsa_analysis"]) {
+  for (const field of ["overview", "ad_groups", "search_terms", "keywords", "devices", "hours", "geography", "rsa_ads", "rsa_analysis", "conversion_actions"]) {
     assert.ok(route.includes(field), `${field} missing from intelligence route`);
   }
   assert.ok(route.includes("writes_allowed:false"));
   assert.ok(route.includes("execution_allowed:false"));
   assert.ok(route.includes("spend_allowed:false"));
-  assert.ok(route.includes("reader_version:2"));
+  assert.ok(route.includes("reader_version:3"));
 });

--- a/test/google-conversion-action-breakdown.test.js
+++ b/test/google-conversion-action-breakdown.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { collectCampaignConversionActions } = require('../google-conversion-action-breakdown');
+
+const args = { campaignId:'23276824770', start:'2026-07-28', end:'2026-08-26' };
+
+function customerWith(rows, capture) {
+  return { async query(q) { capture.push(q); return rows; } };
+}
+
+test('conversion-action collector is read-only and campaign/date scoped', async () => {
+  const capture=[];
+  const rows=[{segments:{conversion_action:'customers/1/conversionActions/2',conversion_action_name:'booking_completed'},metrics:{conversions:5,all_conversions:5,conversions_value:5,all_conversions_value:5}}];
+  const result=await collectCampaignConversionActions({customer:customerWith(rows,capture),...args});
+  assert.equal(capture.length,1);
+  assert.match(capture[0],/segments\.conversion_action_name/);
+  assert.match(capture[0],/campaign\.id = 23276824770/);
+  assert.match(capture[0],/2026-07-28/);
+  assert.match(capture[0],/2026-08-26/);
+  assert.doesNotMatch(capture[0],/\b(MUTATE|CREATE|UPDATE|REMOVE)\b/i);
+  assert.deepEqual(result,[{conversion_action_resource:'customers/1/conversionActions/2',conversion_action_name:'booking_completed',conversions:5,all_conversions:5,conversion_value:5,all_conversion_value:5}]);
+});
+
+test('zero-only conversion action rows are omitted', async () => {
+  const capture=[];
+  const result=await collectCampaignConversionActions({customer:customerWith([{segments:{conversion_action_name:'unused'},metrics:{}}],capture),...args});
+  assert.deepEqual(result,[]);
+});
+
+test('invalid inputs fail before querying', async () => {
+  const customer={query:async()=>{throw new Error('must not query')}};
+  await assert.rejects(()=>collectCampaignConversionActions({customer,campaignId:'23 OR 1=1',start:args.start,end:args.end}),/campaignId is invalid/);
+  await assert.rejects(()=>collectCampaignConversionActions({customer,campaignId:args.campaignId,start:'yesterday',end:args.end}),/YYYY-MM-DD/);
+});


### PR DESCRIPTION
Extends the protected read-only Google campaign intelligence reader with conversion-action breakdowns so aggregate Google Ads conversions can be reconciled against GA4 booking_completed. Adds unit/contract tests. No campaign mutation, activation, budget change, or spend.