### PR TITLE
Controlled Google budget executor: durable claim, no retries, fail closed

### DIFF
--- a/google-budget-rest-adapter.js
+++ b/google-budget-rest-adapter.js
@@ -1,0 +1,20 @@
+'use strict';
+const axios=require('axios');
+const {googleAdsVersion}=require('google-ads-api/build/src/version');
+function createBudgetRestAdapter(customer,{http=axios.create()}={}){
+ const customerId=customer?.credentials?.customer_id;
+ if(!/^\d{1,20}$/.test(customerId)||typeof customer.getAccessToken!=='function'||!/^v\d+$/.test(googleAdsVersion))throw Error('invalid_google_adapter');
+ return {customerId,mutateResources:async(operations,options)=>{
+   if(!Array.isArray(operations)||operations.length!==1||typeof options?.validate_only!=='boolean'||options.partial_failure!==false)throw Error('invalid_budget_operation');
+   const op=operations[0],r=op.resource;
+   if(op.entity!=='campaign_budget'||op.operation!=='update'||!r||Object.keys(r).sort().join(',')!=='amount_micros,resource_name'||
+     !new RegExp(`^customers/${customerId}/campaignBudgets/[0-9]+$`).test(r.resource_name)||!Number.isSafeInteger(r.amount_micros)||r.amount_micros<=0)throw Error('invalid_budget_operation');
+   const token=await customer.getAccessToken();
+   // Isolated Axios instance: no retries or redirects; credentials stay in this process.
+   const response=await http.request({method:'POST',url:`https://googleads.googleapis.com/${googleAdsVersion}/customers/${customerId}/campaignBudgets:mutate`,
+     timeout:15000,maxRedirects:0,headers:{...customer.callHeaders,Authorization:`Bearer ${token}`},
+     data:{operations:[{update:{resourceName:r.resource_name,amountMicros:String(r.amount_micros)},updateMask:'amount_micros'}],validateOnly:options.validate_only,partialFailure:false}});
+   return response.data;
+ }};
+}
+module.exports={createBudgetRestAdapter};

