### PR TITLE
Prepare controlled Google campaign proposals without enabling writes

### DIFF
--- a/docs/GOOGLE_CONTROLLED_INVENTORY.md
+++ b/docs/GOOGLE_CONTROLLED_INVENTORY.md
@@ -1,8 +1,10 @@
 # Controlled inventory collection — preparation milestone
 
-The new google-controlled-inventory.js module orchestrates a trusted read-only
-fetchPage callback. It is not yet connected to the Google SDK, a route, MCP, or
-the production scheduler. No new live collection, mutation or deployment occurs.
+The google-controlled-inventory.js module orchestrates a trusted read-only
+fetchPage callback. google-controlled-inventory-reader.js now supplies that callback
+using the existing google-ads-api SDK and configured environment credentials.
+It is not connected to a route, MCP, or the production scheduler. No new live
+collection, mutation or deployment has been performed in this development pass.
 
 ## Server callback contract
 
@@ -38,7 +40,28 @@ not that campaign execution, approval, or spending is authorized.
 
 Offline tests exercise pagination, second-scan drift, paused campaigns, metadata,
 hostile input, sanitized provider failures, shared budgets and proposal integration.
-The actual Google adapter, live pagination proof, durable snapshot storage,
+Live stream-completeness validation, durable snapshot storage,
 conversion provenance, owner policy UI, approval journal and execution path remain
 unfinished. Existing 50-task backlog is retained; do not mark all trusted-input
 tasks complete on the strength of these offline checks.
+
+## SDK adapter and diagnostic command
+
+Run `node scripts/run-google-controlled-inventory.js` only in the authorized server
+environment with existing Google configuration. Output includes success, counts,
+collection time and fixed blockers; no credentials, IDs or raw API errors.
+The adapter uses google-ads-api 24.1.0 queryStream (inspected from the pinned npm
+package). Each scan reads customer metadata and every non-removed campaign to
+stream completion. There are no metric, date or campaign-ID filters. Normalized
+pages of 1,000 are local slices of this fully consumed stream, not provider pages.
+The 10,000-row limit is checked while consuming the stream. Identifiers and linked
+resource names are validated against the configured account. Only DAILY budgets
+are accepted; lifetime/custom periods, missing sharing flags and unsafe numeric
+IDs/amounts block the entire inventory. Timeout withholds results, but this SDK
+does not expose AbortSignal cancellation through queryStream; a pending network
+read may finish after timeout and is never used as a successful result.
+
+Offline validation: 60/60 tests across reader, inventory and current proposal
+evaluator; includes a 1,001-campaign stream and errors after partial delivery.
+No full repository regression or live provider test has been claimed.
+Reference: https://developers.google.com/google-ads/api/reference/rpc/v24/BudgetPeriodEnum.BudgetPeriod

--- a/docs/GOOGLE_CONTROLLED_INVENTORY.md
+++ b/docs/GOOGLE_CONTROLLED_INVENTORY.md
@@ -1,0 +1,44 @@
+# Controlled inventory collection — preparation milestone
+
+The new google-controlled-inventory.js module orchestrates a trusted read-only
+fetchPage callback. It is not yet connected to the Google SDK, a route, MCP, or
+the production scheduler. No new live collection, mutation or deployment occurs.
+
+## Server callback contract
+
+Input: customerId, pageToken (null for the first page), AbortSignal.
+Output: customer_id, currency, time_zone, campaigns, next_page_token.
+Each campaign has campaign_id, budget_id, daily_budget_micros (safe integer),
+status (ENABLED or PAUSED), and shared_budget (boolean). No metric/date filter:
+the future adapter must enumerate every non-removed campaign including zero-
+traffic campaigns and validate resource/account ownership before normalizing.
+IDs must be lossless strings. next_page_token must be explicitly null at the end.
+Never accept the callback, normalized pages, or completeness flags from public
+request bodies as authorization evidence. The adapter is still a prerequisite.
+
+## Implemented checks
+
+All pages consumed, 100 pages per scan / 10,000 campaigns / 60 seconds total.
+Repeated tokens, duplicate campaign IDs, inconsistent shared budgets, invalid
+amounts, missing fields, unknown states, currency other than EUR and wrong
+accounts fail closed. Timezone must be recognized and consistent across pages.
+Two independent complete scans must match after sorting. This detects observed
+drift but does not create an atomic provider snapshot or rule out ABA changes.
+The timestamp is collection start, not completion, to avoid understating age.
+Underlying reader should honor AbortSignal; timeout prevents result use even
+if a callback ignores cancellation. No automatic retries. Provider errors are
+replaced by fixed codes; partial results and page tokens are never returned.
+
+Returned snapshot matches the proposal evaluator. Conversion trust is always
+false until a separate trusted evidence path exists. Shared budgets remain
+blocked by the evaluator. Success means inventory collection passed these checks,
+not that campaign execution, approval, or spending is authorized.
+
+## Validation and remaining work
+
+Offline tests exercise pagination, second-scan drift, paused campaigns, metadata,
+hostile input, sanitized provider failures, shared budgets and proposal integration.
+The actual Google adapter, live pagination proof, durable snapshot storage,
+conversion provenance, owner policy UI, approval journal and execution path remain
+unfinished. Existing 50-task backlog is retained; do not mark all trusted-input
+tasks complete on the strength of these offline checks.

--- a/docs/GOOGLE_CONTROLLED_MANAGEMENT.md
+++ b/docs/GOOGLE_CONTROLLED_MANAGEMENT.md
@@ -32,7 +32,7 @@ Preparation component implemented with automated positive/adversarial tests.
 Live controlled management NOT complete or enabled.
 
 ## Remaining gates before any external write
-1. Owner supplies allowed campaign IDs/actions, budget limits and validity period.
+1. Owner supplies the customer ID, allowed campaign IDs/actions, budget limits and validity period.
 2. Trusted read adapter collects fresh whole-account budget inventory, IDs and
    conversion integrity; resolve shared budgets explicitly.
 3. Persist authenticated approval bound to exact proposal digest, expiry and owner;
@@ -48,3 +48,13 @@ Live controlled management NOT complete or enabled.
 
 Tests use synthetic policies only. No campaign, budget, announcement, credentials
 or spend has been changed by this preparation.
+
+## Review fixes — 2026-09-04
+
+The policy now requires customer_id and rejects a different snapshot account.
+Null/primitive/array inputs return a non-executable validation failure rather than throwing.
+Percentage comparisons use exact integer arithmetic against the decimal policy value,
+so an exact 7% boundary is not rejected as 7.000000000000001%.
+Policies without customer_id must be regenerated; no policy is auto-authorized.
+Targeted local validation: 27/27 tests with zod 3.25.76. Full repository suite
+and deployed validation were not rerun in this review. No merge or deployment.

