### PR TITLE
P7: verify Control Tower through authenticated production OIDC

### DIFF
--- a/.github/workflows/objective-ingress.yml
+++ b/.github/workflows/objective-ingress.yml
@@ -68,6 +68,18 @@ jobs:
           printf 'objective_id=%s\n' "$OID"
           printf 'transitions:\n'; cat transitions.txt
           jq --arg oid "$OID" '{runner,active_objective,last_task_completed,current_task,next_task,stop_reason,updated_at,ingress:{audit:(.ingress.audit|map(select(.data.objective_id==$oid)) // [])}}' status.json
+      - name: Verify Control Tower observability
+        env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE='https://supportive-stillness-production-ec37.up.railway.app'
+          curl -fsS "$BASE/tools/agent/control-tower" -H "Authorization: Bearer $OIDC_TOKEN" -o control-tower.json
+          curl -fsS "$BASE/tools/agent/recurring" -H "Authorization: Bearer $OIDC_TOKEN" -o recurring.json
+          jq -e '(.success==true) and (.schema=="parma.control_tower.v1") and (.runner.status=="RUNNING") and (.runner.kill_switch|type=="boolean") and (.objectives.total_count>=1) and (.specialists|map(.id)|index("google_ads")!=null) and (.specialists|map(.id)|index("orderbird")!=null) and (.guardrails.conversion_integrity.booking_completed.trust=="UNTRUSTED_AS_RESERVATION") and (.guardrails.conversion_integrity.table_reservation_completed.allowed_for_autonomous_booking_optimization==false) and (.recurring.timezone=="Europe/Berlin")' control-tower.json >/dev/null
+          jq -e '(.success==true) and (.timezone=="Europe/Berlin") and (.storage.durable==true) and ([.schedules[].id]|index("morning-runtime-health")!=null)' recurring.json >/dev/null
+          jq '{schema,runner,objectives,current_task,next_task,last_successful_action,last_mutation,evidence_timestamp,pending_needs_human,blocked_external,retry_state,guardrails:{budget_cage:.guardrails.budget_cage,conversion_integrity:.guardrails.conversion_integrity},recurring,specialists:(.specialists|map({id,status,health}))}' control-tower.json
       - name: Verify replay protection
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}


### PR DESCRIPTION
Hardens P7 verification only. Extends the existing secure objective-ingress workflow so each production E2E also reads `/tools/agent/control-tower` and `/tools/agent/recurring` with the same short-lived GitHub Actions OIDC identity, asserting runtime status, kill switch visibility, specialist registry, conversion-integrity safeguards, Europe/Berlin recurring state and durable scheduler storage. No application authority, provider access or mutation behavior is changed.