--- a/google-controlled-executor.js
+++ b/google-controlled-executor.js
@@ -1,0 +1,134 @@
+'use strict';
+// Server-only. No HTTP/MCP registration and no caller-supplied approval flags.
+// Dependencies must be constructed by trusted runtime composition, not request JSON.
+const fs = require('node:fs');
+const path = require('node:path');
+const {createHash, createHmac, timingSafeEqual, randomUUID} = require('node:crypto');
+const {prepareControlledProposal} = require('./google-controlled-proposals');
+const hash = x => createHash('sha256').update(JSON.stringify(x)).digest('hex');
+const fail = code => { throw new Error(code); };
+class ExecutionLedger {
+  constructor({directory, integrityKey}) {
+    if (!path.isAbsolute(directory) || directory === path.parse(directory).root || !Buffer.isBuffer(integrityKey) || integrityKey.length < 32) fail('invalid_execution_storage');
+    const st=fs.lstatSync(directory);
+    if (!st.isDirectory() || st.isSymbolicLink() || fs.realpathSync(directory)!==directory || (st.mode&0o077)) fail('unsafe_execution_storage');
+    this.directory=directory; this.key=Buffer.from(integrityKey);this.seen=new Set();
+  }
+  syncDirectory(){const fd=fs.openSync(this.directory,'r');try{fs.fsyncSync(fd);}finally{fs.closeSync(fd);}}
+  file(id){if(!/^[a-f0-9]{64}$/.test(id))fail('invalid_execution_id');return path.join(this.directory,id+'.json');}
+  read(id){
+    const file=this.file(id);if(!fs.existsSync(file)){if(this.seen.has(id))fail('execution_record_disappeared');return null;}
+    const st=fs.lstatSync(file);if(!st.isFile()||st.isSymbolicLink()||st.nlink!==1||(st.mode&0o077)||st.size>1048576)fail('unsafe_execution_record');
+    const envelope=JSON.parse(fs.readFileSync(file,'utf8'));
+    const expected=createHmac('sha256',this.key).update(JSON.stringify(envelope.payload)).digest();
+    const actual=Buffer.from(String(envelope.mac),'hex');
+    if(actual.length!==expected.length||!timingSafeEqual(actual,expected)||envelope.payload.id!==id)fail('execution_integrity_failed');
+    this.seen.add(id);return envelope.payload;
+  }
+  write(id,payload){
+    const file=this.file(id),temp=path.join(this.directory,randomUUID()+'.tmp');
+    if(payload.id!==id)fail('execution_id_mismatch');
+    const previous=this.read(id);
+    if(!['sending','blocked','verified','uncertain','reconciliation_required'].includes(payload.status))fail('invalid_execution_status');
+    if(previous&&previous.status!=='sending')fail('execution_terminal');
+    if(!previous&&payload.status!=='sending')fail('execution_transition_invalid');
+    payload={...payload,events:[...(previous?.events||[]),{status:payload.status,at:Date.now()}]};
+    const text=JSON.stringify({payload,mac:createHmac('sha256',this.key).update(JSON.stringify(payload)).digest('hex')});
+    const fd=fs.openSync(temp,'wx',0o600);try{fs.writeFileSync(fd,text);fs.fsyncSync(fd);}finally{fs.closeSync(fd);}
+    fs.renameSync(temp,file);this.syncDirectory();this.seen.add(id);
+  }
+  async exclusive(customerId,fn){
+    if(!/^\d{1,20}$/.test(customerId))fail('invalid_customer');
+    const lock=path.join(this.directory,'account-'+customerId+'.lock');
+    const fd=fs.openSync(lock,'wx',0o600);fs.fsyncSync(fd);fs.closeSync(fd);this.syncDirectory();
+    // A process crash deliberately leaves the lock: no automatic stale-lock removal.
+    try{return await fn();}finally{fs.unlinkSync(lock);this.syncDirectory();}
+  }
+  pending(customerId,create=false){
+    const file=path.join(this.directory,'account-'+customerId+'.pending');
+    if(!create)return fs.existsSync(file);
+    const fd=fs.openSync(file,'wx',0o600);fs.fsyncSync(fd);fs.closeSync(fd);this.syncDirectory();
+  }
+  clearPending(customerId){fs.unlinkSync(path.join(this.directory,'account-'+customerId+'.pending'));this.syncDirectory();}
+}
+function buildBudgetMutation(proposal){
+  const {action,before,customer_id:customer}=proposal;
+  if(action.type!=='set_daily_budget')fail('executor_action_not_supported');
+  if(!/^\d{1,20}$/.test(customer)||!/^\d{1,20}$/.test(before.budget_id))fail('invalid_resource');
+  return {entity:'campaign_budget',operation:'update',resource:{resource_name:`customers/${customer}/campaignBudgets/${before.budget_id}`,amount_micros:action.amount_micros}};
+}
+function createSingleAttemptAdapter(customer){
+  if(typeof customer?.buildMutationRequestAndService!=='function'||!/^\d{1,20}$/.test(customer.credentials?.customer_id))fail('unsupported_google_client');
+  return {customerId:customer.credentials.customer_id,mutateResources:async(operations,options)=>{
+    const {service,request}=customer.buildMutationRequestAndService(operations,options);
+    // google-ads-api's default mutateResources retries UNAVAILABLE/DEADLINE_EXCEEDED.
+    // Use the same request builder but explicitly disable gax retries for this executor.
+    return (await service.mutate(request,{retry:null,timeout:15000,otherArgs:{headers:customer.callHeaders}}))[0];
+  }};
+}
+function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafety,readPolicy,killSwitch,now=Date.now}){
+  for(const fn of [readSnapshot,readSafety,readPolicy,killSwitch,now])if(typeof fn!=='function')fail('trusted_runtime_dependencies_required');
+  if(!(ledger instanceof ExecutionLedger)||!journal||typeof journal.get!=='function'||typeof customer?.mutateResources!=='function')fail('trusted_runtime_dependencies_required');
+  async function execute(proposalId){
+    if(!/^[a-f0-9]{64}$/.test(proposalId))fail('invalid_proposal_id');
+    const initial=await journal.get(proposalId);
+    if(!initial?.proposal)fail('approved_proposal_required');
+    const owner=initial.proposal.customer_id;
+    if(customer.customerId!==owner)fail('mutation_customer_mismatch');
+    return ledger.exclusive(owner,async()=>{
+      const previous=ledger.read(proposalId);
+      if(previous)return {status:previous.status,id:proposalId,replayed:true,writes_executed:false};
+      if(ledger.pending(owner))fail('account_reconciliation_required');
+      const approval=await journal.get(proposalId), proposal=approval?.proposal;
+      if(approval?.approval_current!==true||approval.status!=='approved'||hash(proposal)!==proposalId)fail('approved_proposal_required');
+      const check=async()=>{
+        if(await killSwitch()!==false)fail('kill_switch_active');
+        const current=await journal.get(proposalId);
+        if(current?.approval_current!==true||current.status!=='approved')fail('approval_revoked');
+        const clock=now();if(!Number.isSafeInteger(clock)||Date.parse(proposal.expires_at)<=clock)fail('proposal_expired');
+        const policy=await readPolicy();if(hash(policy)!==proposal.policy_digest)fail('policy_changed');
+        const snapshot=await readSnapshot();
+        if(!proposal.inventory_state_digest||hash({...snapshot,captured_at:undefined})!==proposal.inventory_state_digest)fail('snapshot_changed');
+        const prepared=prepareControlledProposal({action:proposal.action,policy,snapshot,now:clock,kill_switch:false});
+        if(!prepared.policy_fit)fail('policy_gate_failed');
+        const safety=await readSafety();
+        // Evidence must be live, account-bound, reconciled and certified by a trusted gate.
+        // A configured average budget or client boolean must never produce this evidence.
+        if(safety?.customer_id!==owner||safety.currency!=='EUR'||safety.time_zone!=='Europe/Berlin'||
+          safety.hard_daily_spend_cap_verified!==true||safety.today_history_reconciled!==true||
+          !Number.isSafeInteger(safety.maximum_billable_today_micros)||safety.maximum_billable_today_micros>10000000||safety.maximum_billable_today_micros<0||
+          !Number.isSafeInteger(safety.reported_cost_micros)||safety.reported_cost_micros<0||safety.reported_cost_micros>10000000||
+          !Number.isSafeInteger(safety.checked_at)||clock-safety.checked_at<0||clock-safety.checked_at>5000||
+          safety.proposal_id!==proposalId||safety.audit_storage_durable!==true||safety.live_execution_gate!==true)fail('economic_or_runtime_gate_unverified');
+        return snapshot;
+      };
+      const before=await check();const mutation=buildBudgetMutation(proposal);
+      await customer.mutateResources([mutation],{validate_only:true,partial_failure:false});
+      await check();
+      const record={id:proposalId,status:'sending',before,mutation,rollback:{type:'set_daily_budget',campaign_id:proposal.action.campaign_id,amount_micros:proposal.before.daily_budget_micros},created_at:now()};
+      ledger.pending(owner,true);
+      ledger.write(proposalId,record);
+      // Once sending is durable, this ID can never send again, even after a timeout/crash.
+      if(await killSwitch()!==false){record.status='blocked';ledger.write(proposalId,record);ledger.clearPending(owner);fail('kill_switch_active');}
+      try{
+        await customer.mutateResources([mutation],{validate_only:false,partial_failure:false});
+        const after=await readSnapshot();
+        const expected=structuredClone(before);const target=expected.campaigns.find(c=>c.campaign_id===proposal.action.campaign_id);
+        target.daily_budget_micros=proposal.action.amount_micros;
+        // Capture time necessarily changes; all account/campaign fields must match.
+        expected.captured_at=after.captured_at;
+        record.after=after;
+        record.status=hash(after)===hash(expected)?'verified':'reconciliation_required';
+        record.finished_at=now();ledger.write(proposalId,record);
+        if(record.status==='verified')ledger.clearPending(owner);
+        return {id:proposalId,status:record.status,writes_executed:true};
+      }catch{
+        record.status='uncertain';record.finished_at=now();ledger.write(proposalId,record);
+        return {id:proposalId,status:'uncertain',writes_executed:'unknown'};
+      }
+    });
+  }
+  // Rollback is a fresh policy/preflight-checked proposal, never an unchecked compensating write.
+  return {execute};
+}
+module.exports={ExecutionLedger,buildBudgetMutation,createControlledExecutor,createSingleAttemptAdapter};

