### PR TITLE
Extract read-only connection control plane onto current main

### DIFF
--- a/connection-api.js
+++ b/connection-api.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { listConnections, connectionHealth, canUseCapability, humanActionNeeded } = require('./connection-registry');
+
+function buildConnectionsView() {
+  return { success:true, mode:'read_only_capability_registry', mutation_permission:false, connections:listConnections().map((connection) => ({ ...connection, health:connectionHealth(connection.id), human_action:humanActionNeeded(connection.id) })) };
+}
+
+function buildConnectionsHealth() {
+  const connections = listConnections().map((connection) => connectionHealth(connection.id));
+  return { success:true, mode:'read_only_health', mutation_permission:false, summary:{ total:connections.length, usable:connections.filter((x)=>x.usable).length, blocked:connections.filter((x)=>!x.usable).length }, connections };
+}
+
+function resolveCapability({ connectionId, capability, mutation=false } = {}) {
+  if (!connectionId || !capability) return { success:false, allowed:false, reason:'connection_id_and_capability_required', mutation_permission:false };
+  const decision = canUseCapability(connectionId, capability, { mutation:Boolean(mutation) });
+  return { success:true, connection_id:connectionId, capability, requested_mutation:Boolean(mutation), mutation_permission:false, ...decision };
+}
+
+function installConnectionRoutes(app, requireApiKey) {
+  app.get('/capabilities/connections', requireApiKey, (req,res)=>res.json(buildConnectionsView()));
+  app.get('/health/connections', requireApiKey, (req,res)=>res.json(buildConnectionsHealth()));
+  app.get('/capabilities/connections/:id/:capability', requireApiKey, (req,res)=>{
+    const result=resolveCapability({connectionId:req.params.id, capability:req.params.capability, mutation:req.query.mutation==='true'});
+    res.status(result.success ? 200 : 400).json(result);
+  });
+}
+
+module.exports={buildConnectionsView,buildConnectionsHealth,resolveCapability,installConnectionRoutes};

--- a/connection-registry.js
+++ b/connection-registry.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const registry = require('./state/CONNECTION_REGISTRY.json');
+
+const HEALTH = new Set(['healthy','degraded','reauth_required','external_security_gate','unavailable']);
+
+function listConnections() {
+  return registry.connections.map((c) => ({
+    id: c.id,
+    system: c.system,
+    status: c.status,
+    health: HEALTH.has(c.health) ? c.health : 'unavailable',
+    autonomous_read_allowed: c.autonomous_read_allowed === true,
+    priority: c.priority,
+    shared_agent_backend_access: c.shared_agent_backend_access,
+    blocker: c.blocker || null,
+    human_gate: c.human_gate || null,
+    capabilities: c.capabilities || [],
+    capabilities_target: c.capabilities_target || []
+  }));
+}
+
+function connectionHealth(id) {
+  const c = registry.connections.find((x) => x.id === id);
+  if (!c) return { found:false, health:'unavailable', healthy:false, usable:false, autonomous_read_allowed:false, reason:'unknown_connection' };
+  const health = HEALTH.has(c.health) ? c.health : 'unavailable';
+  const autonomousRead = c.autonomous_read_allowed === true;
+  const blocked = c.shared_agent_backend_access === 'BLOCKED' || health === 'unavailable' || health === 'reauth_required' || health === 'external_security_gate';
+  const usable = autonomousRead && !blocked && (health === 'healthy' || health === 'degraded');
+  return { found:true, id:c.id, system:c.system, status:c.status, health, healthy:health === 'healthy', usable, autonomous_read_allowed:autonomousRead, shared_agent_backend_access:c.shared_agent_backend_access, blocker:c.blocker || null };
+}
+
+function canUseCapability(connectionId, capability, { mutation=false } = {}) {
+  const c = registry.connections.find((x) => x.id === connectionId);
+  if (!c) return { allowed:false, reason:'unknown_connection' };
+  const health = connectionHealth(connectionId);
+  if (!health.usable) return { allowed:false, reason:'connection_not_usable', health:health.health, blocker:c.blocker || null };
+  const granted = new Set(c.capabilities || []);
+  if (!granted.has(capability)) return { allowed:false, reason:'capability_not_verified' };
+  if (mutation) return { allowed:false, reason:'mutation_requires_separate_permission_class' };
+  return { allowed:true, reason:'verified_read_capability', health:health.health };
+}
+
+function humanActionNeeded(connectionId) {
+  const c = registry.connections.find((x) => x.id === connectionId);
+  if (!c) return { needed:false, reason:'unknown_connection' };
+  const health = connectionHealth(connectionId);
+  if (health.usable || health.health === 'degraded') return { needed:false, reason:'no_current_human_gate' };
+  const ownerGate = health.health === 'reauth_required' || health.health === 'external_security_gate';
+  return { needed:ownerGate, reason:c.blocker || health.health, smallest_action:ownerGate ? (c.human_gate || null) : null };
+}
+
+module.exports = { listConnections, connectionHealth, canUseCapability, humanActionNeeded };