--- a/docs/GOOGLE_CONTROLLED_MANAGEMENT.md
+++ b/docs/GOOGLE_CONTROLLED_MANAGEMENT.md
@@ -1,0 +1,50 @@
+# Controlled Google campaign management — preparation only
+
+## Delivered
+Pure, offline proposal evaluator in google-controlled-proposals.js. No routes,
+MCP tools, API mutation adapter, credentials, scheduling or platform writes.
+Existing autonomy-policy and read-only connector remain unchanged.
+
+Supported proposal types: daily campaign budget, pause, resume, exact/phrase
+negative keyword. RSA edits, targeting and bidding changes are not implemented.
+Every result remains execution_allowed=false, writes_allowed=false and
+spend_allowed=false, even when policy_fit=true. This is NOT an authorization
+decision or proof that an owner approved anything.
+
+Inputs must eventually come from trusted server-side sources: authenticated owner
+policy, complete account inventory and conversion validation. Never accept model-
+supplied policy_fit, approval booleans, inventory completeness or conversion trust
+as authority for writes. No real owner limits are configured by this change.
+
+Proposal includes before state, policy/snapshot digests, immutable-content ID,
+creation and expiry timestamps. Digests bind content but are NOT signatures or
+approval tokens. Freshness and policy expiry are enforced; shared budgets are
+blocked pending dedicated treatment. Account totals conservatively include paused
+campaign budgets. Budget arithmetic uses integer micros and checks safe integers.
+
+Daily budget totals are configuration ceilings, NOT a hard actual-spend cap.
+Before any live rollout, separately design actual-spend tracking, period/timezone,
+reporting-delay handling and stop behavior; do not promise an exact spend ceiling
+from daily-budget settings alone.
+
+## Acceptance status
+Preparation component implemented with automated positive/adversarial tests.
+Live controlled management NOT complete or enabled.
+
+## Remaining gates before any external write
+1. Owner supplies allowed campaign IDs/actions, budget limits and validity period.
+2. Trusted read adapter collects fresh whole-account budget inventory, IDs and
+   conversion integrity; resolve shared budgets explicitly.
+3. Persist authenticated approval bound to exact proposal digest, expiry and owner;
+   no caller-provided booleans. Initially require approval for each proposal.
+4. Durable audit journal and idempotency ledger; account-level serialization and
+   fresh before-state check prevent concurrent/cumulative changes escaping limits.
+5. Separate disabled-by-default mutation adapter with allowlisted fields, platform
+   validation, explicit write consent/scope and emergency stop. Do not repurpose
+   parma.read or weaken existing global promotion/execution gates.
+6. Post-write readback, partial-failure handling and reviewed compensation. Never
+   blindly retry uncertain writes or treat budget rollback as recovery of spend.
+7. Test and review independently before owner-authorized live validation.
+
+Tests use synthetic policies only. No campaign, budget, announcement, credentials
+or spend has been changed by this preparation.

--- a/docs/GOOGLE_NEXT_50_TASKS.md
+++ b/docs/GOOGLE_NEXT_50_TASKS.md
@@ -1,0 +1,69 @@
+# Next 50 tasks — controlled Google management
+
+Backlog, not completed work or a promise of background execution. All development
+defaults to offline/read-only. D = owner decision/access required before activation.
+Existing proposed scope does not authorize launching these changes on Ads.
+
+## Trusted inputs
+1. Build whole-account campaign inventory adapter.
+2. Fetch and reconcile budget resource IDs.
+3. Verify inventory pagination completeness.
+4. Model shared budget membership and account impact.
+5. Read authoritative account currency and timezone.
+6. Reject inconsistent snapshots across collector calls.
+7. Add immutable versioned snapshot persistence.
+8. Verify conversion evidence provenance server-side.
+9. Provide an owner policy editor with validation (D).
+10. Version owner policies with explicit revocation.
+
+## Approval lifecycle
+11. Bind approval to authenticated owner identity.
+12. Bind approval to exact proposal and account.
+13. Store signed single-use approval records.
+14. Implement approval expiry enforcement.
+15. Invalidate approval when proposal content changes.
+16. Invalidate approval when owner limits change.
+17. Add explicit rejection state.
+18. Add cancellation before dispatch.
+19. Require reconfirmation after material account drift.
+20. Display concise before/after owner review.
+
+## Execution infrastructure — disabled until reviewed
+21. Design account-level write serialization.
+22. Implement durable idempotency keys.
+23. Implement crash-safe execution journal.
+24. Re-read relevant resources immediately before dispatch.
+25. Distinguish failed, successful and uncertain outcomes.
+26. Prevent automatic retries on uncertain writes.
+27. Build allowlisted Google mutation adapter, disabled by default.
+28. Validate proposed requests with supported platform validation.
+29. Separate write scope and consent from parma.read (D).
+30. Add owner emergency stop and revocation checks.
+
+## Financial and reliability safeguards
+31. Add actual-spend collection separately from budget configuration.
+32. Define daily/monthly spend objectives and limits with owner (D).
+33. Model reporting delays without claiming exact hard spend caps.
+34. Track cumulative budget changes across proposals.
+35. Add change-frequency limits and cooldowns (D).
+36. Read back and compare every applied change.
+37. Handle partial mutation failures explicitly.
+38. Prepare conditional compensation, never blind rollback.
+39. Test journal recovery after interruption.
+40. Test conflicting proposals from concurrent sessions.
+
+## Campaign quality and measured outcomes
+41. Prepare RSA editing proposals with field validation.
+42. Check German copy and destination consistency.
+43. Separate dine-in and direct-order proposal objectives.
+44. Detect conflicts between negative and active keywords.
+45. Validate presence-based local targeting before proposing changes.
+46. Compare ad schedules with verified ordering availability.
+47. Distinguish completed orders from generic booking events.
+48. Build controlled before/after performance comparisons.
+49. Add evidence-based proposal outcome evaluations.
+50. Prepare an owner-approved limited live acceptance trial (D).
+
+Sequence: trusted inputs -> approvals -> execution infrastructure -> safeguards
+-> live trial. Campaign-quality analysis can proceed in read-only alongside this.
+No numeric owner budget limits are supplied by this backlog.

