### PR TITLE
Attribute discovered GA4 reservation candidates

### DIFF
--- a/ga4-shadow-data.js
+++ b/ga4-shadow-data.js
@@ -84,7 +84,7 @@ async function runBookingSourceReport({accessToken,propertyId,start,end}){
 
 async function collectGa4ShadowData({ env = process.env, days = 30, now = new Date(), startDate = null, endDate = null } = {}) {
   const collectedAt=now.toISOString();
-  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null};
+  if(!ga4Configured(env))return{access_ok:false,configuration_complete:false,collected_at:collectedAt,error:"ga4_configuration_incomplete",required_variable:"GA4_PROPERTY_ID",total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null,candidate_attribution:null};
   const fallback=getDateRange(days,now); const start=startDate||fallback.start; const end=endDate||fallback.end;
   try{
     const accessToken=await getGoogleAccessToken(env);
@@ -98,9 +98,16 @@ async function collectGa4ShadowData({ env = process.env, days = 30, now = new Da
       runEventInventory({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end}),
     ]);
     const summarized=summarizeFunnel(funnelRows,eventNames); const funnel={event_names:eventNames,...summarized};
-    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,booking_sources:bookingSources,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)},event_inventory:summarizeEventInventory(eventInventoryRows,eventNames)};
+    const eventInventory=summarizeEventInventory(eventInventoryRows,eventNames);
+    const candidateNames=eventInventory.reservation_candidates.map((row)=>row.event_name).filter(Boolean);
+    let candidateAttribution={event_names:[],totals:{},google_cpc:{}};
+    if(candidateNames.length){
+      const candidateRows=await runFunnelReport({accessToken,propertyId:env.GA4_PROPERTY_ID,start,end,eventNames:candidateNames});
+      candidateAttribution={event_names:candidateNames,...summarizeFunnel(candidateRows,candidateNames)};
+    }
+    return {access_ok:true,configuration_complete:true,collected_at:collectedAt,period:{start,end},event_name:"booking_completed",total_booking_completed:allBookings.event_count,google_cpc_booking_completed:googleCpcBookings.event_count,last_seen_at:googleCpcBookings.last_seen_at||allBookings.last_seen_at,booking_quality:bookingQuality,booking_sources:bookingSources,funnel:{...funnel,completeness:funnelCompleteness(funnel,DEFAULT_FUNNEL_EVENTS),rates:funnelRates(funnel)},event_inventory:eventInventory,candidate_attribution:candidateAttribution};
   }catch(error){
-    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null};
+    return {access_ok:false,configuration_complete:true,collected_at:collectedAt,error:sanitizeGoogleError(error,"ga4_read_failed"),total_booking_completed:null,google_cpc_booking_completed:null,last_seen_at:null,booking_quality:null,booking_sources:null,funnel:null,event_inventory:null,candidate_attribution:null};
   }
 }
 

--- a/runtime-public-view.js
+++ b/runtime-public-view.js
@@ -58,6 +58,17 @@ function publicEventCandidates(ga4 = {}) {
   }));
 }
 
+function publicCandidateAttribution(ga4 = {}) {
+  const names = Array.isArray(ga4.candidate_attribution?.event_names) ? ga4.candidate_attribution.event_names : [];
+  const totals = ga4.candidate_attribution?.totals || {};
+  const googleCpc = ga4.candidate_attribution?.google_cpc || {};
+  return names.slice(0, 20).map((name) => ({
+    event_name: safeCode(name, "unknown_event"),
+    total: safeAggregateCount(totals[name]),
+    google_cpc: safeAggregateCount(googleCpc[name]),
+  }));
+}
+
 function publicGa4Diagnostic(ga4 = {}) {
   if (ga4.access_ok === true) {
     return {
@@ -76,6 +87,7 @@ function publicGa4Diagnostic(ga4 = {}) {
       },
       event_inventory_count: safeAggregateCount(ga4.event_inventory?.event_count),
       reservation_event_candidates: publicEventCandidates(ga4),
+      reservation_candidate_attribution: publicCandidateAttribution(ga4),
     };
   }
   return {
@@ -130,6 +142,7 @@ module.exports = {
   publicTrackingView,
   safeAggregateCount,
   publicEventCandidates,
+  publicCandidateAttribution,
   publicGa4Diagnostic,
   publicMetaDiagnostic,
   buildPublicSourceView,

--- a/test/ga4-candidate-attribution.test.js
+++ b/test/ga4-candidate-attribution.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { publicCandidateAttribution, publicGa4Diagnostic } = require('../runtime-public-view');
+
+test('candidate attribution preserves aggregate total and google/cpc counts only', () => {
+  const ga4 = {
+    access_ok:true,
+    configuration_complete:true,
+    funnel:{completeness:{configuration_complete:true,observation_complete:false}},
+    candidate_attribution:{
+      event_names:['table_reservation_completed','reservation'],
+      totals:{table_reservation_completed:11,reservation:2},
+      google_cpc:{table_reservation_completed:10,reservation:1},
+    },
+  };
+  assert.deepEqual(publicCandidateAttribution(ga4),[
+    {event_name:'table_reservation_completed',total:11,google_cpc:10},
+    {event_name:'reservation',total:2,google_cpc:1},
+  ]);
+  assert.deepEqual(publicGa4Diagnostic(ga4).reservation_candidate_attribution,publicCandidateAttribution(ga4));
+});


### PR DESCRIPTION
For reservation-like events discovered by the read-only GA4 inventory, adds an aggregate source/medium attribution query and exposes sanitized total + google/cpc counts. This allows evidence-based comparison against Google Ads conversion actions without changing GA4 configuration or ad delivery.