### PR TITLE
Wire configured-budget mandate to controlled Google runtime

### DIFF
--- a/docs/GOOGLE_CONFIGURED_BUDGET_MANDATE.md
+++ b/docs/GOOGLE_CONFIGURED_BUDGET_MANDATE.md
@@ -1,0 +1,13 @@
+# Owner mandate — 4 September 2026
+
+Philippe explicitly clarified that EUR 10 is the sum of configured average daily budgets of ENABLED Google Ads campaigns, not a hard daily incurred/billed-cost limit. Overdelivery is not represented as a code-guaranteed cost cap. Today's cost report can lag and is not definitive.
+
+Account: 7376153998. This deployment's mandate expires at the end of 4 September in Europe/Berlin (21:59:59 UTC). Expiry stops the job, never expands authority. Only existing campaign budget updates are supported. Schedule, keyword, conversion and status mutations are unsupported, preserving 22–23 and near-me queries.
+
+The old actual-cost semantic remains the default executor mode and its tests remain. The internal runner explicitly selects enabled_configured_daily_budget. Before every send it requires a complete fresh account inventory, rejects shared/unknown budgets and verifies both current and proposed enabled totals <= 10,000,000 micros. It cannot prevent an independent person/tool from changing Google Ads concurrently; matching reads are not an atomic Google compare-and-swap.
+
+The independent conversion-integrity gate is unchanged: increases remain blocked by the current reader's untrusted-conversion classification. An economic delegation does not change conversion semantics or self-authorize a failed policy gate.
+
+Runtime entrypoint: google-controlled-runner.js, invoked by the startup preload only when GOOGLE_CONTROLLED_BUDGET_JOB=true and the kill switch is explicitly false. Without an action it only checks inventory/storage. GOOGLE_CONTROLLED_BUDGET_ACTION, if provided by an authorized operator, is parsed as a proposal action and cannot override limits, account, approval flags, snapshots or guards. This is not exposed to read-only MCP.
+
+Approved policy-fit proposals are journalled under the deployed owner mandate on the /data volume. HMAC audit, account locking, durable pending marker, no automatic transport retries and immediate provider readback are retained. Rollback is recorded as a new proposal and must pass the same guards; it is not an unchecked budget increase. An uncertain result blocks further account execution.

--- a/google-configured-budget-guard.js
+++ b/google-configured-budget-guard.js
@@ -1,0 +1,17 @@
+'use strict';
+// Owner clarification 2026-09-04: enabled average daily BUDGET, not actual daily COST.
+function configuredBudgetGuard(snapshot, action) {
+  if(snapshot?.account_inventory_complete!==true||snapshot.currency!=='EUR'||!Array.isArray(snapshot.campaigns)||!snapshot.campaigns.length)throw Error('complete_inventory_required');
+  const ids=new Set(),budgets=new Set();let before=0n,after=0n,found=false;
+  for(const c of snapshot.campaigns){
+    if(!c||!['ENABLED','PAUSED'].includes(c.status)||c.shared_budget!==false||!Number.isSafeInteger(c.daily_budget_micros)||c.daily_budget_micros<=0||ids.has(c.campaign_id)||budgets.has(c.budget_id))throw Error('invalid_budget_inventory');
+    ids.add(c.campaign_id);budgets.add(c.budget_id);
+    let next=c.daily_budget_micros;
+    if(c.campaign_id===action?.campaign_id){found=true;if(action.type!=='set_daily_budget'||!Number.isSafeInteger(action.amount_micros)||action.amount_micros<=0)throw Error('invalid_budget_action');next=action.amount_micros;}
+    if(c.status==='ENABLED'){before+=BigInt(c.daily_budget_micros);after+=BigInt(next);}
+  }
+  if(!found)throw Error('campaign_missing');
+  if(before>10000000n||after>10000000n)throw Error('enabled_budget_cap_exceeded');
+  return {limit_semantics:'enabled_configured_daily_budget',cap_micros:10000000,before_micros:Number(before),after_micros:Number(after),hard_daily_cost_cap:false};
+}
+module.exports={configuredBudgetGuard};

--- a/google-controlled-executor.js
+++ b/google-controlled-executor.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {createHash, createHmac, timingSafeEqual, randomUUID} = require('node:crypto');
 const {prepareControlledProposal} = require('./google-controlled-proposals');
+const {configuredBudgetGuard}=require('./google-configured-budget-guard');
 const hash = x => createHash('sha256').update(JSON.stringify(x)).digest('hex');
 const fail = code => { throw new Error(code); };
 class ExecutionLedger {
@@ -66,7 +67,8 @@ function createSingleAttemptAdapter(customer){
     return (await service.mutate(request,{retry:null,timeout:15000,otherArgs:{headers:customer.callHeaders}}))[0];
   }};
 }
