### PR TITLE
Fix MCP consent form Origin rejection without weakening CSRF checks

### DIFF
--- a/docs/STREAM_JSON_COMPATIBILITY.md
+++ b/docs/STREAM_JSON_COMPATIBILITY.md
@@ -1,0 +1,27 @@
+# Google Ads streaming dependency remediation
+
+GHSA-528h-pc64-c93x affects stream-json <=3.4.0. The installed
+google-ads-api 24.1.0 (latest checked 2026-09-04) declares ^1.8.0.
+Do not force the suggested google-ads-api downgrade or exempt the advisory.
+
+The local private @parma/stream-json-compat package replaces that dependency
+with a minimal facade over the genuine npm stream-json 3.5.0 release, installed
+as stream-json-modern. No old stream-json implementation is shipped. The facade
+is not a general replacement: only the SDK's Parser, parser() and StreamArray
+entry points are exported. Other legacy subpaths fail closed.
+
+The SDK still uses Node streams; modern generator factories are converted using
+their upstream asStream APIs. Its undeclared stream-chain import is pinned
+explicitly to 2.2.5; the modern parser has its own stream-chain 4 dependency.
+Node >=22.12 is required for synchronous require of ESM; production engines
+allow Node 22.12+ through 24. No Google API version, query, credentials, campaign,
+budget or authorization scope changes are made.
+
+Validation must include npm ci --ignore-scripts, npm ls, unmodified production
+npm audit, full tests, syntax checks and CI. Tests cover split UTF-8 input, packed
+and default options, precise string metrics, summaries, malformed JSON, error
+envelopes and the actual SDK queryStream with a mock HTTP adapter (no network).
+The owner still must complete live MCP consent; mocked tests are not live Ads
+validation. Retire this facade when upstream supports a patched parser directly.
+
+Reference: https://github.com/advisories/GHSA-528h-pc64-c93x

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -147,6 +147,10 @@ function installMcp(app, { env = process.env, store, google, read, now } = {}) {
     try {
       const state = req.query.state;
       const { csrf } = await provider.finishGoogle({ state, cookie: cookieValue(req), code: req.query.code });
+      // Form POSTs under no-referrer can send Origin: null. Preserve the
+      // origin without disclosing the callback path, code or state in Referer.
+      // Keep the strict Origin, cookie and CSRF checks on the receiving route.
+      res.set('Referrer-Policy', 'strict-origin');
       // Only cryptographically generated base64url values enter this HTML.
       res.type('html').send(`<!doctype html><html lang="it"><meta charset="utf-8"><title>Collega Parma Agent</title>
         <h1>Collega ChatGPT a Parma Agent</h1><p>Consenti esclusivamente la lettura di diagnostica e dati Google Ads.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,12 @@
         "express": "^4.22.2",
         "google-ads-api": "^24.1.0",
         "google-auth-library": "10.3.0",
+        "stream-chain": "2.2.5",
+        "stream-json": "file:vendor/stream-json-compat",
         "zod": "3.25.76"
+      },
+      "engines": {
+        "node": ">=22.12.0 <25"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2918,12 +2923,35 @@
       }
     },
     "node_modules/stream-json": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "resolved": "vendor/stream-json-compat",
+      "link": true
+    },
+    "node_modules/stream-json-modern": {
+      "name": "stream-json",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-3.5.0.tgz",
+      "integrity": "sha512-dobB7zipGW8o11PvdRljQSWuyMxifADLvoHeA4elwNWOTbZo6+BlNa+P6aCq7Y9jRiWTy2Ucu2xSv0Y2/T+/kQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "stream-chain": "^2.2.5"
+        "stream-chain": "^4.2.5"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/stream-json-modern/node_modules/stream-chain": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-4.2.5.tgz",
+      "integrity": "sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/stream-shift": {
@@ -3413,6 +3441,16 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "vendor/stream-json-compat": {
+      "name": "@parma/stream-json-compat",
+      "version": "1.0.0",
+      "dependencies": {
+        "stream-json-modern": "npm:stream-json@3.5.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "parma-ads-agent",
   "version": "1.1.0",
   "main": "server.js",
+  "engines": { "node": ">=22.12.0 <25" },
   "scripts": {
     "start": "node -r ./google-campaign-intelligence-preload.js -r ./meta-legacy-write-preload.js scheduler-bootstrap.js",
     "check": "node --check google-campaign-intelligence-preload.js && node --check google-campaign-breakdowns.js && node --check meta-legacy-write-guard.js && node --check meta-legacy-write-preload.js && node --check operational-live-pulse-preload.js && node --check operational-live-pulse.js && node --check scheduler-bootstrap.js && node --check public-output-safety.js && node --check runtime-public-view.js && node --check google-runtime-config-diagnostics.js && node --check safe-execution.js && node --check shadow-data-quality.js && node --check agent-readiness.js && node --check promotion-controller.js && node --check promotion-status.js && node --check readiness-action-plan.js && node --check shadow-history-store.js && node --check shadow-readonly-cycle.js && node --check operational-dashboard.js && node --check meta-intelligence-v2.js && node --check runtime-resilience.js && node --check shadow-evaluation.js && node --check shadow-operations.js && node --check tiktok-readiness.js && node --check autonomy-policy.js && node --check live-validation-readiness.js && node --check statistical-baseline.js && node --check meta-safe-create-route.js && node --check meta-safe-orchestrator.js && node --check meta-final-manifest.js && node --check server.js && node --check bootstrap.js && node --check reporting.js && node --check proposals.js && node --check meta-paused-draft.js && node --check meta-paused-draft-next.js && node --check meta-timezone-schedule.js && node --check meta-draft-validation.js && node --check meta-stage-diagnostics.js && node --check meta-draft-recovery.js && node --check meta-live-test-readiness.js && node --check meta-safe-payload.js && node --check meta-payload-contract.js && node --check meta-preflight.js && node --check meta-execution-plan.js && node --check meta-preflight-adversarial.js && node --check meta-partial-inspection.js && node --check meta-one-shot-preparation.js && node --check meta-real-preflight.js && node --check meta-real-preflight-endpoint.js && node --check meta-runtime-preflight.js && node --check meta-preflight-decision.js && node --check meta-preflight-status.js && node --check google-rsa-analysis.js && node --check google-rsa-collector.js && node --check google-search-intelligence.js && node --check ga4-funnel-intelligence.js && node --check funnel-analysis.js && node --check preaccess-intelligence.js && node --check trend-intelligence.js && node --check agent-learning.js && node --check dashboard-model.js && node --check landing-page-diagnostics.js && node --check shadow-decision-engine.js && node --check daily-shadow-report.js && node --check decision-lifecycle.js && node --check access-readiness.js && node --check shadow-trends.js && node --check shadow-simulation.js && node --check meta-attribution-integrity.js && node --check decision-support.js && node --check agent-foundation.js && node --check acquisition-intelligence.js && node --check optimization-manager.js && node --check safety-experiments.js && node --check business-ops-evaluation.js && node --check agent-shadow.js && node --check live-shadow-data.js && node --check ga4-shadow-data.js && node --check full-live-shadow-data.js && node --check scripts/run-live-shadow-report.js && node --check scripts/run-full-live-shadow-report.js && node --check scripts/run-preaccess-validation.js && node --check scripts/run-sanitized-shadow-health.js",
@@ -21,9 +22,12 @@
     "express": "^4.22.2",
     "google-ads-api": "^24.1.0",
     "google-auth-library": "10.3.0",
+    "stream-chain": "2.2.5",
+    "stream-json": "file:vendor/stream-json-compat",
     "zod": "3.25.76"
   },
   "overrides": {
+    "google-ads-api": { "stream-json": "$stream-json" },
     "uuid": "^11.1.1",
     "qs": "6.16.0"
   }

--- a/test/google-stream-compat.test.js
+++ b/test/google-stream-compat.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { Readable } = require('node:stream');
+const { createRequire } = require('node:module');
+const sdkRequire = createRequire(require.resolve('google-ads-api'));
+const { Parser, parser } = sdkRequire('stream-json');
+const { streamArray } = sdkRequire('stream-json/streamers/StreamArray');
+const { chain } = sdkRequire('stream-chain');
+
+async function collect(input, packed = false) {
+  const p = packed ? new Parser({ streamValues: false, streamKeys: false, packValues: true, packKeys: true }) : parser();
+  const pipeline = chain([Readable.from(input), p, streamArray()]);
+  const result = [];
+  try { for await (const item of pipeline) result.push(item); }
+  finally { pipeline.destroy(); p.destroy(); }
+  return result;
+}
+test('Google Ads SDK loads unchanged with patched parser facade', () => {
+  assert.equal(typeof require('google-ads-api').GoogleAdsApi, 'function');
+  assert.throws(() => sdkRequire('stream-json/filters/Pick'), { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' });
+});
+for (const packed of [false, true]) test(`SDK parser contract preserves streamed rows and summary (packed=${packed})`, async () => {
+  const values = [{ results: [{ campaign: { id: '23276824770', name: 'Pizza 🍕' }, metrics: { costMicros: '12345678901234567', clicks: '2' } }] },
+    { summaryRow: { metrics: { clicks: '2' } } }];
+  const bytes = Buffer.from(JSON.stringify(values));
+  assert.deepEqual(await collect(Array.from(bytes, b => Buffer.from([b])), packed), values.map((value, key) => ({ key, value })));
+  assert.deepEqual(await collect(['[]'], packed), []);
+  await assert.rejects(collect(['[{"bad":'], packed));
+});
+test('SDK error response parser retains Google error envelope', async () => {
+  const error = { error: { code: 400, message: 'test', details: [{ errors: [{ message: 'invalid query' }] }] } };
+  assert.deepEqual(await collect([JSON.stringify([error])]), [{ key: 0, value: error }]);
+});
+test('actual Google Ads queryStream uses facade without network access', async t => {
+  const axios = require('axios');
+  const original = axios.defaults.adapter;
+  t.after(() => { axios.defaults.adapter = original; });
+  axios.defaults.adapter = async config => ({ status: 200, statusText: 'OK', headers: {}, config,
+    data: Readable.from(['[{"results":[{"campaign":{"id":"23276824770"},"metrics":{"costMicros":"2500000"}}]}]']) });
+  const client = new (require('google-ads-api').GoogleAdsApi)({ client_id: 'test', client_secret: 'test', developer_token: 'test' });
+  const customer = client.Customer({ customer_id: '1234567890', refresh_token: 'test' });
+  customer.getAccessToken = async () => 'test-only';
+  const rows = [];
+  for await (const row of customer.queryStream('SELECT campaign.id, metrics.cost_micros FROM campaign')) rows.push(row);
+  assert.equal(rows.length, 1);
+  // The SDK's existing parserRest converts numeric fields after JSON parsing.
+  assert.equal(rows[0].campaign.id, 23276824770);
+  assert.equal(rows[0].metrics.cost_micros, 2500000);
+});

--- a/test/mcp-oauth.test.js
+++ b/test/mcp-oauth.test.js
@@ -246,6 +246,37 @@ test('OAuth metadata is discoverable and unauthenticated MCP is challenged', asy
   assert.equal(destination.searchParams.get('error'), 'invalid_scope');
   assert.equal(destination.searchParams.get('state'), 'preserved-state');
 });
+test('consent page preserves form Origin without disclosing callback query; rejects unsafe submissions', async t => {
+  const f = await httpFixture(t), provider = f.mounted.provider;
+  let flowCookie, googleState;
+  const original = f.google.generateAuthUrl;
+  f.google.generateAuthUrl = params => { googleState = params.state; return original(params); };
+  await provider.authorize(f.client, { state: 'chatgpt-state', scopes: ['parma.read'], codeChallenge: challenge(verifier),
+    redirectUri: f.config.redirectUri, resource: new URL(f.config.resource) }, {
+    cookie: (_, value) => { flowCookie = value; }, redirect: () => {},
+  });
+  const page = await f.request(`/mcp/oauth/google/callback?state=${googleState}&code=mock-google-code`, {
+    headers: { cookie: `${COOKIE}=${flowCookie}` },
+  });
+  assert.equal(page.status, 200);
+  assert.equal(page.headers.get('referrer-policy'), 'strict-origin');
+  assert.match(page.headers.get('content-security-policy'), /form-action 'self'/);
+  const csrf = (await page.text()).match(/name="csrf" value="([^"]+)"/)[1];
+  const submit = (requestOrigin, overrides = {}, cookie = flowCookie) => f.request('/mcp/oauth/consent', {
+    method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded',
+      ...(requestOrigin === undefined ? {} : { origin: requestOrigin }), cookie: `${COOKIE}=${cookie}` },
+    body: new URLSearchParams({ state: googleState, csrf, decision: 'allow', ...overrides }),
+  });
+  for (const bad of ['null', 'https://evil.example']) assert.equal((await submit(bad)).status, 403);
+  for (const bad of [undefined, 'https://chatgpt.com']) assert.equal((await submit(bad)).status, 400);
+  assert.equal((await submit(origin, { csrf: 'invalid' })).status, 400);
+  assert.equal((await submit(origin, {}, 'wrong-cookie')).status, 400);
+  const accepted = await submit(origin);
+  assert.equal(accepted.status, 302);
+  assert.equal(new URL(accepted.headers.get('location')).origin, 'https://chatgpt.com');
+  assert.equal(accepted.headers.get('referrer-policy'), 'no-referrer');
+  assert.equal((await submit(origin)).status, 400);
+});
 test('real SDK transport initializes, lists and calls only read tools', async t => {
   const f = await httpFixture(t);
   const tokens = f.mounted.provider.issue({ subject: 'owner-subject', family: 'test-family', familyExpires: Date.now() + 86400000 });

--- a/vendor/stream-json-compat/index.cjs
+++ b/vendor/stream-json-compat/index.cjs
@@ -1,0 +1,6 @@
+'use strict';
+// Node >=22.12 supports requiring this synchronous ESM module.
+// No legacy parser/filter code is copied or retained.
+const { parserStream } = require('stream-json-modern');
+function Parser(options) { return parserStream(options); }
+module.exports = { Parser, parser: options => parserStream(options) };

--- a/vendor/stream-json-compat/package.json
+++ b/vendor/stream-json-compat/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@parma/stream-json-compat",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal Google Ads SDK Node-stream compatibility facade over patched stream-json",
+  "main": "index.cjs",
+  "exports": {
+    ".": "./index.cjs",
+    "./streamers/StreamArray": "./stream-array.cjs"
+  },
+  "engines": { "node": ">=22.12.0" },
+  "dependencies": { "stream-json-modern": "npm:stream-json@3.5.0" }
+}

--- a/vendor/stream-json-compat/stream-array.cjs
+++ b/vendor/stream-json-compat/stream-array.cjs
@@ -1,0 +1,3 @@
+'use strict';
+const { streamArray } = require('stream-json-modern/streamers/stream-array.js');
+module.exports = { streamArray: options => streamArray.asStream(options) };


### PR DESCRIPTION
## Completed authorized repair
MCP consent HTML now uses strict-origin; all other responses keep no-referrer. Origin/Host, CSRF, cookie, identity/replay controls unchanged. Private compatibility facade delegates exclusively to patched stream-json 3.5.0, keeping Google Ads SDK 24.1.0. No old parser/filter code, audit exemptions or forced downgrade. See docs/STREAM_JSON_COMPATIBILITY.md.

## Verified evidence
- Clean npm ci and npm install pass; npm ls valid.
- Local full suite 456/456; syntax pass; audit zero vulnerabilities.
- CI 33841502199 SUCCESS on 3b710531128103f14b1767952b316a64fb72aa8d (production audit, syntax, tests).
- Merged ec72bfe348a706d3563c9daf6d172e957fad592e.
- Railway b16859f7-61e4-44b9-868f-fb305b71ae54 SUCCESS. Build used Node22.23.2 and both npm install audits reported zero vulnerabilities.
- Postdeploy public probes: /health 200 success true status ok; /health/mcp 200 enabled true writes_allowed false configured_not_live_validated; /mcp without bearer 401; authorization metadata 200 scope parma.read.

## Remaining acceptance gate
Owner must restart connector login from ChatGPT (old consent flow expired/restarted), complete Google identity and explicit read consent. Authenticated MCP tool discovery and live Ads reads NOT YET verified. No credentials need replacement. No campaigns, budgets, spend or write scopes changed.