### PR TITLE
Add GA4 event inventory diagnostics

### DIFF
--- a/ga4-funnel-intelligence.js
+++ b/ga4-funnel-intelligence.js
@@ -15,6 +15,40 @@ async function runFunnelReport({ accessToken, propertyId, start, end, eventNames
   return response.data.rows || [];
 }
 
+async function runEventInventory({ accessToken, propertyId, start, end }) {
+  const response = await axios.post(
+    `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+    {
+      dateRanges: [{ startDate: start, endDate: end }],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "eventCount" }],
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: "200",
+    },
+    { headers: { authorization: `Bearer ${accessToken}` }, timeout: 20000 }
+  );
+  return response.data.rows || [];
+}
+
+function summarizeEventInventory(rows = [], expectedEvents = []) {
+  const expected = new Set(expectedEvents.map((value) => String(value).toLowerCase()));
+  const events = rows.map((row) => ({
+    event_name: String(row.dimensionValues?.[0]?.value || "").trim(),
+    event_count: Math.max(0, Number(row.metricValues?.[0]?.value || 0)),
+  })).filter((row) => row.event_name && Number.isFinite(row.event_count));
+
+  const reservationCandidates = events.filter((row) => {
+    const name = row.event_name.toLowerCase();
+    return !expected.has(name) && /(reserv|book|table|appoint|calendar|schedule)/i.test(name);
+  }).slice(0, 20);
+
+  return {
+    event_count: events.length,
+    top_events: events.slice(0, 50),
+    reservation_candidates: reservationCandidates,
+  };
+}
+
 function summarizeFunnel(rows = [], eventNames = []) {
   const totals = Object.fromEntries(eventNames.map((name) => [name, 0]));
   const googleCpc = Object.fromEntries(eventNames.map((name) => [name, 0]));
@@ -89,6 +123,8 @@ function reconcileConversions({ googleAdsConversions, ga4GoogleCpcBookings }) {
 
 module.exports = {
   runFunnelReport,
+  runEventInventory,
+  summarizeEventInventory,
   summarizeFunnel,
   funnelTrackingStatus,
   funnelCompleteness,

--- a/ga4-shadow-data.js
+++ b/ga4-shadow-data.js
@@ -2,6 +2,8 @@ const axios = require("axios");
 const { getDateRange } = require("./live-shadow-data");
 const {
   runFunnelReport,
+  runEventInventory,
+  summarizeEventInventory,
   summarizeFunnel,
   funnelCompleteness,
   funnelRates,
@@ -82,22 +84,23 @@ async function runBookingSourceReport({accessToken,propertyId,start,end}){
 
 async function collectGa4ShadowData({ env = process.env, days = 30, now = new Date(), startDate = null, endDate = null } = {}) {
   const collectedAt=now.toISOString();
-  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null};
+  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null};
   const fallback=getDateRange(days,now); const start=startDate||fallback.start; const end=endDate||fallback.end;
   try{
     const accessToken=await getGoogleAccessToken(env);
     const eventNames=String(env.GA4_FUNNEL_EVENTS||DEFAULT_FUNNEL_EVENTS.join(",")).split(",").map((value)=>value.trim()).filter(Boolean);
-    const [allBookings,googleCpcBookings,bookingQuality,bookingSources,funnelRows]=await Promise.all([
+    const [allBookings,googleCpcBookings,bookingQuality,bookingSources,funnelRows,eventInventoryRows]=await Promise.all([
       runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:false}),
       runBookingReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,googleCpcOnly:true}),
       runBookingQualityReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
       runBookingSourceReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
       runFunnelReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,eventNames}),
+      runEventInventory({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
     ]);
     const summarized=summarizeFunnel(funnelRows,eventNames); const funnel={event_names:eventNames,...summarized};
-    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,booking_sources:bookingSources,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)}};
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,booking_sources:bookingSources,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)},event_inventory:summarizeEventInventory(eventInventoryRows,eventNames)};
   }catch(error){
-    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null};
   }
 }
 

--- a/runtime-public-view.js
+++ b/runtime-public-view.js
@@ -45,12 +45,37 @@ function publicTrackingView(ga4 = {}) {
   }]));
 }
 
+function safeAggregateCount(value) {
+  const count = Number(value || 0);
+  return Number.isFinite(count) && count >= 0 ? count : 0;
+}
+
+function publicEventCandidates(ga4 = {}) {
+  const rows = Array.isArray(ga4.event_inventory?.reservation_candidates) ? ga4.event_inventory.reservation_candidates : [];
+  return rows.slice(0, 20).map((row) => ({
+    event_name: safeCode(row.event_name, "unknown_event"),
+    event_count: safeAggregateCount(row.event_count),
+  }));
+}
+
 function publicGa4Diagnostic(ga4 = {}) {
   if (ga4.access_ok === true) {
     return {
       configuration_complete: ga4.configuration_complete === true,
       funnel_configuration_complete: ga4.funnel?.completeness?.configuration_complete === true,
       funnel_observation_complete: ga4.funnel?.completeness?.observation_complete === true,
+      booking_counts: {
+        total: safeAggregateCount(ga4.total_booking_completed),
+        google_cpc: safeAggregateCount(ga4.google_cpc_booking_completed),
+      },
+      booking_quality: {
+        event_count: safeAggregateCount(ga4.booking_quality?.event_count),
+        users: safeAggregateCount(ga4.booking_quality?.users),
+        sessions: safeAggregateCount(ga4.booking_quality?.sessions),
+        duplication_risk: ga4.booking_quality?.duplication_risk === true,
+      },
+      event_inventory_count: safeAggregateCount(ga4.event_inventory?.event_count),
+      reservation_event_candidates: publicEventCandidates(ga4),
     };
   }
   return {
@@ -103,6 +128,8 @@ module.exports = {
   observedEvent,
   configuredEvent,
   publicTrackingView,
+  safeAggregateCount,
+  publicEventCandidates,
   publicGa4Diagnostic,
   publicMetaDiagnostic,
   buildPublicSourceView,

--- a/test/ga4-event-inventory.test.js
+++ b/test/ga4-event-inventory.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { summarizeEventInventory } = require('../ga4-funnel-intelligence');
+const { publicGa4Diagnostic } = require('../runtime-public-view');
+
+function row(name, count) {
+  return { dimensionValues:[{value:name}], metricValues:[{value:String(count)}] };
+}
+
+test('event inventory surfaces reservation-like alternatives without relabeling expected events', () => {
+  const result = summarizeEventInventory([
+    row('page_view', 100),
+    row('booking_completed', 12),
+    row('wix_reservation_started', 8),
+    row('table_booking_opened', 5),
+  ], ['reservation_page_view','reservation_start','booking_completed']);
+
+  assert.equal(result.event_count, 4);
+  assert.deepEqual(result.reservation_candidates, [
+    {event_name:'wix_reservation_started', event_count:8},
+    {event_name:'table_booking_opened', event_count:5},
+  ]);
+});
+
+test('public GA4 diagnostic exposes aggregate counts and sanitized candidate names only', () => {
+  const result = publicGa4Diagnostic({
+    access_ok:true,
+    configuration_complete:true,
+    total_booking_completed:12,
+    google_cpc_booking_completed:4,
+    booking_quality:{event_count:12,users:10,sessions:11,duplication_risk:false},
+    funnel:{completeness:{configuration_complete:true,observation_complete:false}},
+    event_inventory:{event_count:35,reservation_candidates:[{event_name:'reserve form opened!',event_count:9}]},
+  });
+  assert.deepEqual(result.booking_counts,{total:12,google_cpc:4});
+  assert.equal(result.event_inventory_count,35);
+  assert.deepEqual(result.reservation_event_candidates,[{event_name:'reserve_form_opened_',event_count:9}]);
+  assert.equal(JSON.stringify(result).includes('access_token'),false);
+});


### PR DESCRIPTION
Adds a read-only GA4 event inventory to discover reservation/booking-like event names when expected funnel events are configured but not observed. Exposes only sanitized aggregate booking counts, duplication signal, inventory count, and candidate event names/counts in the public health diagnostic. No user-level dimensions, secrets, campaign changes, activation, or spend.