### PR TITLE
Observe Google runtime preflight and today's spend, fail closed

### DIFF
--- a/google-write-runtime.js
+++ b/google-write-runtime.js
@@ -1,0 +1,49 @@
+'use strict';
+// Diagnostics only: this module never sends a real mutation.
+const { customerFrom, configured, validateWritePath } = require('./google-write-path');
+const safeCode = error => Number.isInteger(error?.code) ? error.code : null;
+function berlinDay(now = new Date()) {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Berlin', year: 'numeric', month: '2-digit', day: '2-digit' }).format(now);
+}
+async function readToday(customer, now = new Date()) {
+  const day = berlinDay(now);
+  const account = await customer.query('SELECT customer.id, customer.currency_code, customer.time_zone FROM customer');
+  if (account.length !== 1 || account[0].customer.currency_code !== 'EUR' || account[0].customer.time_zone !== 'Europe/Berlin') throw new Error('account_metadata_invalid');
+  const spend = await customer.query(`SELECT customer.id, metrics.cost_micros FROM customer WHERE segments.date = '${day}'`);
+  if (spend.length !== 1 || String(spend[0].customer.id) !== String(account[0].customer.id)) throw new Error('today_spend_unavailable');
+  const cost = Number(spend[0].metrics?.cost_micros);
+  if (!Number.isSafeInteger(cost) || cost < 0) throw new Error('today_spend_invalid');
+  const history = await customer.query(`SELECT change_event.change_date_time, change_event.change_resource_type, change_event.change_resource_name, change_event.changed_fields, change_event.old_resource, change_event.new_resource FROM change_event WHERE change_event.change_date_time >= '${day} 00:00:00' AND change_event.change_date_time <= '${day} 23:59:59' ORDER BY change_event.change_date_time ASC LIMIT 10000`);
+  if (!Array.isArray(history) || history.length >= 10000) throw new Error('history_truncated');
+  // Change-event has reporting latency. Empty results are NOT proof of no changes.
+  return { day, currency: 'EUR', time_zone: 'Europe/Berlin', reported_cost_micros: cost,
+    change_rows: history.length, history_reconciled: false, hard_daily_spend_cap_verified: false, execution_allowed: false };
+}
+async function runRuntimePreflight({ env = process.env, customer, log = entry => console.log(JSON.stringify(entry)), timeoutMs = 45000 } = {}) {
+  const enabled = env.GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START === 'true';
+  log({ event: 'google_write_path_startup', enabled, writes_executed: false });
+  if (!enabled) return { status: 'disabled' };
+  if (!configured(env)) { log({ event: 'google_write_path_preflight', success: false, blockers: ['google_configuration_incomplete'], writes_executed: false }); return { status: 'blocked' }; }
+  let timer;
+  const work = async () => {
+    customer = customer || customerFrom(env);
+    const preflight = await validateWritePath({ env, customer, maxTotalMicros: 10000000 });
+    let today = null, today_error = null;
+    try { today = await readToday(customer); } catch (error) { today_error = safeCode(error); }
+    return { event: 'google_write_path_preflight', success: preflight.success === true,
+      mode: 'validate_only', mutation_permission_validated: preflight.mutation_permission_validated === true,
+      writes_executed: false, spend_changed: false, execution_allowed: false,
+      enabled_campaigns: preflight.inventory?.enabled_count ?? null,
+      current_enabled_daily_budget_micros: preflight.inventory?.total_enabled_budget_micros ?? null,
+      blockers: preflight.blockers, today, today_read_success: today !== null, today_error_code: today_error };
+  };
+  try {
+    const result = await Promise.race([work(), new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('preflight_timeout')), timeoutMs); })]);
+    log(result); return result;
+  } catch (error) {
+    const result = { event: 'google_write_path_preflight', success: false, mode: 'validate_only', writes_executed: false,
+      execution_allowed: false, blockers: [error.message === 'preflight_timeout' ? 'preflight_timeout' : 'preflight_failed'], provider_code: safeCode(error) };
+    log(result); return result;
+  } finally { clearTimeout(timer); }
+}
+module.exports = { berlinDay, readToday, runRuntimePreflight };

--- a/google-write-validation-preload.js
+++ b/google-write-validation-preload.js
@@ -1,7 +1,3 @@
 'use strict';
-const {validateWritePath}=require('./google-write-path');
-if(process.env.GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START==='true'){
-  setImmediate(async()=>{
-    try{const r=await validateWritePath({env:process.env,maxTotalMicros:10_000_000});console.log(JSON.stringify({event:'google_write_path_preflight',success:r.success===true,mode:'validate_only',mutation_permission_validated:r.mutation_permission_validated===true,writes_executed:false,spend_changed:false,owner_cap_eur:10,enabled_campaigns:r.inventory?.enabled_count??null,current_enabled_daily_budget_eur:Number.isFinite(r.inventory?.total_enabled_budget_micros)?r.inventory.total_enabled_budget_micros/1e6:null,blockers:r.blockers||[]}))}catch{console.error(JSON.stringify({event:'google_write_path_preflight',success:false,mode:'validate_only',writes_executed:false,spend_changed:false,owner_cap_eur:10,blockers:['preflight_exception']}))}
-  });
-}
+const { runRuntimePreflight } = require('./google-write-runtime');
+setImmediate(() => { runRuntimePreflight().catch(() => {}); });

