### PR TITLE
P3: add Google Ads execution dry-run preflight capability

### DIFF
--- a/autonomous-runtime-service.js
+++ b/autonomous-runtime-service.js
@@ -6,6 +6,7 @@ const { autonomyPolicySummary } = require('./autonomy-policy');
 const { authorize:authorizeIngress, verify:verifyIngress, summary:ingressSummary } = require('./objective-ingress-auth');
 const { readCampaign } = require('./google-ads-specialist-read');
 const { proposeChanges } = require('./google-ads-specialist-propose');
+const { buildExecutionDryRun } = require('./google-ads-specialist-execution');
 
 function localHandlers(env=process.env){
   return {
@@ -20,9 +21,21 @@ function localHandlers(env=process.env){
       const source=objective?.tasks.find(x=>x.kind==='google_ads.read_campaign'&&x.status==='DONE')?.evidence?.[0]||null;
       return proposeChanges({readEvidence:source,context:task.input?.context||{}});
     },
+    'google_ads.execution_preflight': async ({objective_id,task}) => {
+      const state=readState(statePath(env));
+      const objective=state.objectives.find(x=>x.id===objective_id);
+      const readTask=objective?.tasks.find(x=>x.kind==='google_ads.read_campaign'&&x.status==='DONE');
+      const proposalTask=objective?.tasks.find(x=>x.kind==='google_ads.propose_changes'&&x.status==='DONE');
+      const historicalKeys=state.objectives.flatMap(o=>o.tasks.filter(t=>t.kind==='google_ads.execution_preflight'&&t.status==='DONE').flatMap(t=>t.evidence||[])).map(e=>e?.execution_key).filter(Boolean);
+      return buildExecutionDryRun({proposal:proposalTask?.evidence?.[0]||null,readEvidence:readTask?.evidence?.[0]||null,proposalCompletedAt:proposalTask?.completed_at||null,taskInput:task.input||{},killSwitch:state.runner.kill_switch===true,now:Date.now(),executionLedger:historicalKeys});
+    },
     generate_report: async ({objective_id,task}) => {
       const state=readState(statePath(env));
       const objective=state.objectives.find(x=>x.id===objective_id);
+      const execution=objective?.tasks.find(x=>x.kind==='google_ads.execution_preflight'&&x.status==='DONE')?.evidence?.[0]||null;
+      if(execution){
+        return {validated:true,evidence:{report:'google_ads_execution_preflight_summary',schema:'google_ads.execution_preflight.report.v1',objective_id,task_id:task.id,mode:'dry_run',execution_key:execution.execution_key,replayed:execution.replayed===true,counts:execution.counts,budget_cage:execution.budget_cage,rollback_readiness:execution.rollback_readiness,actions:(execution.actions||[]).map(a=>({action_id:a.action_id,action_type:a.action_type,status:a.status,reason:a.reason,executor_supported:a.executor_supported===true,rollback_ready:a.rollback_ready===true})),mutations_executed:0,writes_allowed:false,execution_allowed:false,spend_allowed:false}};
+      }
       const proposal=objective?.tasks.find(x=>x.kind==='google_ads.propose_changes'&&x.status==='DONE')?.evidence?.[0]||null;
       if(proposal){
         return {validated:true,evidence:{

--- a/autonomy-policy.js
+++ b/autonomy-policy.js
@@ -17,6 +17,7 @@ const SAFE_AUTONOMOUS_ACTIONS = new Set([
   'simulate_budget',
   'google_ads.read_campaign',
   'google_ads.propose_changes',
+  'google_ads.execution_preflight',
 ]);
 
 function classifyAction(action = {}) {

--- a/google-ads-specialist-execution.js
+++ b/google-ads-specialist-execution.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const crypto=require('node:crypto');
+const {buildBudgetMutation}=require('./google-controlled-executor');
+const {PROTECTED,validCandidate}=require('./google-controlled-negative');
+
+const MAX_PROPOSAL_AGE_MS=5*60*1000;
+const CAP_EUR=10;
+const RED_TYPES=new Set(['primary_conversion_change','tracking_semantic_change','conversion_action_change']);
+const ROLLBACK_REQUIRED=new Set(['budget_adjustment','negative_keyword_addition','match_type_adjustment','rsa_assets_improvement','late_night_schedule_adjustment','geographic_refinement']);
+const WRITE_TYPES=new Set([...ROLLBACK_REQUIRED]);
+const SUPPORTED_EXECUTOR_TYPES=new Set(['budget_adjustment','negative_keyword_addition']);
+
+function stable(value){return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');}
+function reject(reason,extra={}){return {status:'REJECTED',reason,...extra};}
+function needsHuman(reason,extra={}){return {status:'NEEDS_HUMAN',reason,...extra};}
+function auto(reason,extra={}){return {status:'AUTO_EXECUTABLE',reason,...extra};}
+function hasPersistedAuthorization(action,input={}){
+  const rows=Array.isArray(input.authorizations)?input.authorizations:[];
+  return rows.some(a=>a&&a.persisted===true&&a.action_id===action.action_id&&a.campaign_id===action.campaign_id&&a.scope===action.action_type&&(!a.expires_at||Date.parse(a.expires_at)>Date.now()));
+}
+function actionInProposal(action,proposal){return Array.isArray(proposal?.actions)&&proposal.actions.some(a=>stable(a)===stable(action));}
+function safeCampaign(action,proposal,readEvidence){return action.campaign_id===proposal.campaign_id&&action.campaign_id===readEvidence.campaign_id;}
+function budgetCheck(action,proposal){
+  const cage=proposal?.budget_cage;
+  if(!cage||cage.cap_eur!==CAP_EUR||cage.validated!==true)return {ok:false,reason:'budget_cage_missing_or_invalid'};
+  if(Number(cage.before_total_eur)>CAP_EUR||Number(cage.proposed_total_eur)>CAP_EUR)return {ok:false,reason:'budget_cap_exceeded'};
+  if(action.action_type==='budget_adjustment'){
+    const next=Number(action.proposed_value?.daily_budget_eur);
+    const before=Number(action.current_value?.daily_budget_eur);
+    const projected=Number(cage.before_total_eur)-before+next;
+    if(!Number.isFinite(projected)||projected>CAP_EUR)return {ok:false,reason:'budget_cap_exceeded'};
+  }
+  return {ok:true,before_total_eur:Number(cage.before_total_eur),proposed_total_eur:Number(cage.proposed_total_eur),cap_eur:CAP_EUR,hard_daily_cost_cap:false};
+}
+function rollbackCheck(action){return !ROLLBACK_REQUIRED.has(action.action_type)||action.rollback_possible===true;}
+function negativeGuard(action){
+  if(action.action_type!=='negative_keyword_addition')return {ok:true};
+  const term=String(action.proposed_value?.term||'');
+  const match=String(action.proposed_value?.match_type||'');
+  if(match!=='EXACT')return {ok:false,reason:'negative_must_be_exact_for_existing_executor'};
+  if(PROTECTED.test(term))return {ok:false,reason:'protected_local_intent'};
+  return {ok:true};
+}
+function buildExecutorPreview(action,readEvidence){
+  if(action.action_type==='budget_adjustment'){
+    const budget=readEvidence.account_budget_context?.enabled_budgets?.find(b=>(b.campaign_ids||[]).includes(action.campaign_id));
+    if(!budget)return {supported:false,reason:'budget_resource_missing'};
+    const proposal={customer_id:'7376153998',action:{type:'set_daily_budget',campaign_id:action.campaign_id,amount_micros:Math.round(Number(action.proposed_value.daily_budget_eur)*1e6)},before:{budget_id:String(budget.budget_id),daily_budget_micros:Math.round(Number(action.current_value.daily_budget_eur)*1e6)}};
+    return {supported:true,executor:'google-controlled-executor',provider_operation:buildBudgetMutation(proposal),rollback:{type:'set_daily_budget',campaign_id:action.campaign_id,amount_micros:proposal.before.daily_budget_micros}};
+  }
+  if(action.action_type==='negative_keyword_addition'){
+    const c={campaign_id:action.campaign_id,text:String(action.proposed_value?.term||''),match_type:String(action.proposed_value?.match_type||''),semantic_class:'verified_other_restaurant',evidence_url:'https://example.invalid/evidence'};
+    if(!validCandidate(c))return {supported:false,reason:'existing_negative_executor_candidate_contract_not_met'};
+    return {supported:true,executor:'google-controlled-negative',provider_operation:{type:'create',campaign_id:c.campaign_id,text:c.text,match_type:'EXACT'},rollback:{type:'remove_exact_negative',resource_name:'assigned_after_write'}};
+  }
+  return {supported:false,reason:'executor_not_available_for_action_type'};
+}
+function simulateReadAfterWrite(preview,{simulateReadAfterWriteFailure=false}={}){
+  if(!preview.supported)return {required:false,ready:false,reason:preview.reason};
+  if(simulateReadAfterWriteFailure)return {required:true,ready:false,reason:'read_after_write_failure_simulated'};
+  return {required:true,ready:true,verification:'existing_executor_read_after_write_contract'};
+}
+function preflightAction(action,{proposal,readEvidence,proposalCompletedAt,taskInput={},killSwitch=false,now=Date.now()}={}){
+  if(killSwitch)return reject('kill_switch_active');
+  if(!proposal||proposal.mode!=='proposal_only')return reject('proposal_required');
+  const completed=Date.parse(proposalCompletedAt||'');
+  if(!Number.isFinite(completed)||now-completed<0||now-completed>MAX_PROPOSAL_AGE_MS)return reject('proposal_stale_or_future');
+  if(!actionInProposal(action,proposal))return reject('action_not_in_proposal');
+  if(!safeCampaign(action,proposal,readEvidence||{}))return reject('campaign_account_mismatch');
+  if(RED_TYPES.has(action.action_type)||action.delegation_class==='conversion_write')return reject('red_action_forbidden');
+  if(action.action_type==='primary_conversion_change'||/primary.?conversion/i.test(String(action.target||'')))return reject('primary_conversion_change_forbidden');
+  if(/tracking|conversion semantic/i.test(String(action.target||'')))return reject('tracking_semantic_change_forbidden');
+  const budget=budgetCheck(action,proposal);if(!budget.ok)return reject(budget.reason,{budget_cage:budget});
+  if(!rollbackCheck(action))return reject('rollback_required_missing');
+  const neg=negativeGuard(action);if(!neg.ok)return reject(neg.reason);
+  if(!action.evidence_refs?.length)return reject('evidence_insufficient');
+  const preview=buildExecutorPreview(action,readEvidence);
+  const raw=simulateReadAfterWrite(preview,taskInput);
+  if(taskInput.simulateReadAfterWriteFailure&&preview.supported)return reject(raw.reason,{executor_preview:preview,read_after_write:raw});
+  if(action.status==='NEEDS_HUMAN'&&!hasPersistedAuthorization(action,taskInput))return needsHuman('persisted_authorization_required',{executor_supported:preview.supported,executor_preview:preview,budget_cage:budget,rollback_ready:rollbackCheck(action),read_after_write:raw});
+  if(action.status==='REJECTED')return reject('proposal_action_rejected');
+  if(action.status==='AUTO_EXECUTABLE')return auto('dry_run_safe_non_mutating_action',{executor_supported:preview.supported,executor_preview:preview,budget_cage:budget,rollback_ready:rollbackCheck(action),read_after_write:raw});
+  if(WRITE_TYPES.has(action.action_type)&&!preview.supported)return needsHuman('executor_not_available_for_action_type',{executor_supported:false,budget_cage:budget,rollback_ready:rollbackCheck(action)});
+  return auto('authorized_for_future_executor_preflight',{executor_supported:preview.supported,executor_preview:preview,budget_cage:budget,rollback_ready:rollbackCheck(action),read_after_write:raw});
+}
+function buildExecutionDryRun({proposal,readEvidence,proposalCompletedAt,taskInput={},killSwitch=false,now=Date.now(),executionLedger=[]}={}){
+  if(!proposal||!readEvidence)return {validated:false,correctable:false,evidence:{schema:'google_ads.execution_preflight.v1',mode:'dry_run',mutations_executed:0,blockers:['proposal_and_live_evidence_required']}};
+  const executionKey=stable({proposal_fingerprint:proposal.evidence_fingerprint,proposalCompletedAt,actions:proposal.actions?.map(a=>a.action_id)});
+  if((executionLedger||[]).includes(executionKey))return {validated:true,evidence:{schema:'google_ads.execution_preflight.v1',mode:'dry_run',execution_key:executionKey,replayed:true,mutations_executed:0,counts:{AUTO_EXECUTABLE:0,NEEDS_HUMAN:0,REJECTED:0},actions:[]}};
+  const actions=(proposal.actions||[]).map(action=>({action_id:action.action_id,campaign_id:action.campaign_id,action_type:action.action_type,...preflightAction(action,{proposal,readEvidence,proposalCompletedAt,taskInput,killSwitch,now})}));
+  const counts={AUTO_EXECUTABLE:actions.filter(a=>a.status==='AUTO_EXECUTABLE').length,NEEDS_HUMAN:actions.filter(a=>a.status==='NEEDS_HUMAN').length,REJECTED:actions.filter(a=>a.status==='REJECTED').length};
+  const cage=budgetCheck({action_type:'none'},proposal);
+  return {validated:true,evidence:{schema:'google_ads.execution_preflight.v1',mode:'dry_run',execution_key:executionKey,replayed:false,proposal_fingerprint:proposal.evidence_fingerprint,proposal_age_ms:now-Date.parse(proposalCompletedAt),budget_cage:cage,counts,actions,rollback_readiness:actions.map(a=>({action_id:a.action_id,ready:a.rollback_ready===true||a.status==='AUTO_EXECUTABLE'&&a.action_type==='protect_high_intent_local_terms'})),mutations_executed:0,writes_allowed:false,execution_allowed:false,spend_allowed:false,provider_validate_only_called:false,provider_write_called:false}};
+}
+module.exports={MAX_PROPOSAL_AGE_MS,CAP_EUR,preflightAction,buildExecutionDryRun,buildExecutorPreview,simulateReadAfterWrite};

--- a/test/google-ads-specialist-execution.test.js
+++ b/test/google-ads-specialist-execution.test.js
@@ -1,0 +1,23 @@
+'use strict';
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {preflightAction,buildExecutionDryRun}=require('../google-ads-specialist-execution');
+
+const now=Date.parse('2026-09-04T20:30:00.000Z');
+const read={campaign_id:'23276824770',account_budget_context:{enabled_budgets:[{budget_id:'15148237814',daily_budget_eur:3.5,campaign_ids:['23276824770']}]}};
+const baseAction={action_id:'a1',campaign_id:'23276824770',action_type:'budget_adjustment',target:'campaign:23276824770:daily_budget',current_value:{daily_budget_eur:3.5},proposed_value:{daily_budget_eur:6},reason:'x',evidence_refs:['read_campaign.overview.daily_budget_eur'],expected_effect:'x',risk_level:'HIGH',delegation_class:'spend_change',rollback_possible:true,confidence:.9,conversion_signal_used:'NONE',status:'NEEDS_HUMAN'};
+const proposal={mode:'proposal_only',campaign_id:'23276824770',evidence_fingerprint:'fp1',budget_cage:{cap_eur:10,before_total_eur:7.5,target_campaign_before_eur:3.5,target_campaign_proposed_eur:6,proposed_total_eur:10,hard_daily_cost_cap:false,validated:true},actions:[baseAction]};
+const completed='2026-09-04T20:29:00.000Z';
+function run(action=baseAction,opts={}){return preflightAction(action,{proposal:opts.proposal||proposal,readEvidence:opts.readEvidence||read,proposalCompletedAt:opts.completed||completed,taskInput:opts.taskInput||{},killSwitch:opts.killSwitch||false,now:opts.now||now});}
+
+test('rejects stale proposal',()=>assert.equal(run(baseAction,{completed:'2026-09-04T20:20:00.000Z'}).reason,'proposal_stale_or_future'));
+test('rejects aggregate configured budget above 10 EUR',()=>{const p=structuredClone(proposal);p.budget_cage.proposed_total_eur=10.01;assert.equal(run(baseAction,{proposal:p}).reason,'budget_cap_exceeded');});
+test('NEEDS_HUMAN is not inferred authorized',()=>{const r=run();assert.equal(r.status,'NEEDS_HUMAN');assert.equal(r.reason,'persisted_authorization_required');});
+test('rejects RED / Primary Conversion action',()=>{const a={...baseAction,action_id:'red',action_type:'primary_conversion_change',target:'Primary Conversion'};const p={...proposal,actions:[a]};const r=preflightAction(a,{proposal:p,readEvidence:read,proposalCompletedAt:completed,now});assert.equal(r.status,'REJECTED');});
+test('duplicate dry-run execution is idempotently replayed',()=>{const first=buildExecutionDryRun({proposal,readEvidence:read,proposalCompletedAt:completed,now});const second=buildExecutionDryRun({proposal,readEvidence:read,proposalCompletedAt:completed,now,executionLedger:[first.evidence.execution_key]});assert.equal(second.evidence.replayed,true);assert.equal(second.evidence.mutations_executed,0);});
+test('rejects mismatched campaign',()=>assert.equal(run(baseAction,{readEvidence:{...read,campaign_id:'999'}}).reason,'campaign_account_mismatch'));
+test('kill switch rejects preflight action',()=>assert.equal(run(baseAction,{killSwitch:true}).reason,'kill_switch_active'));
+test('missing rollback is rejected when required',()=>{const a={...baseAction,rollback_possible:false};const p={...proposal,actions:[a]};const r=preflightAction(a,{proposal:p,readEvidence:read,proposalCompletedAt:completed,now});assert.equal(r.reason,'rollback_required_missing');});
+test('read-after-write failure simulation fails closed',()=>{const a={...baseAction,status:'AUTO_EXECUTABLE'};const p={...proposal,actions:[a]};const r=preflightAction(a,{proposal:p,readEvidence:read,proposalCompletedAt:completed,taskInput:{simulateReadAfterWriteFailure:true},now});assert.equal(r.reason,'read_after_write_failure_simulated');});
+test('action absent from proposal is rejected',()=>assert.equal(run({...baseAction,action_id:'other'}).reason,'action_not_in_proposal'));
+test('dry run never calls provider validate-only or write',()=>{const r=buildExecutionDryRun({proposal,readEvidence:read,proposalCompletedAt:completed,now});assert.equal(r.validated,true);assert.equal(r.evidence.mutations_executed,0);assert.equal(r.evidence.provider_validate_only_called,false);assert.equal(r.evidence.provider_write_called,false);});


### PR DESCRIPTION
Adds `google_ads.execution_preflight` to the persistent autonomous runner. It consumes only persisted `google_ads.propose_changes` actions plus fresh LIVE read evidence, reuses existing budget/negative executor primitives, enforces 5-minute proposal freshness, aggregate configured budget <= EUR10, campaign binding, authorization presence, RED/Primary Conversion/tracking rejection, rollback readiness, idempotent replay, kill switch and read-after-write fail-closed simulation. Production dry-run path cannot call provider validate-only or write and always reports mutations_executed=0. No Google Ads mutation is performed by this PR.