--- a/docs/CONNECTION_CONTROL_PLANE.md
+++ b/docs/CONNECTION_CONTROL_PLANE.md
@@ -1,0 +1,13 @@
+# Connection control plane
+
+This current-main extraction exposes only sanitized capability and health metadata. It does not contain provider credentials and does not grant mutation permission.
+
+## Contract
+- Known, verified read capabilities may be reported usable.
+- Unknown connections/capabilities fail closed.
+- Every mutation request is denied by this module and requires a separate permission class.
+- Human intervention is reported only for an evidenced provider gate, not merely because a capability is incomplete.
+- Registry state is non-secret; customer/reservation/order records must not be persisted here.
+
+## Integration gate
+The route installer exists but is not mounted into production bootstrap by this extraction. Mounting is a separate change after exact-head CI is green and route authentication is independently reviewed.

--- a/state/CONNECTION_REGISTRY.json
+++ b/state/CONNECTION_REGISTRY.json
@@ -1,0 +1,12 @@
+{
+  "registry_version":"1.0.0",
+  "purpose":"Non-secret registry of verified external read capabilities. Credentials must never be stored here.",
+  "connections":[
+    {"id":"github","system":"GitHub","status":"CONNECTED","health":"healthy","autonomous_read_allowed":true,"priority":"P0","shared_agent_backend_access":"PARTIAL","capabilities":["repo_read","actions_read"]},
+    {"id":"google_ads","system":"Google Ads","status":"CONNECTED_BACKEND_READ_ONLY","health":"healthy","autonomous_read_allowed":true,"priority":"P0","shared_agent_backend_access":"PARTIAL","capabilities":["campaign_read","keyword_read","search_term_read","conversion_action_read","diagnostics_read"]},
+    {"id":"ga4","system":"Google Analytics 4","status":"CONNECTED_BACKEND_READ_ONLY","health":"healthy","autonomous_read_allowed":true,"priority":"P0","shared_agent_backend_access":"PARTIAL","capabilities":["report_read","event_read","source_health"]},
+    {"id":"wix","system":"Wix","status":"CONNECTED_DIRECT_READ_VERIFIED","health":"healthy","autonomous_read_allowed":true,"priority":"P0","shared_agent_backend_access":"PARTIAL","capabilities":["reservation_read","reservation_status_read"],"capabilities_target":["reservation_aggregate_read","orders_read"]},
+    {"id":"meta","system":"Meta Ads","status":"BACKEND_SOURCE_PRESENT_DIAGNOSTIC_PARTIAL","health":"degraded","autonomous_read_allowed":true,"priority":"P1","shared_agent_backend_access":"PARTIAL","capabilities":["asset_read_partial","issue_classification_read"],"blocker":"Write/activation path is separately gated.","human_gate":"Provider security/payment checkpoint or explicit mutation authorization when actually required."},
+    {"id":"railway","system":"Railway","status":"CONNECTED_DIRECT_READ_VERIFIED","health":"healthy","autonomous_read_allowed":true,"priority":"P0","shared_agent_backend_access":"PARTIAL","capabilities":["project_read","service_read","environment_read","deployment_status_read","deployment_history_read","logs_read","environment_health_read","domain_read","service_config_read","metrics_read"],"capabilities_target":["deploy_within_delegated_gate"]}
+  ]
+}

--- a/test/connection-control-plane.test.js
+++ b/test/connection-control-plane.test.js
@@ -1,0 +1,14 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {listConnections,connectionHealth,canUseCapability,humanActionNeeded}=require('../connection-registry');
+const {buildConnectionsView,buildConnectionsHealth,resolveCapability}=require('../connection-api');
+
+test('registry exposes sanitized named connections',()=>{const rows=listConnections();assert.ok(rows.length>=6);assert.ok(rows.every(x=>x.id&&x.system&&Array.isArray(x.capabilities)));assert.equal(JSON.stringify(rows).includes('token'),false);});
+test('known healthy read capability is allowed',()=>{assert.equal(canUseCapability('google_ads','campaign_read').allowed,true);});
+test('all mutation requests fail closed',()=>{assert.deepEqual(canUseCapability('google_ads','campaign_read',{mutation:true}).allowed,false);assert.equal(resolveCapability({connectionId:'wix',capability:'reservation_read',mutation:true}).mutation_permission,false);});
+test('unknown connection and unknown capability fail closed',()=>{assert.equal(canUseCapability('missing','read').allowed,false);assert.equal(canUseCapability('ga4','made_up').allowed,false);});
+test('degraded verified read remains usable but not healthy',()=>{const h=connectionHealth('meta');assert.equal(h.usable,true);assert.equal(h.healthy,false);});
+test('healthy connection needs no human action',()=>{assert.equal(humanActionNeeded('wix').needed,false);});
+test('views are explicitly read only',()=>{assert.equal(buildConnectionsView().mutation_permission,false);assert.equal(buildConnectionsHealth().mutation_permission,false);assert.equal(buildConnectionsHealth().summary.total,listConnections().length);});
+test('missing capability request is rejected',()=>{assert.equal(resolveCapability({connectionId:'ga4'}).success,false);});


### PR DESCRIPTION
Clean extraction from the old architecture stack onto current main. Adds only sanitized connection capability state, fail-closed read capability evaluation, an unmounted protected-route module, tests and safety documentation. No provider credentials, customer/reservation rows, campaign changes, tracking changes, spend or production route mounting. Mutation requests are always denied by this module. Exact-head CI must pass before review/merge; route mounting remains a separate independently reviewed change.