--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -89,7 +89,7 @@ function prepareControlledProposal(input = {}) {
   result.policy_fit = result.blockers.length === 0;
   result.proposal = { customer_id: snapshot.customer_id, action, before: campaign,
     proposed_account_daily_budget_micros: proposedTotal,
-    snapshot_digest: digest(snapshot), policy_digest: digest(policy),
+    snapshot_digest: digest(snapshot), inventory_state_digest: digest({...snapshot,captured_at:undefined}), policy_digest: digest(policy),
     created_at: new Date(now).toISOString(),
     expires_at: new Date(Math.min(Date.parse(policy.expires_at), Date.parse(snapshot.captured_at) + policy.max_snapshot_age_seconds * 1000)).toISOString(),
   };

--- a/google-write-runtime.js
+++ b/google-write-runtime.js
@@ -1,6 +1,7 @@
 'use strict';
 // Diagnostics only: this module never sends a real mutation.
 const { customerFrom, configured, validateWritePath } = require('./google-write-path');
+const {createBudgetRestAdapter}=require('./google-budget-rest-adapter');
 const safeCode = error => Number.isInteger(error?.code) ? error.code : null;
 function berlinDay(now = new Date()) {
   return new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Berlin', year: 'numeric', month: '2-digit', day: '2-digit' }).format(now);
@@ -27,7 +28,11 @@ async function runRuntimePreflight({ env = process.env, customer, log = entry =>
   let timer;
   const work = async () => {
     customer = customer || customerFrom(env);
-    const preflight = await validateWritePath({ env, customer, maxTotalMicros: 10000000 });
+    const adapter=createBudgetRestAdapter(customer);
+    let queryNumber=0;
+    const observed={query:async q=>{log({event:'google_write_path_stage',stage:'read',number:++queryNumber,writes_executed:false});return customer.query(q);},
+      mutateResources:async(...args)=>{log({event:'google_write_path_stage',stage:'validate_only_rest',writes_executed:false});return adapter.mutateResources(...args);}};
+    const preflight = await validateWritePath({ env, customer:observed, maxTotalMicros: 10000000 });
     let today = null, today_error = null;
     try { today = await readToday(customer); } catch (error) { today_error = safeCode(error); }
     return { event: 'google_write_path_preflight', success: preflight.success === true,

--- a/google-write-runtime.js
+++ b/google-write-runtime.js
@@ -2,7 +2,7 @@
 // Diagnostics only: this module never sends a real mutation.
 const { customerFrom, configured, validateWritePath } = require('./google-write-path');
 const {createBudgetRestAdapter}=require('./google-budget-rest-adapter');
-const safeCode = error => Number.isInteger(error?.code) ? error.code : null;
+const safeCode = error => Number.isInteger(error?.response?.status) ? error.response.status : Number.isInteger(error?.code) ? error.code : null;
 function berlinDay(now = new Date()) {
   return new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Berlin', year: 'numeric', month: '2-digit', day: '2-digit' }).format(now);
 }

--- a/google-write-runtime.js
+++ b/google-write-runtime.js
@@ -25,16 +25,15 @@ async function runRuntimePreflight({ env = process.env, customer, log = entry =>
   log({ event: 'google_write_path_startup', enabled, writes_executed: false });
   if (!enabled) return { status: 'disabled' };
   if (!configured(env)) { log({ event: 'google_write_path_preflight', success: false, blockers: ['google_configuration_incomplete'], writes_executed: false }); return { status: 'blocked' }; }
-  let timer;
+  let timer,today=null,today_error=null;
   const work = async () => {
     customer = customer || customerFrom(env);
     const adapter=createBudgetRestAdapter(customer);
     let queryNumber=0;
     const observed={query:async q=>{log({event:'google_write_path_stage',stage:'read',number:++queryNumber,writes_executed:false});return customer.query(q);},
       mutateResources:async(...args)=>{log({event:'google_write_path_stage',stage:'validate_only_rest',writes_executed:false});return adapter.mutateResources(...args);}};
+    try { today = await readToday(observed); } catch (error) { today_error = safeCode(error); }
     const preflight = await validateWritePath({ env, customer:observed, maxTotalMicros: 10000000 });
-    let today = null, today_error = null;
-    try { today = await readToday(customer); } catch (error) { today_error = safeCode(error); }
     return { event: 'google_write_path_preflight', success: preflight.success === true,
       mode: 'validate_only', mutation_permission_validated: preflight.mutation_permission_validated === true,
       writes_executed: false, spend_changed: false, execution_allowed: false,
@@ -47,7 +46,7 @@ async function runRuntimePreflight({ env = process.env, customer, log = entry =>
     log(result); return result;
   } catch (error) {
     const result = { event: 'google_write_path_preflight', success: false, mode: 'validate_only', writes_executed: false,
-      execution_allowed: false, blockers: [error.message === 'preflight_timeout' ? 'preflight_timeout' : 'preflight_failed'], provider_code: safeCode(error) };
+      execution_allowed: false, blockers: [error.message === 'preflight_timeout' ? 'preflight_timeout' : 'preflight_failed'], provider_code: safeCode(error),today,today_read_success:today!==null,today_error_code:today_error };
     log(result); return result;
   } finally { clearTimeout(timer); }
 }

--- a/test/google-budget-rest-adapter.test.js
+++ b/test/google-budget-rest-adapter.test.js
@@ -1,0 +1,24 @@
+'use strict';
+const {test}=require('node:test'),assert=require('node:assert/strict');
+const {createBudgetRestAdapter}=require('../google-budget-rest-adapter');
+const client=()=>({credentials:{customer_id:'1'},getAccessToken:async()=>'',callHeaders:{}});
+const op={entity:'campaign_budget',operation:'update',resource:{resource_name:'customers/1/campaignBudgets/2',amount_micros:1000000}};
+test('REST validates exact field only, bounded and without redirects',async()=>{
+ let request;const a=createBudgetRestAdapter(client(),{http:{request:async r=>{request=r;return {data:{}};}}});
+ await a.mutateResources([op],{validate_only:true,partial_failure:false});
+ assert.match(request.url,/googleads.googleapis.com\/v\d+\/customers\/1\/campaignBudgets:mutate$/);
+ assert.equal(request.timeout,15000);assert.equal(request.maxRedirects,0);assert.equal(request.data.validateOnly,true);assert.equal(request.data.partialFailure,false);assert.equal(request.data.operations[0].updateMask,'amount_micros');
+});
+test('REST does not retry failed mutation',async()=>{
+ let calls=0;const a=createBudgetRestAdapter(client(),{http:{request:async()=>{calls++;throw Error('failed');}}});
+ await assert.rejects(a.mutateResources([op],{validate_only:false,partial_failure:false}));assert.equal(calls,1);
+});
+test('REST rejects foreign budget before token retrieval',async()=>{
+ const c=client();c.getAccessToken=()=>assert.fail();const a=createBudgetRestAdapter(c);
+ await assert.rejects(a.mutateResources([{...op,resource:{...op.resource,resource_name:'customers/9/campaignBudgets/2'}}],{validate_only:true,partial_failure:false}));
+});
+test('REST rejects extra fields and missing explicit options',async()=>{
+ const c=client();c.getAccessToken=()=>assert.fail();const a=createBudgetRestAdapter(c);
+ await assert.rejects(a.mutateResources([{...op,resource:{...op.resource,status:'ENABLED'}}],{validate_only:true,partial_failure:false}));
+ await assert.rejects(a.mutateResources([op],{}));
+});

--- a/test/google-controlled-executor.test.js
+++ b/test/google-controlled-executor.test.js
@@ -1,0 +1,57 @@
+'use strict';
+const {test}=require('node:test'),assert=require('node:assert/strict');
+const fs=require('node:fs'),os=require('node:os'),path=require('node:path');
+const {randomBytes}=require('node:crypto');
+const {ControlledProposalJournal}=require('../google-controlled-journal');
+const {ExecutionLedger,createControlledExecutor,buildBudgetMutation,createSingleAttemptAdapter}=require('../google-controlled-executor');
+function fixture(t){
+ const root=fs.mkdtempSync(path.join(os.tmpdir(),'google-execution-'));
+ t.after(()=>fs.rmSync(root,{recursive:true,force:true}));
+ const dir=path.join(root,'execution');fs.mkdirSync(dir,{mode:0o700});
+ const now=Date.now();const key=randomBytes(32);
+ const journal=new ControlledProposalJournal({directory:path.join(root,'proposals'),integrityKey:key,resolveActor:()=> 'owner-policy',now:()=>now});
+ const ledger=new ExecutionLedger({directory:dir,integrityKey:key});
+ const snapshot={customer_id:'1',currency:'EUR',captured_at:new Date(now).toISOString(),account_inventory_complete:true,campaigns:[{campaign_id:'2',budget_id:'3',daily_budget_micros:2000000,status:'ENABLED',shared_budget:false,conversion_integrity_trusted:false}]};
+ const policy={customer_id:'1',campaign_ids:['2'],allowed_actions:['set_daily_budget'],expires_at:new Date(now+60000).toISOString(),max_account_daily_budget_micros:10000000,max_campaign_daily_budget_micros:5000000,max_budget_change_percent:100,max_snapshot_age_seconds:60};
+ const p=journal.propose({action:{type:'set_daily_budget',campaign_id:'2',amount_micros:1000000},snapshot,policy});
+ journal.decide({proposalId:p.proposal_id,expectedDigest:p.proposal_id,decision:'approved'});
+ const calls=[];let current=structuredClone(snapshot),kill=false;
+ const safety={customer_id:'1',currency:'EUR',time_zone:'Europe/Berlin',hard_daily_spend_cap_verified:true,today_history_reconciled:true,maximum_billable_today_micros:4000000,reported_cost_micros:100000,checked_at:now,proposal_id:p.proposal_id,audit_storage_durable:true,live_execution_gate:true};
+ const customer={customerId:'1',mutateResources:async(ops,options)=>{calls.push(options);if(!options.validate_only)current.campaigns[0].daily_budget_micros=ops[0].resource.amount_micros;}};
+ const args={journal,ledger,customer,readSnapshot:async()=>structuredClone(current),readSafety:async()=>safety,readPolicy:async()=>policy,killSwitch:async()=>kill,now:()=>now};
+ return {root,dir,p,ledger,journal,safety,args,calls,customer,setKill:x=>kill=x,setCurrent:x=>current=x,snapshot};
+}
+test('real adapter sends once, verifies, and replay never resends',async t=>{
+ const f=fixture(t),e=createControlledExecutor(f.args);const result=await e.execute(f.p.proposal_id);
+ assert.equal(result.status,'verified');assert.deepEqual(f.calls,[{validate_only:true,partial_failure:false},{validate_only:false,partial_failure:false}]);
+ assert.equal((await e.execute(f.p.proposal_id)).replayed,true);assert.equal(f.calls.length,2);
+ assert.equal(f.ledger.read(f.p.proposal_id).rollback.amount_micros,2000000);
+});
+test('kill switch stops before provider validation',async t=>{const f=fixture(t);f.setKill(true);await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/kill_switch/);assert.equal(f.calls.length,0);});
+test('hard cap is mandatory even for budget reduction',async t=>{const f=fixture(t);f.safety.hard_daily_spend_cap_verified=false;await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/economic_or_runtime/);assert.equal(f.calls.length,0);});
+test('10 EUR cannot be exceeded by evidence',async t=>{const f=fixture(t);f.safety.maximum_billable_today_micros=10000001;await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/economic_or_runtime/);});
+test('uncertain response persists account stop and no retry',async t=>{
+ const f=fixture(t);f.customer.mutateResources=async(o,v)=>{f.calls.push(v);if(!v.validate_only)throw Error('network failure');};
+ const e=createControlledExecutor(f.args);assert.equal((await e.execute(f.p.proposal_id)).status,'uncertain');
+ assert.equal(f.ledger.pending('1'),true);await e.execute(f.p.proposal_id);assert.equal(f.calls.length,2);
+});
+test('verification mismatch blocks reconciliation without automatic rollback',async t=>{
+ const f=fixture(t);f.customer.mutateResources=async(o,v)=>f.calls.push(v);
+ assert.equal((await createControlledExecutor(f.args).execute(f.p.proposal_id)).status,'reconciliation_required');assert.equal(f.ledger.pending('1'),true);assert.equal(f.calls.length,2);
+});
+test('revoked approval fails closed',async t=>{const f=fixture(t);f.journal.decide({proposalId:f.p.proposal_id,expectedDigest:f.p.proposal_id,decision:'cancelled'});await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/approved_proposal/);});
+test('stale evidence cannot send',async t=>{const f=fixture(t);f.safety.checked_at-=5001;await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/economic_or_runtime/);});
+test('concurrent account execution locks',async t=>{const f=fixture(t);await f.ledger.exclusive('1',async()=>{await assert.rejects(f.ledger.exclusive('1',async()=>{}),/EEXIST/);});});
+test('tampered audit is rejected',async t=>{const f=fixture(t);f.ledger.write(f.p.proposal_id,{id:f.p.proposal_id,status:'sending'});fs.writeFileSync(f.ledger.file(f.p.proposal_id),'{}');assert.throws(()=>f.ledger.read(f.p.proposal_id));});
+test('campaign schedule, conversion, and negative writes unsupported',()=>{
+ for(const type of ['pause','resume','add_negative_keyword','set_schedule','set_conversion'])assert.throws(()=>buildBudgetMutation({action:{type},before:{},customer_id:'1'}),/not_supported/);
+});
+test('whole inventory drift rejects even unrelated campaign',async t=>{
+ const f=fixture(t);const changed=structuredClone(f.snapshot);changed.campaigns.push({...changed.campaigns[0],campaign_id:'4',budget_id:'5'});f.setCurrent(changed);
+ await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/snapshot_changed/);
+});
+test('Google adapter explicitly disables transport retries',async()=>{
+ let opts;const adapter=createSingleAttemptAdapter({credentials:{customer_id:'1'},callHeaders:{},buildMutationRequestAndService:()=>({request:{},service:{mutate:async(r,o)=>{opts=o;return [{}];}}})});
+ await adapter.mutateResources([],{validate_only:true,partial_failure:false});assert.equal(opts.retry,null);assert.equal(opts.timeout,15000);
+});
+test('adapter cannot target another customer',async t=>{const f=fixture(t);f.customer.customerId='9';await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/customer_mismatch/);});

--- a/test/google-write-runtime.test.js
+++ b/test/google-write-runtime.test.js
@@ -28,6 +28,6 @@ test('truncated history fails closed',async()=>{
 test('unresponsive provider yields bounded sanitized failure',async()=>{
  const env=Object.fromEntries(['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_DEVELOPER_TOKEN','GOOGLE_REFRESH_TOKEN','GOOGLE_CUSTOMER_ID'].map(k=>[k,randomUUID()]));
  env.GOOGLE_ADS_VALIDATE_WRITE_PATH_ON_START='true';
- const r=await runRuntimePreflight({env,customer:{query:()=>new Promise(()=>{})},timeoutMs:5,log:()=>{}});
+ const r=await runRuntimePreflight({env,customer:{credentials:{customer_id:'1'},getAccessToken:async()=>'',query:()=>new Promise(()=>{})},timeoutMs:5,log:()=>{}});
  assert.deepEqual(r.blockers,['preflight_timeout']);assert.equal(r.execution_allowed,false);
 });


### PR DESCRIPTION
P0: server-only executor using existing authenticated approval journal, full inventory/policy binding, exact account binding, validate_only then single-attempt Google mutation (gax retry:null), durable HMAC audit and exclusive account lock, persistent uncertain-account stop, idempotent proposal ID and immediate readback. Stores rollback proposal; rollback is NOT sent unchecked. Only budget actions supported: cannot touch schedules, near-me negatives, conversion meanings. Absolute 10 EUR billable gate remains required plus reconciled current-day history, durable storage and runtime gate. No route or startup invocation is enabled, no credentials/scopes/safety flags changed. Runtime composition/economic evidence remain required before any live execution; not a claim of operational activation. 14 targeted executor tests passed; CI mandatory.