--- a/google-controlled-inventory-reader.js
+++ b/google-controlled-inventory-reader.js
@@ -1,0 +1,80 @@
+'use strict';
+const { collectControlledInventory } = require('./google-controlled-inventory');
+const ACCOUNT_QUERY = 'SELECT customer.id, customer.currency_code, customer.time_zone FROM customer';
+const INVENTORY_QUERY = `SELECT campaign.id, campaign.resource_name, campaign.status,
+  campaign.campaign_budget, campaign_budget.id, campaign_budget.resource_name,
+  campaign_budget.amount_micros, campaign_budget.explicitly_shared, campaign_budget.period
+  FROM campaign WHERE campaign.status != 'REMOVED'`;
+function identifier(value) {
+  if (typeof value === 'number' && !Number.isSafeInteger(value)) throw new Error('invalid_identifier');
+  if (!['string','number','bigint'].includes(typeof value) || !/^\d{1,20}$/.test(String(value)))
+    throw new Error('invalid_identifier');
+  return String(value);
+}
+function normalizeRow(row, customerId) {
+  const c = row.campaign, b = row.campaign_budget;
+  const campaignId = identifier(c?.id), budgetId = identifier(b?.id);
+  const budgetResource = `customers/${customerId}/campaignBudgets/${budgetId}`;
+  if (c.resource_name !== `customers/${customerId}/campaigns/${campaignId}` ||
+      c.campaign_budget !== budgetResource || b.resource_name !== budgetResource)
+    throw new Error('resource_account_mismatch');
+  if (b.period !== 'DAILY' && b.period !== 2) throw new Error('unsupported_budget_period');
+  const status = ({2:'ENABLED',3:'PAUSED',ENABLED:'ENABLED',PAUSED:'PAUSED'})[c.status];
+  if (!status || typeof b.explicitly_shared !== 'boolean') throw new Error('invalid_inventory_row');
+  const amount = identifier(b.amount_micros), micros = Number(amount);
+  if (!Number.isSafeInteger(micros) || micros <= 0) throw new Error('invalid_budget_amount');
+  return { campaign_id:campaignId, budget_id:budgetId, daily_budget_micros:micros,
+    status, shared_budget:b.explicitly_shared };
+}
+function createInventoryPageReader(customer) {
+  if (!customer || typeof customer.queryStream !== 'function') throw new Error('reader_required');
+  let rows = null, account = null, expectedToken = null;
+  return async ({customerId,pageToken,signal}) => {
+    if (signal.aborted) throw new Error('read_aborted');
+    if (pageToken === null) {
+      rows = null; account = null; expectedToken = null;
+      const accounts = [];
+      for await (const row of customer.queryStream(ACCOUNT_QUERY)) {
+        if (signal.aborted || accounts.length >= 1) throw new Error('invalid_account_response');
+        accounts.push(row);
+      }
+      if (accounts.length !== 1 || identifier(accounts[0].customer?.id) !== customerId)
+        throw new Error('account_mismatch');
+      account = accounts[0].customer;
+      const collected = [];
+      for await (const row of customer.queryStream(INVENTORY_QUERY)) {
+        if (signal.aborted || collected.length >= 10000) throw new Error('inventory_limit_or_abort');
+        collected.push(normalizeRow(row,customerId));
+      }
+      rows = collected;
+    } else if (!rows || pageToken !== expectedToken) throw new Error('unexpected_page_token');
+    const offset = pageToken === null ? 0 : Number(pageToken);
+    const next = offset + 1000 < rows.length ? String(offset + 1000) : null;
+    expectedToken = next;
+    return {customer_id:identifier(account.id),currency:account.currency_code,time_zone:account.time_zone,
+      campaigns:rows.slice(offset,offset+1000),next_page_token:next};
+  };
+}
+async function collectConfiguredInventory({env=process.env, createCustomer} = {}) {
+  const blocked = {success:false,mode:'read_only_inventory',snapshot:null,blockers:['google_inventory_configuration_or_read_failed'],
+    writes_allowed:false,spend_allowed:false,execution_allowed:false};
+  try {
+    for (const key of ['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_DEVELOPER_TOKEN','GOOGLE_REFRESH_TOKEN','GOOGLE_CUSTOMER_ID'])
+      if (typeof env[key] !== 'string' || !env[key].trim()) return blocked;
+    const cleanId = value => {
+      const raw = value.trim();
+      if (!/^\d{1,20}$/.test(raw) && !/^\d{3}-\d{3}-\d{4}$/.test(raw)) throw new Error('invalid_config_id');
+      return raw.replace(/-/g,'');
+    };
+    const customerId = cleanId(env.GOOGLE_CUSTOMER_ID);
+    const options = {customer_id:customerId,refresh_token:env.GOOGLE_REFRESH_TOKEN};
+    if (env.GOOGLE_LOGIN_CUSTOMER_ID) options.login_customer_id=cleanId(env.GOOGLE_LOGIN_CUSTOMER_ID);
+    const clientOptions={client_id:env.GOOGLE_CLIENT_ID,client_secret:env.GOOGLE_CLIENT_SECRET,developer_token:env.GOOGLE_DEVELOPER_TOKEN};
+    const factory = createCustomer || ((config, opts) => {
+      const {GoogleAdsApi}=require('google-ads-api'); return new GoogleAdsApi(config).Customer(opts);
+    });
+    const customer = factory(clientOptions,options);
+    return await collectControlledInventory({customerId,fetchPage:createInventoryPageReader(customer)});
+  } catch { return blocked; }
+}
+module.exports={collectConfiguredInventory,createInventoryPageReader,ACCOUNT_QUERY,INVENTORY_QUERY};

--- a/google-controlled-inventory.js
+++ b/google-controlled-inventory.js
@@ -1,0 +1,94 @@
+'use strict';
+// Read-only orchestration. fetchPage must be wired by trusted server code, never by a request body.
+const { z } = require('zod');
+const id = z.string().regex(/^\d{1,20}$/);
+const row = z.object({
+  campaign_id: id, budget_id: id,
+  daily_budget_micros: z.number().int().positive().safe(),
+  status: z.enum(['ENABLED', 'PAUSED']), shared_budget: z.boolean(),
+}).strict();
+const pageSchema = z.object({
+  customer_id: id, currency: z.literal('EUR'), time_zone: z.string().min(1).max(80),
+  campaigns: z.array(row).max(1000),
+  next_page_token: z.string().min(1).max(4096).nullable(),
+}).strict();
+const MAX_PAGES = 100, MAX_ROWS = 10000, MAX_DURATION_MS = 60000;
+const fail = code => { throw new Error(code); };
+const codes = new Set(['invalid_inventory_input', 'inventory_timeout', 'invalid_inventory_page',
+  'inventory_account_mismatch', 'inventory_metadata_changed', 'inventory_pagination_cycle',
+  'inventory_limit_exceeded', 'inventory_duplicate_campaign', 'inventory_empty',
+  'inventory_changed_during_collection', 'inventory_budget_inconsistent', 'inventory_read_failed']);
+
+async function collectControlledInventory(input = {}) {
+  const result = { mode: 'read_only_inventory', success: false, writes_allowed: false,
+    spend_allowed: false, execution_allowed: false, snapshot: null, blockers: [] };
+  const { customerId, fetchPage } = input && typeof input === 'object' ? input : {};
+  if (!id.safeParse(customerId).success || typeof fetchPage !== 'function') {
+    result.blockers.push('invalid_inventory_input'); return result;
+  }
+  const started = Date.now();
+  const controller = new AbortController();
+  async function scan() {
+    const campaigns = [], ids = new Set(), tokens = new Set(), budgets = new Map();
+    let token = null, metadata = null;
+    for (let count = 0; count < MAX_PAGES; count++) {
+      const remaining = MAX_DURATION_MS - (Date.now() - started);
+      if (remaining <= 0) fail('inventory_timeout');
+      let timer, raw;
+      try {
+        raw = await Promise.race([
+          Promise.resolve().then(() => fetchPage({ customerId, pageToken: token, signal: controller.signal })),
+          new Promise((_, reject) => { timer = setTimeout(() => {
+            controller.abort(); reject(new Error('inventory_timeout'));
+          }, remaining); }),
+        ]);
+      } catch (error) {
+        if (controller.signal.aborted) fail('inventory_timeout');
+        fail('inventory_read_failed');
+      } finally { clearTimeout(timer); }
+      const parsed = pageSchema.safeParse(raw);
+      if (!parsed.success) fail('invalid_inventory_page');
+      const page = parsed.data;
+      if (page.customer_id !== customerId) fail('inventory_account_mismatch');
+      try { new Intl.DateTimeFormat('en', { timeZone: page.time_zone }); }
+      catch { fail('invalid_inventory_page'); }
+      const currentMetadata = JSON.stringify([page.customer_id, page.currency, page.time_zone]);
+      if (metadata !== null && metadata !== currentMetadata) fail('inventory_metadata_changed');
+      metadata = currentMetadata;
+      for (const campaign of page.campaigns) {
+        if (ids.has(campaign.campaign_id)) fail('inventory_duplicate_campaign');
+        ids.add(campaign.campaign_id);
+        const existing = budgets.get(campaign.budget_id);
+        if (existing && (existing.daily_budget_micros !== campaign.daily_budget_micros ||
+            !existing.shared_budget || !campaign.shared_budget)) fail('inventory_budget_inconsistent');
+        budgets.set(campaign.budget_id, campaign);
+        campaigns.push(campaign);
+        if (campaigns.length > MAX_ROWS) fail('inventory_limit_exceeded');
+      }
+      token = page.next_page_token;
+      if (token === null) {
+        if (!campaigns.length) fail('inventory_empty');
+        campaigns.sort((a, b) => a.campaign_id.localeCompare(b.campaign_id));
+        return { metadata, time_zone: page.time_zone, campaigns };
+      }
+      if (tokens.has(token)) fail('inventory_pagination_cycle');
+      tokens.add(token);
+    }
+    fail('inventory_limit_exceeded');
+  }
+  try {
+    const first = await scan(), second = await scan();
+    if (JSON.stringify(first) !== JSON.stringify(second)) fail('inventory_changed_during_collection');
+    if (Date.now() - started >= MAX_DURATION_MS) fail('inventory_timeout');
+    result.snapshot = { customer_id: customerId, currency: 'EUR',
+      captured_at: new Date(started).toISOString(), account_inventory_complete: true,
+      campaigns: first.campaigns.map(c => ({ ...c, conversion_integrity_trusted: false })) };
+    result.time_zone = first.time_zone;
+    result.success = true;
+    result.consistency = 'two_matching_reads_not_atomic';
+  } catch (error) {
+    result.blockers.push(codes.has(error.message) ? error.message : 'inventory_read_failed');
+  } finally { controller.abort(); }
+  return result;
+}
+module.exports = { collectControlledInventory };

