### PR TITLE
Fix elapsed-time safety evidence check in controlled executor

### DIFF
--- a/google-controlled-executor.js
+++ b/google-controlled-executor.js
@@ -94,12 +94,17 @@ function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafe
         const prepared=prepareControlledProposal({action:proposal.action,policy,snapshot,now:clock,kill_switch:false});
         if(!prepared.policy_fit)fail('policy_gate_failed');
         const safety=await readSafety();
+        // A network read completes after the clock captured above. Compare evidence
+        // with the completion clock, while retaining future/stale/expiry rejection.
+        const safetyClock=now();
+        if(!Number.isSafeInteger(safetyClock)||safetyClock<clock)fail('invalid_clock');
+        if(Date.parse(proposal.expires_at)<=safetyClock)fail('proposal_expired');
         if(limitSemantics==='enabled_configured_daily_budget'){
           configuredBudgetGuard(snapshot,proposal.action);
           if(safety?.customer_id!==owner||safety.currency!=='EUR'||safety.time_zone!=='Europe/Berlin'||
              safety.limit_semantics!==limitSemantics||safety.today_read_success!==true||
              !Number.isSafeInteger(safety.reported_cost_micros)||safety.reported_cost_micros<0||
-             !Number.isSafeInteger(safety.checked_at)||clock-safety.checked_at<0||clock-safety.checked_at>5000||
+             !Number.isSafeInteger(safety.checked_at)||safetyClock-safety.checked_at<0||safetyClock-safety.checked_at>5000||
              safety.proposal_id!==proposalId||safety.audit_storage_durable!==true||safety.live_execution_gate!==true)fail('economic_or_runtime_gate_unverified');
           return snapshot;
         }
@@ -109,7 +114,7 @@ function createControlledExecutor({journal,ledger,customer,readSnapshot,readSafe
           safety.hard_daily_spend_cap_verified!==true||safety.today_history_reconciled!==true||
           !Number.isSafeInteger(safety.maximum_billable_today_micros)||safety.maximum_billable_today_micros>10000000||safety.maximum_billable_today_micros<0||
           !Number.isSafeInteger(safety.reported_cost_micros)||safety.reported_cost_micros<0||safety.reported_cost_micros>10000000||
-          !Number.isSafeInteger(safety.checked_at)||clock-safety.checked_at<0||clock-safety.checked_at>5000||
+          !Number.isSafeInteger(safety.checked_at)||safetyClock-safety.checked_at<0||safetyClock-safety.checked_at>5000||
           safety.proposal_id!==proposalId||safety.audit_storage_durable!==true||safety.live_execution_gate!==true)fail('economic_or_runtime_gate_unverified');
         return snapshot;
       };

--- a/test/google-controlled-executor.test.js
+++ b/test/google-controlled-executor.test.js
@@ -66,6 +66,18 @@ test('configured mode still requires live economic read',async t=>{
  const f=fixture(t);f.safety.limit_semantics='enabled_configured_daily_budget';f.safety.today_read_success=false;
  await assert.rejects(createControlledExecutor({...f.args,limitSemantics:'enabled_configured_daily_budget'}).execute(f.p.proposal_id),/economic_or_runtime/);
 });
+test('real elapsed safety read time is not a future timestamp',async t=>{
+ const f=fixture(t);let clock=f.args.now();
+ f.args.now=()=>clock;
+ f.args.readSafety=async()=>{clock+=100;return {...f.safety,checked_at:clock};};
+ assert.equal((await createControlledExecutor(f.args).execute(f.p.proposal_id)).status,'verified');
+});
+test('proposal expiring during safety read cannot reach provider validation',async t=>{
+ const f=fixture(t);let clock=f.args.now();f.args.now=()=>clock;
+ f.args.readSafety=async()=>{clock+=61000;return {...f.safety,checked_at:clock};};
+ await assert.rejects(createControlledExecutor(f.args).execute(f.p.proposal_id),/proposal_expired/);
+ assert.equal(f.calls.length,0);
+});
 test('explicit enabled proposal policy excludes paused budgets but retains conversion gate',()=>{
  const {prepareControlledProposal}=require('../google-controlled-proposals');const now=Date.now();
  const snapshot={customer_id:'1',currency:'EUR',captured_at:new Date(now).toISOString(),account_inventory_complete:true,campaigns:[{campaign_id:'2',budget_id:'3',daily_budget_micros:3500000,status:'ENABLED',shared_budget:false,conversion_integrity_trusted:false},{campaign_id:'4',budget_id:'5',daily_budget_micros:9200000,status:'PAUSED',shared_budget:false,conversion_integrity_trusted:false}]};


### PR DESCRIPTION
Reproduced real elapsed read falsely classified as future evidence. Compare safety.checked_at against completion clock rather than clock before network reads. Retains <=5s freshness, future rejection, adds backwards-clock and post-read proposal-expiry guards. 19 targeted tests pass, including two regression tests first demonstrated failing. No authority, budget, conversion, audit, idempotency, transport or rollback changes. No Google mutation performed.