--- a/test/google-write-runtime.test.js
+++ b/test/google-write-runtime.test.js
@@ -1,0 +1,30 @@
+'use strict';
+const {test}=require('node:test');
+const assert=require('node:assert/strict');
+const {berlinDay,readToday,runRuntimePreflight}=require('../google-write-runtime');
+test('Berlin day includes UTC midnight offset',()=>assert.equal(berlinDay(new Date('2026-09-03T22:30:00Z')),'2026-09-04'));
+test('disabled preflight is observable and does not query',async()=>{
+ const logs=[]; const r=await runRuntimePreflight({env:{},log:x=>logs.push(x),customer:{query:()=>assert.fail()}});
+ assert.equal(r.status,'disabled'); assert.equal(logs[0].enabled,false);
+});
+test('missing config is observable without secret values',async()=>{
+ const logs=[];await runRuntimePreflight({env:{GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START:'true',GOOGLE_CLIENT_SECRET:'do-not-log'},log:x=>logs.push(x)});
+ assert.equal(logs[1].success,false);assert.ok(!JSON.stringify(logs).includes('do-not-log'));
+});
+test('today diagnostics never claim hard cap from empty history',async()=>{
+ const responses=[[{customer:{id:'1',currency_code:'EUR',time_zone:'Europe/Berlin'}}],[{customer:{id:'1'},metrics:{cost_micros:123}}],[]];
+ const r=await readToday({query:async()=>responses.shift()});assert.equal(r.reported_cost_micros,123);assert.equal(r.history_reconciled,false);assert.equal(r.execution_allowed,false);
+});
+test('missing spend is unknown not zero',async()=>{
+ const responses=[[{customer:{id:'1',currency_code:'EUR',time_zone:'Europe/Berlin'}}],[]];
+ await assert.rejects(readToday({query:async()=>responses.shift()}),/today_spend_unavailable/);
+});
+test('truncated history fails closed',async()=>{
+ const responses=[[{customer:{id:'1',currency_code:'EUR',time_zone:'Europe/Berlin'}}],[{customer:{id:'1'},metrics:{cost_micros:0}}],Array(10000).fill({})];
+ await assert.rejects(readToday({query:async()=>responses.shift()}),/history_truncated/);
+});
+test('unresponsive provider yields bounded sanitized failure',async()=>{
+ const env={GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START:'true',GOOGLE_CLIENT_ID:'x',GOOGLE_CLIENT_SECRET:'x',GOOGLE_DEVELOPER_TOKEN:'x',GOOGLE_REFRESH_TOKEN:'x',GOOGLE_CUSTOMER_ID:'1'};
+ const r=await runRuntimePreflight({env,customer:{query:()=>new Promise(()=>{})},timeoutMs:5,log:()=>{}});
+ assert.deepEqual(r.blockers,['preflight_timeout']);assert.equal(r.execution_allowed,false);
+});

--- a/test/google-write-runtime.test.js
+++ b/test/google-write-runtime.test.js
@@ -1,6 +1,7 @@
 'use strict';
 const {test}=require('node:test');
 const assert=require('node:assert/strict');
+const {randomUUID}=require('node:crypto');
 const {berlinDay,readToday,runRuntimePreflight}=require('../google-write-runtime');
 test('Berlin day includes UTC midnight offset',()=>assert.equal(berlinDay(new Date('2026-09-03T22:30:00Z')),'2026-09-04'));
 test('disabled preflight is observable and does not query',async()=>{
@@ -8,8 +9,9 @@ test('disabled preflight is observable and does not query',async()=>{
  assert.equal(r.status,'disabled'); assert.equal(logs[0].enabled,false);
 });
 test('missing config is observable without secret values',async()=>{
- const logs=[];await runRuntimePreflight({env:{GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START:'true',GOOGLE_CLIENT_SECRET:'do-not-log'},log:x=>logs.push(x)});
- assert.equal(logs[1].success,false);assert.ok(!JSON.stringify(logs).includes('do-not-log'));
+ const sentinel=randomUUID();const env=Object.fromEntries([['GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START','true'],['GOOGLE_CLIENT_SECRET',sentinel]]);
+ const logs=[];await runRuntimePreflight({env,log:x=>logs.push(x)});
+ assert.equal(logs[1].success,false);assert.ok(!JSON.stringify(logs).includes(sentinel));
 });
 test('today diagnostics never claim hard cap from empty history',async()=>{
  const responses=[[{customer:{id:'1',currency_code:'EUR',time_zone:'Europe/Berlin'}}],[{customer:{id:'1'},metrics:{cost_micros:123}}],[]];
@@ -24,7 +26,8 @@ test('truncated history fails closed',async()=>{
  await assert.rejects(readToday({query:async()=>responses.shift()}),/history_truncated/);
 });
 test('unresponsive provider yields bounded sanitized failure',async()=>{
- const env={GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START:'true',GOOGLE_CLIENT_ID:'x',GOOGLE_CLIENT_SECRET:'x',GOOGLE_DEVELOPER_TOKEN:'x',GOOGLE_REFRESH_TOKEN:'x',GOOGLE_CUSTOMER_ID:'1'};
+ const env=Object.fromEntries(['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_DEVELOPER_TOKEN','GOOGLE_REFRESH_TOKEN','GOOGLE_CUSTOMER_ID'].map(k=>[k,randomUUID()]));
+ env.GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START='true';
  const r=await runRuntimePreflight({env,customer:{query:()=>new Promise(()=>{})},timeoutMs:5,log:()=>{}});
  assert.deepEqual(r.blockers,['preflight_timeout']);assert.equal(r.execution_allowed,false);
 });


### PR DESCRIPTION
P0 follow-up to #182. Logs explicit enabled/disabled startup, bounds validate-only diagnostics to 45s, reads today's account cost and change-event count without email/secret output. Does not certify history freshness or a hard spend cap. No real mutation enabled, no safety gates changed. 17 targeted tests passed locally. CI required before merge.