### PR TITLE
P0: fix secure objective ingress request resolution

### DIFF
--- a/.github/workflows/objective-ingress.yml
+++ b/.github/workflows/objective-ingress.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Resolve request
         id: req
         shell: bash
@@ -23,6 +25,7 @@ jobs:
           set -euo pipefail
           FILE=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" | grep '^control/objective-requests/.*\.json$' | head -1)
           test -n "$FILE"
+          test -f "$FILE"
           echo "file=$FILE" >> "$GITHUB_OUTPUT"
       - name: Obtain short-lived GitHub OIDC identity
         id: oidc
@@ -32,6 +35,7 @@ jobs:
           RESP=$(curl -fsS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=parma-autonomous-objective-ingress")
           TOKEN=$(printf '%s' "$RESP" | jq -r '.value')
           test -n "$TOKEN" -a "$TOKEN" != null
+          echo "::add-mask::$TOKEN"
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
       - name: Submit objective and verify production completion
         env:
@@ -50,7 +54,7 @@ jobs:
           SUBMIT=$(curl -fsS -X POST "$BASE/internal/objective-ingress" -H "Authorization: Bearer $OIDC_TOKEN" -H 'Content-Type: application/json' --data "$BODY")
           OID=$(printf '%s' "$SUBMIT" | jq -r '.objective_id')
           test "$OID" = "$(jq -r '.id' "$REQUEST_FILE")"
-          cp /dev/null transitions.txt
+          : > transitions.txt
           for i in {1..30}; do
             curl -fsS "$BASE/health/autonomous-runner" -o health.json
             curl -fsS "$BASE/tools/agent/objectives/status" -H "Authorization: Bearer $OIDC_TOKEN" -o status.json
@@ -60,10 +64,10 @@ jobs:
             sleep 2
           done
           jq -e --arg oid "$OID" '(.runner.status=="RUNNING") and (.storage.durable==true) and (.last_task_completed.objective_id==$oid)' status.json >/dev/null
-          jq -e --arg oid "$OID" '[.ingress.audit[]|select(.data.objective_id==$oid and .data.auth_result=="allowed")]|length>=1' status.json >/dev/null
+          jq -e --arg oid "$OID" '[.ingress.audit[]|select(.data.objective_id==$oid and (.data.auth_result=="allowed" or .data.auth_result=="idempotent_existing"))]|length>=1' status.json >/dev/null
           printf 'objective_id=%s\n' "$OID"
           printf 'transitions:\n'; cat transitions.txt
-          jq '{runner,active_objective,last_task_completed,current_task,next_task,stop_reason,updated_at,ingress:{audit:(.ingress.audit|map(select(.data.objective_id==$oid)) // [])}}' --arg oid "$OID" status.json
+          jq --arg oid "$OID" '{runner,active_objective,last_task_completed,current_task,next_task,stop_reason,updated_at,ingress:{audit:(.ingress.audit|map(select(.data.objective_id==$oid)) // [])}}' status.json
       - name: Verify replay protection
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}


### PR DESCRIPTION
Fixes the production E2E-discovered GREEN bug in objective-ingress: checkout was fetch-depth 1, so git diff-tree could not resolve the newly committed request file. Uses fetch-depth 2 and verifies the resolved path exists. Also masks the short-lived OIDC token explicitly and permits the status assertion to recognize a safe idempotent-existing retry. No external capability or permission changes.