### PR TITLE
P1: connect Google Ads read-only specialist to autonomous runner

### DIFF
--- a/autonomous-runtime-service.js
+++ b/autonomous-runtime-service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const express = require('express');
-const { AutonomousRuntime, statePath, storageStatus } = require('./autonomous-runtime');
+const { AutonomousRuntime, statePath, storageStatus, readState } = require('./autonomous-runtime');
 const { autonomyPolicySummary } = require('./autonomy-policy');
 const { authorize:authorizeIngress, verify:verifyIngress, summary:ingressSummary } = require('./objective-ingress-auth');
 const { readCampaign } = require('./google-ads-specialist-read');
@@ -13,7 +13,19 @@ function localHandlers(env=process.env){
       const campaignId=String(task.id||'').replace(/^campaign-/, '');
       return readCampaign({campaignId,env});
     },
-    generate_report: async ({objective_id,task}) => ({ validated:true, evidence:{ report:'runtime_execution_audit', objective_id, task_id:task.id, attempts:task.attempts, structured:true } }),
+    generate_report: async ({objective_id,task}) => {
+      const state=readState(statePath(env));
+      const objective=state.objectives.find(x=>x.id===objective_id);
+      const source=objective?.tasks.find(x=>x.kind==='google_ads.read_campaign'&&x.status==='DONE')?.evidence?.[0]||null;
+      const o=source?.overview;
+      const evidence=source?{
+        report:'google_ads_campaign_read_summary',schema:'google_ads.read_campaign.report.v1',objective_id,task_id:task.id,campaign_id:source.campaign_id,date_range:source.date_range,
+        campaign:{status:o?.status||null,daily_budget_eur:Number(o?.daily_budget_eur||0),impressions:Number(o?.impressions||0),clicks:Number(o?.clicks||0),cost_eur:Number(o?.cost_eur||0),ctr:Number(o?.ctr||0),avg_cpc_eur:Number(o?.avg_cpc_eur||0),conversions_raw:Number(o?.conversions||0),conversion_value_raw:Number(o?.conversion_value||0)},
+        availability:{search_terms:Array.isArray(source.search_terms),keyword_summary:Array.isArray(source.keyword_summary),ad_group_summary:Array.isArray(source.ad_group_summary),hourly_distribution:Array.isArray(source.hourly_distribution),device_distribution:Array.isArray(source.device_distribution)},
+        conversion_metrics_interpretation:'raw_reported_values_only',writes_allowed:false,execution_allowed:false,spend_allowed:false,
+      }:{report:'runtime_execution_audit',objective_id,task_id:task.id,attempts:task.attempts,structured:true};
+      return {validated:true,evidence};
+    },
   };
 }
 

--- a/autonomous-runtime-service.js
+++ b/autonomous-runtime-service.js
@@ -4,11 +4,16 @@ const express = require('express');
 const { AutonomousRuntime, statePath, storageStatus } = require('./autonomous-runtime');
 const { autonomyPolicySummary } = require('./autonomy-policy');
 const { authorize:authorizeIngress, verify:verifyIngress, summary:ingressSummary } = require('./objective-ingress-auth');
+const { readCampaign } = require('./google-ads-specialist-read');
 
 function localHandlers(env=process.env){
   return {
     run_diagnostics: async () => ({ validated:true, evidence:{ component:'autonomous_runtime', storage:storageStatus(env), delegation_policy:autonomyPolicySummary(), kill_switch_supported:true } }),
-    generate_report: async ({objective_id,task}) => ({ validated:true, evidence:{ report:'runtime_execution_audit', objective_id, task_id:task.id, attempts:task.attempts } }),
+    'google_ads.read_campaign': async ({task}) => {
+      const campaignId=String(task.id||'').replace(/^campaign-/, '');
+      return readCampaign({campaignId,env});
+    },
+    generate_report: async ({objective_id,task}) => ({ validated:true, evidence:{ report:'runtime_execution_audit', objective_id, task_id:task.id, attempts:task.attempts, structured:true } }),
   };
 }
 