--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -42,7 +42,7 @@ function prepareControlledProposal({ action, policy, snapshot, now = Date.now(),
   if (result.blockers.length) return result;
   action = a.data; policy = p.data; snapshot = s.data;
   const age = now - Date.parse(snapshot.captured_at);
-  if (age < 0 || age > policy.max_snapshot_age_seconds * 1000) result.blockers.push('snapshot_stale_or_future');
+  if (age < 0 || age >= policy.max_snapshot_age_seconds * 1000) result.blockers.push('snapshot_stale_or_future');
   if (Date.parse(policy.expires_at) <= now) result.blockers.push('owner_policy_expired');
   if (!policy.campaign_ids.includes(action.campaign_id)) result.blockers.push('campaign_not_authorized');
   if (!policy.allowed_actions.includes(action.type)) result.blockers.push('action_not_authorized');

--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -6,6 +6,7 @@ const id = z.string().regex(/^\d{1,20}$/);
 const money = z.number().int().nonnegative().safe();
 const time = z.string().datetime();
 const policySchema = z.object({
+  customer_id: id,
   campaign_ids: z.array(id).min(1),
   allowed_actions: z.array(z.enum(['set_daily_budget', 'pause', 'resume', 'add_negative_keyword'])),
   expires_at: time,
@@ -30,9 +31,24 @@ const snapshotSchema = z.object({
   }).strict()).min(1),
 }).strict();
 function digest(value) { return createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
-function prepareControlledProposal({ action, policy, snapshot, now = Date.now(), kill_switch = false } = {}) {
+// Compare integer micros against the exact decimal form of the configured percent.
+function exceedsPercent(delta, current, percent) {
+  const [coefficient, exponent = '0'] = String(percent).split('e');
+  const decimals = (coefficient.split('.')[1] || '').length;
+  const scale = decimals - Number(exponent);
+  const numerator = BigInt(coefficient.replace('.', ''));
+  const left = BigInt(delta) * 100n * (scale > 0 ? 10n ** BigInt(scale) : 1n);
+  const right = BigInt(current) * numerator * (scale < 0 ? 10n ** BigInt(-scale) : 1n);
+  return left > right;
+}
+function prepareControlledProposal(input = {}) {
   const result = { mode: 'prepare_only', writes_allowed: false, spend_allowed: false,
     execution_allowed: false, policy_fit: false, requires_owner_approval: true, blockers: [] };
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    result.blockers.push('invalid_proposal_input');
+    return result;
+  }
+  let { action, policy, snapshot, now = Date.now(), kill_switch = false } = input;
   if (kill_switch !== false) result.blockers.push('kill_switch_active');
   if (!Number.isSafeInteger(now)) result.blockers.push('invalid_clock');
   const a = actionSchema.safeParse(action), p = policySchema.safeParse(policy), s = snapshotSchema.safeParse(snapshot);
@@ -41,6 +57,7 @@ function prepareControlledProposal({ action, policy, snapshot, now = Date.now(),
   if (!s.success) result.blockers.push('trusted_complete_snapshot_required');
   if (result.blockers.length) return result;
   action = a.data; policy = p.data; snapshot = s.data;
+  if (policy.customer_id !== snapshot.customer_id) result.blockers.push('customer_not_authorized');
   const age = now - Date.parse(snapshot.captured_at);
   if (age < 0 || age >= policy.max_snapshot_age_seconds * 1000) result.blockers.push('snapshot_stale_or_future');
   if (Date.parse(policy.expires_at) <= now) result.blockers.push('owner_policy_expired');
@@ -65,8 +82,7 @@ function prepareControlledProposal({ action, policy, snapshot, now = Date.now(),
     }
   }
   if (action.type === 'set_daily_budget') {
-    const changePercent = Math.abs(nextBudget - campaign.daily_budget_micros) / campaign.daily_budget_micros * 100;
-    if (changePercent > policy.max_budget_change_percent) result.blockers.push('budget_change_limit_exceeded');
+    if (exceedsPercent(Math.abs(nextBudget - campaign.daily_budget_micros), campaign.daily_budget_micros, policy.max_budget_change_percent)) result.blockers.push('budget_change_limit_exceeded');
     if (nextBudget === campaign.daily_budget_micros) result.blockers.push('no_change');
   }
   if ((action.type === 'pause' && campaign.status === 'PAUSED') || (action.type === 'resume' && campaign.status === 'ENABLED')) result.blockers.push('no_change');

--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -50,7 +50,7 @@ function prepareControlledProposal(input = {}) {
   }
   let { action, policy, snapshot, now = Date.now(), kill_switch = false } = input;
   if (kill_switch !== false) result.blockers.push('kill_switch_active');
-  if (!Number.isSafeInteger(now)) result.blockers.push('invalid_clock');
+  if (!Number.isSafeInteger(now) || !Number.isFinite(new Date(now).getTime())) result.blockers.push('invalid_clock');
   const a = actionSchema.safeParse(action), p = policySchema.safeParse(policy), s = snapshotSchema.safeParse(snapshot);
   if (!a.success) result.blockers.push('invalid_or_unsupported_action');
   if (!p.success) result.blockers.push('owner_limits_missing_or_invalid');

--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -1,0 +1,83 @@
+'use strict';
+// Preparation only. This module has no network, credentials or mutation adapter.
+const { z } = require('zod');
+const { createHash } = require('node:crypto');
+const id = z.string().regex(/^\d{1,20}$/);
+const money = z.number().int().nonnegative().safe();
+const time = z.string().datetime();
+const policySchema = z.object({
+  campaign_ids: z.array(id).min(1),
+  allowed_actions: z.array(z.enum(['set_daily_budget', 'pause', 'resume', 'add_negative_keyword'])),
+  expires_at: time,
+  max_account_daily_budget_micros: money,
+  max_campaign_daily_budget_micros: money,
+  max_budget_change_percent: z.number().min(0).max(100),
+  max_snapshot_age_seconds: z.number().int().min(1).max(3600),
+}).strict();
+const actionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('set_daily_budget'), campaign_id: id, amount_micros: money.positive() }).strict(),
+  z.object({ type: z.literal('pause'), campaign_id: id }).strict(),
+  z.object({ type: z.literal('resume'), campaign_id: id }).strict(),
+  z.object({ type: z.literal('add_negative_keyword'), campaign_id: id,
+    text: z.string().trim().min(1).max(80), match_type: z.enum(['EXACT', 'PHRASE']) }).strict(),
+]);
+const snapshotSchema = z.object({
+  customer_id: id, currency: z.literal('EUR'), captured_at: time,
+  account_inventory_complete: z.literal(true),
+  campaigns: z.array(z.object({ campaign_id: id, budget_id: id,
+    daily_budget_micros: money.positive(), status: z.enum(['ENABLED', 'PAUSED']),
+    shared_budget: z.boolean(), conversion_integrity_trusted: z.boolean(),
+  }).strict()).min(1),
+}).strict();
+function digest(value) { return createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
+function prepareControlledProposal({ action, policy, snapshot, now = Date.now(), kill_switch = false } = {}) {
+  const result = { mode: 'prepare_only', writes_allowed: false, spend_allowed: false,
+    execution_allowed: false, policy_fit: false, requires_owner_approval: true, blockers: [] };
+  if (kill_switch !== false) result.blockers.push('kill_switch_active');
+  if (!Number.isSafeInteger(now)) result.blockers.push('invalid_clock');
+  const a = actionSchema.safeParse(action), p = policySchema.safeParse(policy), s = snapshotSchema.safeParse(snapshot);
+  if (!a.success) result.blockers.push('invalid_or_unsupported_action');
+  if (!p.success) result.blockers.push('owner_limits_missing_or_invalid');
+  if (!s.success) result.blockers.push('trusted_complete_snapshot_required');
+  if (result.blockers.length) return result;
+  action = a.data; policy = p.data; snapshot = s.data;
+  const age = now - Date.parse(snapshot.captured_at);
+  if (age < 0 || age > policy.max_snapshot_age_seconds * 1000) result.blockers.push('snapshot_stale_or_future');
+  if (Date.parse(policy.expires_at) <= now) result.blockers.push('owner_policy_expired');
+  if (!policy.campaign_ids.includes(action.campaign_id)) result.blockers.push('campaign_not_authorized');
+  if (!policy.allowed_actions.includes(action.type)) result.blockers.push('action_not_authorized');
+  if (new Set(snapshot.campaigns.map(c => c.campaign_id)).size !== snapshot.campaigns.length) result.blockers.push('duplicate_campaign_inventory');
+  const campaign = snapshot.campaigns.find(c => c.campaign_id === action.campaign_id);
+  if (!campaign) result.blockers.push('campaign_not_found');
+  if (result.blockers.length) return result;
+  // Reject shared/reused budgets rather than underestimate their account impact.
+  if (snapshot.campaigns.some(c => c.shared_budget) || new Set(snapshot.campaigns.map(c => c.budget_id)).size !== snapshot.campaigns.length)
+    result.blockers.push('shared_budget_requires_separate_review');
+  const currentTotal = snapshot.campaigns.reduce((sum, c) => sum + c.daily_budget_micros, 0);
+  const nextBudget = action.type === 'set_daily_budget' ? action.amount_micros : campaign.daily_budget_micros;
+  const proposedTotal = currentTotal - campaign.daily_budget_micros + nextBudget;
+  if (!Number.isSafeInteger(currentTotal) || !Number.isSafeInteger(proposedTotal)) result.blockers.push('budget_arithmetic_overflow');
+  if (action.type === 'set_daily_budget' || action.type === 'resume') {
+    if (nextBudget > policy.max_campaign_daily_budget_micros) result.blockers.push('campaign_budget_limit_exceeded');
+    if (proposedTotal > policy.max_account_daily_budget_micros) result.blockers.push('account_budget_limit_exceeded');
+    if (action.type === 'resume' || nextBudget > campaign.daily_budget_micros) {
+      if (!campaign.conversion_integrity_trusted) result.blockers.push('conversion_integrity_untrusted');
+    }
+  }
+  if (action.type === 'set_daily_budget') {
+    const changePercent = Math.abs(nextBudget - campaign.daily_budget_micros) / campaign.daily_budget_micros * 100;
+    if (changePercent > policy.max_budget_change_percent) result.blockers.push('budget_change_limit_exceeded');
+    if (nextBudget === campaign.daily_budget_micros) result.blockers.push('no_change');
+  }
+  if ((action.type === 'pause' && campaign.status === 'PAUSED') || (action.type === 'resume' && campaign.status === 'ENABLED')) result.blockers.push('no_change');
+  result.policy_fit = result.blockers.length === 0;
+  result.proposal = { customer_id: snapshot.customer_id, action, before: campaign,
+    proposed_account_daily_budget_micros: proposedTotal,
+    snapshot_digest: digest(snapshot), policy_digest: digest(policy),
+    created_at: new Date(now).toISOString(),
+    expires_at: new Date(Math.min(Date.parse(policy.expires_at), Date.parse(snapshot.captured_at) + policy.max_snapshot_age_seconds * 1000)).toISOString(),
+  };
+  result.proposal_id = digest(result.proposal);
+  return result;
+}
+module.exports = { prepareControlledProposal };

--- a/scripts/run-google-controlled-inventory.js
+++ b/scripts/run-google-controlled-inventory.js
@@ -1,0 +1,17 @@
+'use strict';
+const {collectConfiguredInventory}=require('../google-controlled-inventory-reader');
+async function main() {
+  const result=await collectConfiguredInventory();
+  const campaigns=result.snapshot?.campaigns || [];
+  console.log(JSON.stringify({success:result.success,mode:'read_only_inventory',
+    campaign_count:campaigns.length,paused_count:campaigns.filter(c=>c.status==='PAUSED').length,
+    shared_budget_campaign_count:campaigns.filter(c=>c.shared_budget).length,
+    captured_at:result.snapshot?.captured_at || null,blockers:result.blockers,
+    conversion_integrity_trusted:false,writes_allowed:false,spend_allowed:false,execution_allowed:false}));
+  if (!result.success) process.exitCode=1;
+}
+if (require.main===module) main().catch(()=>{
+  console.log(JSON.stringify({success:false,error:'inventory_diagnostic_failed',writes_allowed:false,spend_allowed:false,execution_allowed:false}));
+  process.exitCode=1;
+});
+module.exports={main};

--- a/test/google-controlled-inventory-reader.test.js
+++ b/test/google-controlled-inventory-reader.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const test=require('node:test'),assert=require('node:assert/strict');
+const {collectConfiguredInventory:collect,INVENTORY_QUERY}=require('../google-controlled-inventory-reader');
+const env={GOOGLE_CLIENT_ID:'private',GOOGLE_CLIENT_SECRET:'private',GOOGLE_DEVELOPER_TOKEN:'private',GOOGLE_REFRESH_TOKEN:'private',GOOGLE_CUSTOMER_ID:'123'};
+const row=(id=1)=>({campaign:{id,resource_name:`customers/123/campaigns/${id}`,status:2,campaign_budget:`customers/123/campaignBudgets/${id}`},
+  campaign_budget:{id,resource_name:`customers/123/campaignBudgets/${id}`,amount_micros:'3500000',explicitly_shared:false,period:2}});
+function factory(rows, calls=[], account={id:123,currency_code:'EUR',time_zone:'Europe/Berlin'}) {
+  return ()=>({async *queryStream(query){calls.push(query); if(query.includes('FROM customer')) yield {customer:account};
+    else for(const r of rows) yield r;
+  }});
+}
+test('configured SDK reader completes two full scans and normalizes daily budgets',async()=>{
+  const calls=[],rows=[row(),row(2)]; rows[1].campaign.status='PAUSED';
+  const r=await collect({env,createCustomer:factory(rows,calls)});
+  assert.equal(r.success,true);assert.equal(calls.length,4);
+  assert.equal(r.snapshot.campaigns[1].status,'PAUSED');
+  assert.equal(r.snapshot.campaigns[0].daily_budget_micros,3500000);
+  assert.equal(r.execution_allowed,false);
+  assert.ok(!/metrics\.|segments\.|LIMIT|campaign.id\s*=/.test(INVENTORY_QUERY));
+});
+test('streams over one normalized page without losing rows',async()=>{
+  const r=await collect({env,createCustomer:factory(Array.from({length:1001},(_,i)=>row(i+1)))});
+  assert.equal(r.success,true);assert.equal(r.snapshot.campaigns.length,1001);
+});
+for(const [name,change] of [
+  ['foreign resource',r=>r.campaign.resource_name='customers/456/campaigns/1'],
+  ['budget link mismatch',r=>r.campaign.campaign_budget='customers/123/campaignBudgets/9'],
+  ['lifetime budget',r=>r.campaign_budget.period='CUSTOM_PERIOD'],
+  ['missing sharing flag',r=>delete r.campaign_budget.explicitly_shared],
+  ['unsafe id',r=>r.campaign.id=Number.MAX_SAFE_INTEGER+1],
+  ['unsafe amount',r=>r.campaign_budget.amount_micros='9007199254740993'],
+  ['removed row',r=>r.campaign.status=4],
+]) test(`blocks ${name}`,async()=>{
+  const data=row();change(data);const r=await collect({env,createCustomer:factory([data])});
+  assert.equal(r.success,false);assert.equal(r.snapshot,null);assert.equal(r.execution_allowed,false);
+});
+test('wrong account metadata fails closed',async()=>{
+  const r=await collect({env,createCustomer:factory([row()],[],{id:456,currency_code:'EUR',time_zone:'UTC'})});
+  assert.equal(r.success,false);
+});
+test('stream errors discard all partial data and redact provider errors',async()=>{
+  const r=await collect({env,createCustomer:()=>({async *queryStream(q){
+    if(q.includes('FROM customer')) yield {customer:{id:123,currency_code:'EUR',time_zone:'UTC'}};
+    else {yield row();throw new Error('PRIVATE_TOKEN');}
+  }})});
+  assert.equal(r.snapshot,null);assert.ok(!JSON.stringify(r).includes('PRIVATE_TOKEN'));
+});
+test('invalid configuration does not initialize SDK or leak values',async()=>{
+  for(const config of [{},{...env,GOOGLE_CUSTOMER_ID:'abc123'},{...env,GOOGLE_LOGIN_CUSTOMER_ID:'bad'}]) {
+    let called=false;const r=await collect({env:config,createCustomer:()=>{called=true;throw new Error('private');}});
+    assert.equal(called,false);assert.equal(r.success,false);assert.ok(!JSON.stringify(r).includes('private'));
+  }
+});
+test('formatted account ID is normalized before creating SDK customer',async()=>{
+  let actual;
+  const r=await collect({env:{...env,GOOGLE_CUSTOMER_ID:'123-456-7890'},createCustomer:(_,opts)=>{
+    actual=opts.customer_id;return factory([],[],{id:'1234567890',currency_code:'EUR',time_zone:'UTC'})();
+  }});
+  assert.equal(actual,'1234567890');assert.equal(r.success,false); // Empty accounts cannot back proposals.
+});

--- a/test/google-controlled-inventory.test.js
+++ b/test/google-controlled-inventory.test.js
@@ -1,0 +1,85 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { collectControlledInventory: collect } = require('../google-controlled-inventory');
+const { prepareControlledProposal: prepare } = require('../google-controlled-proposals');
+const campaign = (id = '1') => ({ campaign_id: id, budget_id: `${id}0`,
+  daily_budget_micros: 3500000, status: 'ENABLED', shared_budget: false });
+const page = (rows = [campaign()], token = null) => ({ customer_id: '123', currency: 'EUR',
+  time_zone: 'Europe/Berlin', campaigns: rows, next_page_token: token });
+async function run(p) { return collect({ customerId: '123', fetchPage: async () => structuredClone(p) }); }
+test('two paginated reads include paused campaigns, never infer trusted conversions', async () => {
+  const calls = [], paused = { ...campaign('2'), status: 'PAUSED' };
+  const r = await collect({ customerId: '123', fetchPage: async ({pageToken, signal}) => {
+    assert.equal(signal.aborted, false); calls.push(pageToken);
+    return pageToken === null ? page([campaign()], 'next') : page([paused]);
+  } });
+  assert.deepEqual(calls, [null, 'next', null, 'next']);
+  assert.equal(r.success, true); assert.equal(r.snapshot.campaigns.length, 2);
+  assert.equal(r.snapshot.campaigns[1].status, 'PAUSED');
+  assert.ok(r.snapshot.campaigns.every(c => c.conversion_integrity_trusted === false));
+  assert.equal(r.execution_allowed, false);
+  const policy = { customer_id: '123', campaign_ids: ['1'], allowed_actions: ['pause', 'set_daily_budget'],
+    expires_at: new Date(Date.now()+60000).toISOString(), max_account_daily_budget_micros: 9000000,
+    max_campaign_daily_budget_micros: 5000000, max_budget_change_percent: 20, max_snapshot_age_seconds: 300 };
+  const args = { policy, snapshot: r.snapshot, action: {type:'pause',campaign_id:'1'} };
+  assert.equal(prepare(args).policy_fit, true);
+  args.action = {type:'set_daily_budget',campaign_id:'1',amount_micros:4000000};
+  assert.ok(prepare(args).blockers.includes('conversion_integrity_untrusted'));
+});
+for (const [name, change, code] of [
+  ['foreign account', p => p.customer_id = '456', 'inventory_account_mismatch'],
+  ['missing pagination', p => delete p.next_page_token, 'invalid_inventory_page'],
+  ['currency', p => p.currency = 'USD', 'invalid_inventory_page'],
+  ['timezone', p => p.time_zone = 'not/a/zone', 'invalid_inventory_page'],
+  ['unsafe money', p => p.campaigns[0].daily_budget_micros = Number.MAX_SAFE_INTEGER+1, 'invalid_inventory_page'],
+  ['unknown status', p => p.campaigns[0].status = 'UNKNOWN', 'invalid_inventory_page'],
+  ['empty inventory', p => p.campaigns = [], 'inventory_empty'],
+  ['duplicate', p => p.campaigns.push(campaign()), 'inventory_duplicate_campaign'],
+  ['injected trust', p => p.campaigns[0].conversion_integrity_trusted = true, 'invalid_inventory_page'],
+  ['shared mismatch', p => p.campaigns.push({...campaign('2'),budget_id:'10'}), 'inventory_budget_inconsistent'],
+]) test(`rejects ${name}`, async () => {
+  const p=page(); change(p); const r=await run(p);
+  assert.equal(r.snapshot, null); assert.deepEqual(r.blockers,[code]); assert.equal(r.success,false);
+});
+test('rejects token cycles without exposing tokens', async () => {
+  const r=await run(page([], 'PRIVATE_TOKEN'));
+  assert.deepEqual(r.blockers,['inventory_pagination_cycle']);
+  assert.ok(!JSON.stringify(r).includes('PRIVATE_TOKEN'));
+});
+test('rejects drift between scans', async () => {
+  let n=0;
+  const r=await collect({customerId:'123',fetchPage: async()=>page([{...campaign(),daily_budget_micros:3500000+n++}])});
+  assert.deepEqual(r.blockers,['inventory_changed_during_collection']); assert.equal(r.snapshot,null);
+});
+test('row ordering changes do not masquerade as account drift', async () => {
+  let n=0;
+  const r=await collect({customerId:'123',fetchPage: async()=>page(n++ ? [campaign('2'),campaign()] : [campaign(),campaign('2')])});
+  assert.equal(r.success,true);
+});
+test('metadata cannot change mid-pagination', async () => {
+  const r=await collect({customerId:'123',fetchPage: async({pageToken})=>pageToken ?
+    {...page([campaign('2')]),time_zone:'UTC'} : page([campaign()],'next')});
+  assert.deepEqual(r.blockers,['inventory_metadata_changed']);
+});
+test('provider errors never escape and partial inventory is discarded', async () => {
+  const r=await collect({customerId:'123',fetchPage: async({pageToken})=>{
+    if(pageToken) throw new Error('SECRET_CREDENTIAL'); return page([campaign()],'next');
+  }});
+  assert.deepEqual(r.blockers,['inventory_read_failed']); assert.equal(r.snapshot,null);
+  assert.ok(!JSON.stringify(r).includes('SECRET'));
+});
+test('consistent shared budgets are represented but proposal evaluator blocks them', async () => {
+  const r=await run(page([{...campaign(),shared_budget:true}, {...campaign('2'),budget_id:'10',shared_budget:true}]));
+  assert.equal(r.success,true); assert.ok(r.snapshot.campaigns.every(c=>c.shared_budget));
+});
+test('invalid entry inputs fail closed', async () => {
+  for(const input of [undefined,null,42,{}, {customerId:'123'}]) {
+    const r=await collect(input); assert.deepEqual(r.blockers,['invalid_inventory_input']);
+  }
+});
+test('bounded pagination stops a non-terminating reader', async () => {
+  let calls=0;
+  const r=await collect({customerId:'123',fetchPage:async()=>page([],String(++calls))});
+  assert.equal(calls,100); assert.deepEqual(r.blockers,['inventory_limit_exceeded']);
+});

--- a/test/google-controlled-proposals.test.js
+++ b/test/google-controlled-proposals.test.js
@@ -90,3 +90,8 @@ test('budget reductions remain proposals, not authority to spend or rollback mon
   f.snapshot.campaigns[0].conversion_integrity_trusted = false;
   const r = prepare(f); assert.equal(r.policy_fit, true); assert.equal(r.execution_allowed, false);
 });
+
+test('out-of-range clocks fail closed', () => {
+  const f = fixture(); f.now = Number.MAX_SAFE_INTEGER;
+  assert.ok(prepare(f).blockers.includes('invalid_clock'));
+});

--- a/test/google-controlled-proposals.test.js
+++ b/test/google-controlled-proposals.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { prepareControlledProposal: prepare } = require('../google-controlled-proposals');
+const now = Date.parse('2026-09-04T10:00:00Z');
+function fixture() { return { now,
+  action: { type: 'set_daily_budget', campaign_id: '1', amount_micros: 4000000 },
+  policy: { campaign_ids: ['1'], allowed_actions: ['set_daily_budget','pause','resume','add_negative_keyword'],
+    expires_at: '2026-09-05T00:00:00Z', max_account_daily_budget_micros: 8000000,
+    max_campaign_daily_budget_micros: 5000000, max_budget_change_percent: 20, max_snapshot_age_seconds: 300 },
+  snapshot: { customer_id: '123', currency: 'EUR', captured_at: '2026-09-04T10:00:00Z', account_inventory_complete: true,
+    campaigns: [{ campaign_id: '1', budget_id: '10', daily_budget_micros: 3500000, status: 'ENABLED', shared_budget: false, conversion_integrity_trusted: true },
+      { campaign_id: '2', budget_id: '20', daily_budget_micros: 4000000, status: 'PAUSED', shared_budget: false, conversion_integrity_trusted: true }] } }; }
+test('valid proposal stays non-executable and includes paused campaign budgets', () => {
+  const f = fixture(), copy = structuredClone(f), r = prepare(f);
+  assert.equal(r.policy_fit, true); assert.equal(r.proposal.proposed_account_daily_budget_micros, 8000000);
+  assert.equal(r.execution_allowed, false); assert.equal(r.writes_allowed, false); assert.equal(r.spend_allowed, false);
+  assert.equal(r.requires_owner_approval, true); assert.deepEqual(f, copy);
+  assert.equal(r.proposal_id, prepare(f).proposal_id);
+  f.action.amount_micros++; assert.notEqual(r.proposal_id, prepare(f).proposal_id);
+});
+for (const [name, change] of [
+  ['missing limits', f => delete f.policy], ['string money', f => f.action.amount_micros = '4000000'],
+  ['extra approval cannot authorize', f => f.policy.approved = true], ['unsupported write', f => f.action.type = 'delete_campaign'],
+  ['foreign campaign', f => f.policy.campaign_ids = ['9']], ['expired policy', f => f.policy.expires_at = '2026-09-04T09:00:00Z'],
+  ['stale snapshot', f => f.now += 301000], ['future snapshot', f => f.now--],
+  ['incomplete inventory', f => f.snapshot.account_inventory_complete = false], ['shared budget', f => f.snapshot.campaigns[0].shared_budget = true],
+  ['reused budget', f => f.snapshot.campaigns[1].budget_id = '10'], ['duplicate campaign', f => f.snapshot.campaigns[1].campaign_id = '1'],
+  ['untrusted conversion', f => f.snapshot.campaigns[0].conversion_integrity_trusted = false],
+  ['account limit', f => f.policy.max_account_daily_budget_micros = 7900000], ['campaign limit', f => f.policy.max_campaign_daily_budget_micros = 3900000],
+  ['percentage limit', f => f.policy.max_budget_change_percent = 10], ['kill switch', f => f.kill_switch = true],
+  ['invalid clock', f => f.now = NaN], ['no change', f => f.action.amount_micros = 3500000],
+]) test(`blocks ${name}`, () => { const f = fixture(); change(f); const r = prepare(f); assert.equal(r.policy_fit, false); assert.equal(r.execution_allowed, false); assert.ok(r.blockers.length); });
+test('pause and exact negative proposals work without trusting conversions', () => {
+  const f = fixture(); f.snapshot.campaigns[0].conversion_integrity_trusted = false;
+  for (const action of [{type:'pause',campaign_id:'1'}, {type:'add_negative_keyword',campaign_id:'1',text:'test query',match_type:'EXACT'}]) {
+    f.action = action; assert.equal(prepare(f).policy_fit, true);
+  }
+  f.action.match_type = 'BROAD'; assert.equal(prepare(f).policy_fit, false);
+});

--- a/test/google-controlled-proposals.test.js
+++ b/test/google-controlled-proposals.test.js
@@ -37,3 +37,28 @@ test('pause and exact negative proposals work without trusting conversions', () 
   }
   f.action.match_type = 'BROAD'; assert.equal(prepare(f).policy_fit, false);
 });
