### PR TITLE
Align proposal totals with enabled-budget mandate

### DIFF
--- a/google-controlled-proposals.js
+++ b/google-controlled-proposals.js
@@ -14,6 +14,7 @@ const policySchema = z.object({
   max_campaign_daily_budget_micros: money,
   max_budget_change_percent: z.number().min(0).max(100),
   max_snapshot_age_seconds: z.number().int().min(1).max(3600),
+  budget_limit_semantics: z.enum(['all_configured','enabled_configured']).optional(),
 }).strict();
 const actionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('set_daily_budget'), campaign_id: id, amount_micros: money.positive() }).strict(),
@@ -70,9 +71,14 @@ function prepareControlledProposal(input = {}) {
   // Reject shared/reused budgets rather than underestimate their account impact.
   if (snapshot.campaigns.some(c => c.shared_budget) || new Set(snapshot.campaigns.map(c => c.budget_id)).size !== snapshot.campaigns.length)
     result.blockers.push('shared_budget_requires_separate_review');
-  const currentTotal = snapshot.campaigns.reduce((sum, c) => sum + c.daily_budget_micros, 0);
+  const enabledOnly=policy.budget_limit_semantics==='enabled_configured';
+  const currentTotal = snapshot.campaigns.filter(c=>!enabledOnly||c.status==='ENABLED').reduce((sum, c) => sum + c.daily_budget_micros, 0);
   const nextBudget = action.type === 'set_daily_budget' ? action.amount_micros : campaign.daily_budget_micros;
-  const proposedTotal = currentTotal - campaign.daily_budget_micros + nextBudget;
+  const proposedTotal = enabledOnly?snapshot.campaigns.reduce((sum,c)=>{
+    const target=c.campaign_id===action.campaign_id;
+    const enabled=target&&action.type==='resume'?true:target&&action.type==='pause'?false:c.status==='ENABLED';
+    return sum+(enabled?(target?nextBudget:c.daily_budget_micros):0);
+  },0):currentTotal - campaign.daily_budget_micros + nextBudget;
   if (!Number.isSafeInteger(currentTotal) || !Number.isSafeInteger(proposedTotal)) result.blockers.push('budget_arithmetic_overflow');
   if (action.type === 'set_daily_budget' || action.type === 'resume') {
     if (nextBudget > policy.max_campaign_daily_budget_micros) result.blockers.push('campaign_budget_limit_exceeded');

--- a/google-controlled-runner.js
+++ b/google-controlled-runner.js
@@ -23,7 +23,7 @@ async function runControlledBudgetJob({env=process.env,action=null}={}){
  };
  const snapshot=await readSnapshot();const today=await readToday(customer);
  const policy={customer_id:mandate.customer_id,campaign_ids:snapshot.campaigns.map(c=>c.campaign_id),allowed_actions:['set_daily_budget'],expires_at:mandate.expires_at,
-   max_account_daily_budget_micros:mandate.cap_micros,max_campaign_daily_budget_micros:mandate.cap_micros,max_budget_change_percent:100,max_snapshot_age_seconds:60};
+   max_account_daily_budget_micros:mandate.cap_micros,max_campaign_daily_budget_micros:mandate.cap_micros,max_budget_change_percent:100,max_snapshot_age_seconds:60,budget_limit_semantics:'enabled_configured'};
  const summary={mandate:mandate.id,limit_semantics:'enabled_configured_daily_budget',hard_daily_cost_cap:false,
    campaigns:snapshot.campaigns.map(c=>({campaign_id:c.campaign_id,status:c.status,daily_budget_micros:c.daily_budget_micros})),
    enabled_budget_micros:snapshot.campaigns.filter(c=>c.status==='ENABLED').reduce((n,c)=>n+c.daily_budget_micros,0),today,writes_executed:false};
@@ -45,6 +45,7 @@ async function runControlledBudgetJob({env=process.env,action=null}={}){
    limitSemantics:'enabled_configured_daily_budget',killSwitch:async()=>env.GOOGLE_ADS_WRITE_KILL_SWITCH!=='false'||env.GOOGLE_CONTROLLED_BUDGET_JOB!=='true',
    readSafety:async()=>{const fresh=await readToday(customer);return {...fresh,customer_id:mandate.customer_id,limit_semantics:'enabled_configured_daily_budget',today_read_success:true,checked_at:Date.now(),proposal_id:proposed.proposal_id,audit_storage_durable:true,live_execution_gate:true};}});
  const result=await executor.execute(proposed.proposal_id);
- return {...summary,...result,audit_id:proposed.proposal_id};
+ const audit=ledger.read(proposed.proposal_id);
+ return {...summary,...result,audit_id:proposed.proposal_id,before:audit?.before?.campaigns||null,after:audit?.after?.campaigns||null,rollback:audit?.rollback||null};
 }
 module.exports={runControlledBudgetJob};

--- a/test/google-controlled-executor.test.js
+++ b/test/google-controlled-executor.test.js
@@ -66,3 +66,12 @@ test('configured mode still requires live economic read',async t=>{
  const f=fixture(t);f.safety.limit_semantics='enabled_configured_daily_budget';f.safety.today_read_success=false;
  await assert.rejects(createControlledExecutor({...f.args,limitSemantics:'enabled_configured_daily_budget'}).execute(f.p.proposal_id),/economic_or_runtime/);
 });
+test('explicit enabled proposal policy excludes paused budgets but retains conversion gate',()=>{
+ const {prepareControlledProposal}=require('../google-controlled-proposals');const now=Date.now();
+ const snapshot={customer_id:'1',currency:'EUR',captured_at:new Date(now).toISOString(),account_inventory_complete:true,campaigns:[{campaign_id:'2',budget_id:'3',daily_budget_micros:3500000,status:'ENABLED',shared_budget:false,conversion_integrity_trusted:false},{campaign_id:'4',budget_id:'5',daily_budget_micros:9200000,status:'PAUSED',shared_budget:false,conversion_integrity_trusted:false}]};
+ const policy={customer_id:'1',campaign_ids:['2','4'],allowed_actions:['set_daily_budget'],expires_at:new Date(now+60000).toISOString(),max_account_daily_budget_micros:10000000,max_campaign_daily_budget_micros:10000000,max_budget_change_percent:100,max_snapshot_age_seconds:60,budget_limit_semantics:'enabled_configured'};
+ const reduction=prepareControlledProposal({action:{type:'set_daily_budget',campaign_id:'2',amount_micros:3000000},policy,snapshot,now});
+ assert.equal(reduction.policy_fit,true);assert.equal(reduction.proposal.proposed_account_daily_budget_micros,3000000);
+ const increase=prepareControlledProposal({action:{type:'set_daily_budget',campaign_id:'2',amount_micros:6000000},policy,snapshot,now});
+ assert.deepEqual(increase.blockers,['conversion_integrity_untrusted']);
+});


### PR DESCRIPTION
Live inventory has 4 paused campaigns in addition to 2 enabled. Explicit new policy semantic counts enabled budgets; default all-configured semantics and all prior tests remain unchanged. Conversion-integrity gate still blocks increases. Runner returns audit before/after and rollback metadata after any actual send. 45 targeted proposal/executor tests passed. No campaign mutation; startup action remains unset.