--- a/autonomy-policy.js
+++ b/autonomy-policy.js
@@ -15,6 +15,7 @@ const SAFE_AUTONOMOUS_ACTIONS = new Set([
   'record_internal_journal',
   'score_recommendation',
   'simulate_budget',
+  'google_ads.read_campaign',
 ]);
 
 function classifyAction(action = {}) {

--- a/google-ads-specialist-read.js
+++ b/google-ads-specialist-read.js
@@ -1,0 +1,59 @@
+'use strict';
+const { GoogleAdsApi } = require('google-ads-api');
+const {
+  collectCampaignSearchTerms, collectCampaignKeywords, collectCampaignDevices,
+  collectCampaignHours, collectCampaignOverview, collectCampaignAdGroups,
+} = require('./google-campaign-breakdowns');
+const { collectCampaignConversionActions } = require('./google-conversion-action-breakdown');
+
+function digits(v){ return String(v||'').replace(/\D/g,''); }
+function iso(d){ return d.toISOString().slice(0,10); }
+function safeRange(input={}){
+  const end = input.end ? new Date(`${input.end}T00:00:00Z`) : new Date(Date.now()-86400000);
+  const start = input.start ? new Date(`${input.start}T00:00:00Z`) : new Date(end.getTime()-29*86400000);
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start>end) throw Object.assign(new Error('invalid_date_range'),{status:400});
+  const days=Math.floor((end-start)/86400000)+1; if(days<1||days>90) throw Object.assign(new Error('date_range_out_of_bounds'),{status:400});
+  return {start:iso(start),end:iso(end),days};
+}
+function customerFromEnv(env=process.env){
+  const required=['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_DEVELOPER_TOKEN','GOOGLE_REFRESH_TOKEN','GOOGLE_CUSTOMER_ID'];
+  if(required.some(k=>!String(env[k]||'').trim())) throw Object.assign(new Error('google_ads_configuration_missing'),{status:401});
+  const api=new GoogleAdsApi({client_id:env.GOOGLE_CLIENT_ID,client_secret:env.GOOGLE_CLIENT_SECRET,developer_token:env.GOOGLE_DEVELOPER_TOKEN});
+  const cfg={customer_id:digits(env.GOOGLE_CUSTOMER_ID),refresh_token:env.GOOGLE_REFRESH_TOKEN};
+  const login=digits(env.GOOGLE_LOGIN_CUSTOMER_ID); if(login)cfg.login_customer_id=login;
+  return api.Customer(cfg);
+}
+function finite(n){ return Number.isFinite(Number(n)); }
+function validateEvidence(e,campaignId){
+  if(!e||e.campaign_id!==String(campaignId)||!e.overview) return false;
+  const nums=[e.overview.daily_budget_eur,e.overview.impressions,e.overview.clicks,e.overview.cost_eur,e.overview.ctr,e.overview.avg_cpc_eur,e.overview.conversions,e.overview.conversion_value];
+  if(nums.some(v=>!finite(v)||Number(v)<0)) return false;
+  if(e.overview.clicks>e.overview.impressions) return false;
+  return !/token|secret|password|api[_-]?key|authorization|bearer/i.test(JSON.stringify(e));
+}
+async function readCampaign({campaignId,start,end,env=process.env,timeoutMs=25000}){
+  if(!/^\d{1,20}$/.test(String(campaignId||''))) throw Object.assign(new Error('invalid_campaign_id'),{status:400});
+  const range=safeRange({start,end}), customer=customerFromEnv(env);
+  const work=Promise.all([
+    collectCampaignOverview({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignAdGroups({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignSearchTerms({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignKeywords({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignDevices({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignHours({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+    collectCampaignConversionActions({customer,campaignId:String(campaignId),start:range.start,end:range.end}),
+  ]);
+  const timeout=new Promise((_,reject)=>setTimeout(()=>reject(Object.assign(new Error('google_ads_read_timeout'),{code:'ETIMEDOUT',status:504})),timeoutMs));
+  const [overviewRows,adGroups,searchTerms,keywords,devices,hours,conversionActions]=await Promise.race([work,timeout]);
+  if(!Array.isArray(overviewRows)||overviewRows.length===0) throw Object.assign(new Error('campaign_response_empty'),{status:404});
+  const o=overviewRows[0], impressions=Number(o.impressions||0), clicks=Number(o.clicks||0), cost=Number(o.cost_eur||0);
+  const evidence={
+    schema:'google_ads.read_campaign.v1', source:'google_ads', mode:'read_only', campaign_id:String(campaignId),
+    date_range:{start:range.start,end:range.end,days:range.days},
+    overview:{status:o.status||null,primary_status:o.primary_status||null,channel_type:o.channel_type||null,daily_budget_eur:Number(o.daily_budget_eur||0),impressions,clicks,cost_eur:cost,ctr:impressions?clicks/impressions:0,avg_cpc_eur:clicks?cost/clicks:0,conversions:Number(o.conversions||0),conversion_value:Number(o.conversion_value||0)},
+    search_terms:searchTerms, keyword_summary:keywords, ad_group_summary:adGroups, hourly_distribution:hours, device_distribution:devices,
+    conversion_metrics:{raw_reported_values:true,actions:conversionActions}, writes_allowed:false,execution_allowed:false,spend_allowed:false,
+  };
+  return {validated:validateEvidence(evidence,campaignId),correctable:false,evidence};
+}
+module.exports={readCampaign,validateEvidence,safeRange,customerFromEnv};

--- a/test/google-ads-specialist-read.test.js
+++ b/test/google-ads-specialist-read.test.js
@@ -1,0 +1,22 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {safeRange,validateEvidence}=require('../google-ads-specialist-read');
+const {authorizeAutonomy}=require('../autonomy-policy');
+
+test('google_ads.read_campaign is explicitly safe read-only',()=>{
+  const r=authorizeAutonomy({name:'google_ads.read_campaign'},{kill_switch:false,human_approved:false});
+  assert.equal(r.allowed,true); assert.equal(r.action_class,'read_only'); assert.equal(r.reason,'safe_read_only_action');
+});
+
+test('date range is bounded to 90 days',()=>{
+  assert.deepEqual(safeRange({start:'2026-08-02',end:'2026-08-31'}),{start:'2026-08-02',end:'2026-08-31',days:30});
+  assert.throws(()=>safeRange({start:'2026-01-01',end:'2026-08-31'}),/date_range_out_of_bounds/);
+});
+
+test('deterministic evidence validates and rejects secret-shaped output',()=>{
+  const base={campaign_id:'23276824770',overview:{daily_budget_eur:3.5,impressions:100,clicks:10,cost_eur:5,ctr:0.1,avg_cpc_eur:0.5,conversions:2,conversion_value:0}};
+  assert.equal(validateEvidence(base,'23276824770'),true);
+  assert.equal(validateEvidence({...base,authorization:'Bearer abc'},'23276824770'),false);
+  assert.equal(validateEvidence({...base,overview:{...base.overview,clicks:101}},'23276824770'),false);
+});


### PR DESCRIPTION
Adds only the `google_ads.read_campaign` specialist capability. It reuses existing Google Ads campaign collectors, performs read-only external queries, persists deterministic sanitized evidence through the autonomous runtime, validates campaign identity/numeric consistency/no secret-shaped evidence, and remains behind Delegation Policy. No write capability is registered or changed. Includes bounded 90-day range, timeout, and existing runtime retry/backoff behavior for transient failures.