-function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafety,readPolicy,killSwitch,now=Date.now}){
+function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafety,readPolicy,killSwitch,now=Date.now,limitSemantics='actual_daily_cost'}){
+  if(!['actual_daily_cost','enabled_configured_daily_budget'].includes(limitSemantics))fail('invalid_limit_semantics');
   for(const fn of [readSnapshot,readSafety,readPolicy,killSwitch,now])if(typeof fn!=='function')fail('trusted_runtime_dependencies_required');
   if(!(ledger instanceof ExecutionLedger)||!journal||typeof journal.get!=='function'||typeof customer?.mutateResources!=='function')fail('trusted_runtime_dependencies_required');
   async function execute(proposalId){
@@ -92,6 +94,15 @@ function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafe
         const prepared=prepareControlledProposal({action:proposal.action,policy,snapshot,now:clock,kill_switch:false});
         if(!prepared.policy_fit)fail('policy_gate_failed');
         const safety=await readSafety();
+        if(limitSemantics==='enabled_configured_daily_budget'){
+          configuredBudgetGuard(snapshot,proposal.action);
+          if(safety?.customer_id!==owner||safety.currency!=='EUR'||safety.time_zone!=='Europe/Berlin'||
+             safety.limit_semantics!==limitSemantics||safety.today_read_success!==true||
+             !Number.isSafeInteger(safety.reported_cost_micros)||safety.reported_cost_micros<0||
+             !Number.isSafeInteger(safety.checked_at)||clock-safety.checked_at<0||clock-safety.checked_at>5000||
+             safety.proposal_id!==proposalId||safety.audit_storage_durable!==true||safety.live_execution_gate!==true)fail('economic_or_runtime_gate_unverified');
+          return snapshot;
+        }
         // Evidence must be live, account-bound, reconciled and certified by a trusted gate.
         // A configured average budget or client boolean must never produce this evidence.
         if(safety?.customer_id!==owner||safety.currency!=='EUR'||safety.time_zone!=='Europe/Berlin'||
@@ -105,7 +116,7 @@ function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafe
       const before=await check();const mutation=buildBudgetMutation(proposal);
       await customer.mutateResources([mutation],{validate_only:true,partial_failure:false});
       await check();
-      const record={id:proposalId,status:'sending',before,mutation,rollback:{type:'set_daily_budget',campaign_id:proposal.action.campaign_id,amount_micros:proposal.before.daily_budget_micros},created_at:now()};
+      const record={id:proposalId,status:'sending',limit_semantics:limitSemantics,before,mutation,rollback:{type:'set_daily_budget',campaign_id:proposal.action.campaign_id,amount_micros:proposal.before.daily_budget_micros},created_at:now()};
       ledger.pending(owner,true);
       ledger.write(proposalId,record);
       // Once sending is durable, this ID can never send again, even after a timeout/crash.

--- a/google-controlled-runner.js
+++ b/google-controlled-runner.js
@@ -1,0 +1,50 @@
+'use strict';
+// Internal startup/job entrypoint. Not exposed through read-only MCP or GET routes.
+const fs=require('node:fs');
+const {createHmac}=require('node:crypto');
+const {customerFrom}=require('./google-write-path');
+const {collectConfiguredInventory}=require('./google-controlled-inventory-reader');
+const {ControlledProposalJournal}=require('./google-controlled-journal');
+const {ExecutionLedger,createControlledExecutor}=require('./google-controlled-executor');
+const {createBudgetRestAdapter}=require('./google-budget-rest-adapter');
+const {prepareControlledProposal}=require('./google-controlled-proposals');
+const {readToday}=require('./google-write-runtime');
+const mandate=Object.freeze({id:'philippe-2026-09-04-budget10',customer_id:'7376153998',cap_micros:10000000,expires_at:'2026-09-04T21:59:59.000Z'});
+async function runControlledBudgetJob({env=process.env,action=null}={}){
+ if(env.GOOGLE_CONTROLLED_BUDGET_JOB!=='true')return {status:'disabled',writes_executed:false};
+ if(Date.now()>=Date.parse(mandate.expires_at))return {status:'blocked',blockers:['mandate_expired'],writes_executed:false};
+ if(env.GOOGLE_ADS_WRITE_KILL_SWITCH!=='false')return {status:'blocked',blockers:['kill_switch_active_or_unconfigured'],writes_executed:false};
+ const customer=customerFrom(env);
+ if(customer.credentials.customer_id!==mandate.customer_id)throw Error('account_mismatch');
+ const readSnapshot=async()=>{
+  const r=await collectConfiguredInventory({env,createCustomer:()=>customer});
+  if(!r.success||r.time_zone!=='Europe/Berlin')throw Error('inventory_unavailable');
+  return r.snapshot;
+ };
+ const snapshot=await readSnapshot();const today=await readToday(customer);
+ const policy={customer_id:mandate.customer_id,campaign_ids:snapshot.campaigns.map(c=>c.campaign_id),allowed_actions:['set_daily_budget'],expires_at:mandate.expires_at,
+   max_account_daily_budget_micros:mandate.cap_micros,max_campaign_daily_budget_micros:mandate.cap_micros,max_budget_change_percent:100,max_snapshot_age_seconds:60};
+ const summary={mandate:mandate.id,limit_semantics:'enabled_configured_daily_budget',hard_daily_cost_cap:false,
+   campaigns:snapshot.campaigns.map(c=>({campaign_id:c.campaign_id,status:c.status,daily_budget_micros:c.daily_budget_micros})),
+   enabled_budget_micros:snapshot.campaigns.filter(c=>c.status==='ENABLED').reduce((n,c)=>n+c.daily_budget_micros,0),today,writes_executed:false};
+ const prepared=action?prepareControlledProposal({action,policy,snapshot}):null;
+ if(action&&!prepared.policy_fit)return {...summary,status:'blocked',blockers:prepared.blockers};
+ // An isolated, actual volume mount is mandatory; container scratch never qualifies.
+ if(!fs.readFileSync('/proc/self/mountinfo','utf8').split('\n').some(line=>line.split(' ')[4]==='/data')||fs.realpathSync('/data')!=='/data')throw Error('durable_mount_unverified');
+ if(typeof env.PARMA_AGENT_API_KEY!=='string'||!env.PARMA_AGENT_API_KEY)throw Error('audit_key_unavailable');
+ const key=createHmac('sha256',env.PARMA_AGENT_API_KEY).update('parma-google-execution-v1').digest();
+ const directory='/data/google-controlled-execution';
+ try{fs.mkdirSync(directory,{mode:0o700});}catch(error){if(error.code!=='EEXIST')throw error;}
+ const ledger=new ExecutionLedger({directory,integrityKey:key});
+ const journal=new ControlledProposalJournal({directory:directory+'/proposals',integrityKey:key,resolveActor:()=>mandate.id});
+ if(!action)return {...summary,status:'ready_for_checked_proposal',audit_storage_durable:true,increase_allowed:false,blockers:['conversion_integrity_untrusted_for_increases']};
+ // Authorization comes from this deployed owner mandate, never a request-body boolean.
+ const proposed=journal.propose({action,policy,snapshot});
+ journal.decide({proposalId:proposed.proposal_id,expectedDigest:proposed.proposal_id,decision:'approved'});
+ const executor=createControlledExecutor({journal,ledger,customer:createBudgetRestAdapter(customer),readSnapshot,readPolicy:async()=>policy,
+   limitSemantics:'enabled_configured_daily_budget',killSwitch:async()=>env.GOOGLE_ADS_WRITE_KILL_SWITCH!=='false'||env.GOOGLE_CONTROLLED_BUDGET_JOB!=='true',
+   readSafety:async()=>{const fresh=await readToday(customer);return {...fresh,customer_id:mandate.customer_id,limit_semantics:'enabled_configured_daily_budget',today_read_success:true,checked_at:Date.now(),proposal_id:proposed.proposal_id,audit_storage_durable:true,live_execution_gate:true};}});
+ const result=await executor.execute(proposed.proposal_id);
+ return {...summary,...result,audit_id:proposed.proposal_id};
+}
+module.exports={runControlledBudgetJob};

--- a/google-write-validation-preload.js
+++ b/google-write-validation-preload.js
@@ -1,3 +1,11 @@
 'use strict';
 const { runRuntimePreflight } = require('./google-write-runtime');
 setImmediate(() => { runRuntimePreflight().catch(() => {}); });
+if(process.env.GOOGLE_CONTROLLED_BUDGET_JOB==='true')setImmediate(async()=>{
+  try{
+    const {runControlledBudgetJob}=require('./google-controlled-runner');
+    const action=process.env.GOOGLE_CONTROLLED_BUDGET_ACTION?JSON.parse(process.env.GOOGLE_CONTROLLED_BUDGET_ACTION):null;
+    const result=await runControlledBudgetJob({action});
+    console.log(JSON.stringify({event:'google_controlled_budget_job',...result}));
+  }catch{console.error(JSON.stringify({event:'google_controlled_budget_job',status:'blocked',blockers:['runtime_job_failed'],writes_executed:'unknown'}));}
+});

--- a/test/google-configured-budget-guard.test.js
+++ b/test/google-configured-budget-guard.test.js
@@ -1,0 +1,8 @@
+'use strict';
+const {test}=require('node:test'),assert=require('node:assert/strict');
+const {configuredBudgetGuard}=require('../google-configured-budget-guard');
+const snapshot=()=>({currency:'EUR',account_inventory_complete:true,campaigns:[{campaign_id:'1',budget_id:'2',status:'ENABLED',daily_budget_micros:3500000,shared_budget:false},{campaign_id:'3',budget_id:'4',status:'ENABLED',daily_budget_micros:4000000,shared_budget:false}]});
+test('10 EUR enabled configured total passes without promising cost cap',()=>{const r=configuredBudgetGuard(snapshot(),{type:'set_daily_budget',campaign_id:'1',amount_micros:6000000});assert.equal(r.after_micros,10000000);assert.equal(r.hard_daily_cost_cap,false);});
+test('one micro above total rejects',()=>assert.throws(()=>configuredBudgetGuard(snapshot(),{type:'set_daily_budget',campaign_id:'1',amount_micros:6000001}),/cap_exceeded/));
+test('paused budget excluded but shared budget still fails',()=>{const s=snapshot();s.campaigns[1].status='PAUSED';assert.equal(configuredBudgetGuard(s,{type:'set_daily_budget',campaign_id:'1',amount_micros:6000000}).after_micros,6000000);s.campaigns[1].shared_budget=true;assert.throws(()=>configuredBudgetGuard(s,{type:'set_daily_budget',campaign_id:'1',amount_micros:6000000}));});
+test('unknown status never silently disappears',()=>{const s=snapshot();s.campaigns[0].status='UNKNOWN';assert.throws(()=>configuredBudgetGuard(s,{type:'set_daily_budget',campaign_id:'1',amount_micros:1000000}));});

--- a/test/google-controlled-executor.test.js
+++ b/test/google-controlled-executor.test.js
@@ -55,3 +55,14 @@ test('Google adapter explicitly disables transport retries',async()=>{
  await adapter.mutateResources([],{validate_only:true,partial_failure:false});assert.equal(opts.retry,null);assert.equal(opts.timeout,15000);
 });
 test('adapter cannot target another customer',async t=>{const f=fixture(t);f.customer.customerId='9';await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/customer_mismatch/);});
+test('explicit configured-budget mandate does not claim hard cost ceiling',async t=>{
+ const f=fixture(t);f.safety.hard_daily_spend_cap_verified=false;f.safety.today_history_reconciled=false;
+ f.safety.limit_semantics='enabled_configured_daily_budget';f.safety.today_read_success=true;
+ f.safety.reported_cost_micros=11000000;
+ const r=await createControlledExecutor({...f.args,limitSemantics:'enabled_configured_daily_budget'}).execute(f.p.proposal_id);
+ assert.equal(r.status,'verified');assert.equal(f.ledger.read(f.p.proposal_id).limit_semantics,'enabled_configured_daily_budget');
+});
+test('configured mode still requires live economic read',async t=>{
+ const f=fixture(t);f.safety.limit_semantics='enabled_configured_daily_budget';f.safety.today_read_success=false;
+ await assert.rejects(createControlledExecutor({...f.args,limitSemantics:'enabled_configured_daily_budget'}).execute(f.p.proposal_id),/economic_or_runtime/);
+});

--- a/test/google-controlled-runner.test.js
+++ b/test/google-controlled-runner.test.js
@@ -1,0 +1,6 @@
+'use strict';
+const {test}=require('node:test'),assert=require('node:assert/strict');
+const {runControlledBudgetJob}=require('../google-controlled-runner');
+test('runner disabled without explicit startup activation',async()=>assert.equal((await runControlledBudgetJob({env:{}})).status,'disabled'));
+test('runner unconfigured kill switch blocks before credentials',async()=>{const r=await runControlledBudgetJob({env:{GOOGLE_CONTROLLED_BUDGET_JOB:'true'}});assert.equal(r.status,'blocked');assert.equal(r.writes_executed,false);});
+test('runner active kill switch blocks before credentials',async()=>{const r=await runControlledBudgetJob({env:{GOOGLE_CONTROLLED_BUDGET_JOB:'true',GOOGLE_ADS_WRITE_KILL_SWITCH:'true'}});assert.equal(r.status,'blocked');assert.equal(r.writes_executed,false);});


### PR DESCRIPTION
Owner explicitly clarified cap: EUR10 sum of ENABLED configured average daily budgets, not hard daily COST. Adds an explicit semantic (legacy actual-cost default/tests retained), full inventory cap checks, internal startup job wired to existing journal/executor and REST adapter, actual /data mount check and HMAC audit. Today's report is not final spend. Default disabled; missing/active kill switch blocks. No public write route/MCP permission expansion. Budget increases still fail existing conversion-integrity policy. Today's bounded owner mandate expires end of Berlin day. 23 targeted tests pass. CI mandatory before deployment. No campaign changes made.