+test('resume cannot bypass budget ceilings or conversion integrity', () => {
+  const f = fixture(); f.action = {type:'resume',campaign_id:'1'};
+  f.snapshot.campaigns[0].status = 'PAUSED';
+  assert.equal(prepare(f).policy_fit, true);
+  f.snapshot.campaigns[0].conversion_integrity_trusted = false;
+  assert.ok(prepare(f).blockers.includes('conversion_integrity_untrusted'));
+  f.snapshot.campaigns[0].conversion_integrity_trusted = true;
+  f.policy.max_account_daily_budget_micros = 7000000;
+  assert.ok(prepare(f).blockers.includes('account_budget_limit_exceeded'));
+});
+test('exact expiry is blocked and changed policy or snapshot changes proposal binding', () => {
+  const f = fixture(), before = prepare(f).proposal_id;
+  f.policy.max_budget_change_percent = 30;
+  assert.notEqual(prepare(f).proposal_id, before);
+  const policyChanged = prepare(f).proposal_id;
+  f.snapshot.campaigns[0].status = 'PAUSED';
+  assert.notEqual(prepare(f).proposal_id, policyChanged);
+  f.now += 300000;
+  assert.equal(prepare(f).policy_fit, false);
+});
+test('budget reductions remain proposals, not authority to spend or rollback money', () => {
+  const f = fixture(); f.action.amount_micros = 3000000;
+  f.snapshot.campaigns[0].conversion_integrity_trusted = false;
+  const r = prepare(f); assert.equal(r.policy_fit, true); assert.equal(r.execution_allowed, false);
+});

--- a/test/google-controlled-proposals.test.js
+++ b/test/google-controlled-proposals.test.js
@@ -4,7 +4,7 @@ const { prepareControlledProposal: prepare } = require('../google-controlled-pro
 const now = Date.parse('2026-09-04T10:00:00Z');
 function fixture() { return { now,
   action: { type: 'set_daily_budget', campaign_id: '1', amount_micros: 4000000 },
-  policy: { campaign_ids: ['1'], allowed_actions: ['set_daily_budget','pause','resume','add_negative_keyword'],
+  policy: { customer_id: '123', campaign_ids: ['1'], allowed_actions: ['set_daily_budget','pause','resume','add_negative_keyword'],
     expires_at: '2026-09-05T00:00:00Z', max_account_daily_budget_micros: 8000000,
     max_campaign_daily_budget_micros: 5000000, max_budget_change_percent: 20, max_snapshot_age_seconds: 300 },
   snapshot: { customer_id: '123', currency: 'EUR', captured_at: '2026-09-04T10:00:00Z', account_inventory_complete: true,
@@ -17,6 +17,34 @@ test('valid proposal stays non-executable and includes paused campaign budgets',
   assert.equal(r.requires_owner_approval, true); assert.deepEqual(f, copy);
   assert.equal(r.proposal_id, prepare(f).proposal_id);
   f.action.amount_micros++; assert.notEqual(r.proposal_id, prepare(f).proposal_id);
+});
+test('policy must name and match the snapshot account', () => {
+  const f = fixture(); f.policy.customer_id = '456';
+  assert.ok(prepare(f).blockers.includes('customer_not_authorized'));
+  delete f.policy.customer_id;
+  assert.ok(prepare(f).blockers.includes('owner_limits_missing_or_invalid'));
+});
+test('null and primitive inputs fail closed without throwing', () => {
+  for (const input of [null, false, 42, 'input', []]) {
+    const r = prepare(input);
+    assert.equal(r.policy_fit, false); assert.equal(r.execution_allowed, false);
+    assert.ok(r.blockers.length);
+  }
+});
+test('percentage ceiling accepts exact boundary and rejects one micro above', () => {
+  const f = fixture(); f.policy.max_budget_change_percent = 7;
+  f.action.amount_micros = 3745000;
+  assert.equal(prepare(f).policy_fit, true);
+  f.action.amount_micros++;
+  assert.ok(prepare(f).blockers.includes('budget_change_limit_exceeded'));
+  f.policy.max_budget_change_percent = 0.07;
+  f.action.amount_micros = 3502450;
+  assert.equal(prepare(f).policy_fit, true);
+  f.action.amount_micros++;
+  assert.ok(prepare(f).blockers.includes('budget_change_limit_exceeded'));
+  f.policy.max_budget_change_percent = 1e-7;
+  f.action.amount_micros = 3500001;
+  assert.ok(prepare(f).blockers.includes('budget_change_limit_exceeded'));
 });
 for (const [name, change] of [
   ['missing limits', f => delete f.policy], ['string money', f => f.action.amount_micros = '4000000'],


### PR DESCRIPTION
Preparation-only pure module, no external writes or routes. Explicit owner limits required (not configured); fresh complete inventory; shared budget rejection; fixed allowlisted actions; budget ceilings/percentage checks; content-bound proposal ID and expiry. All results execution_allowed=false. 21 targeted tests passed; full local suite run recorded separately. Docs distinguish policy-fit from approval and daily budget from actual spend; enumerate remaining trusted approval, durable journal, idempotency, locking, mutation validation and readback gates. Do not activate writes based on this PR.