### PR TITLE
Orderbird: add explicit revenue ground-truth runtime states

### DIFF
--- a/orderbird-ingestion.js
+++ b/orderbird-ingestion.js
@@ -1,6 +1,7 @@
 'use strict';
 const { normalizeOrderbirdAggregate, containsDisallowedPii } = require('./orderbird-normalize');
 const { keyFor } = require('./orderbird-store');
+const { buildOrderbirdRevenueStatus } = require('./orderbird-revenue-status');
 
 function createOrderbirdIngestion({ adapter, store, normalize=normalizeOrderbirdAggregate, now=()=>new Date() } = {}) {
   if (!adapter || typeof adapter.readAggregates !== 'function') throw new TypeError('adapter_required');
@@ -44,8 +45,9 @@ function createOrderbirdIngestion({ adapter, store, normalize=normalizeOrderbird
     const storeHealth = typeof store.health === 'function' ? store.health() : {healthy:true,writable:true};
     return { provider:'orderbird', source_kind:'pos_revenue_ground_truth', attribution_kind:'none', adapter:adapterHealth, store:storeHealth, last_run:{...lastRun}, healthy:Boolean(adapterHealth.usable && storeHealth.healthy && lastRun.status !== 'error') };
   }
+  function revenueStatus() { return buildOrderbirdRevenueStatus(health()); }
 
-  return { ingestRange, backfill7Days:(endDate)=>backfillDays(endDate,7), backfillDays, ingestCompletedDay, health };
+  return { ingestRange, backfill7Days:(endDate)=>backfillDays(endDate,7), backfillDays, ingestCompletedDay, health, revenueStatus };
 }
 
 module.exports = { createOrderbirdIngestion };

--- a/orderbird-revenue-status.js
+++ b/orderbird-revenue-status.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const REVENUE_VERIFIED = 'REVENUE_VERIFIED';
+const REVENUE_PARTIAL = 'REVENUE_PARTIAL';
+const REVENUE_UNAVAILABLE = 'REVENUE_UNAVAILABLE';
+
+function buildOrderbirdRevenueStatus(ingestionHealth = {}) {
+  const adapter = ingestionHealth.adapter || {};
+  const store = ingestionHealth.store || {};
+  const lastRun = ingestionHealth.last_run || {};
+
+  const base = {
+    provider: 'orderbird',
+    source_kind: 'pos_revenue_ground_truth',
+    attribution_kind: 'none',
+    source_health: 'unavailable',
+    revenue_ground_truth: REVENUE_UNAVAILABLE,
+    reason: 'provider_supported_transport_unavailable',
+    contains_pii: false,
+    mutation_permission: false,
+  };
+
+  if (!adapter.usable || adapter.health === 'unavailable') return base;
+
+  if (!store.healthy || store.writable === false) {
+    return {
+      ...base,
+      source_health: 'degraded',
+      revenue_ground_truth: REVENUE_PARTIAL,
+      reason: 'durable_store_unhealthy',
+    };
+  }
+
+  if (lastRun.status === 'error') {
+    return {
+      ...base,
+      source_health: 'degraded',
+      revenue_ground_truth: REVENUE_PARTIAL,
+      reason: 'last_ingestion_failed',
+    };
+  }
+
+  if (lastRun.status !== 'success' || Number(lastRun.received || 0) === 0) {
+    return {
+      ...base,
+      source_health: 'healthy',
+      revenue_ground_truth: REVENUE_UNAVAILABLE,
+      reason: 'no_verified_revenue_ingested',
+    };
+  }
+
+  if (Number(lastRun.rejected || 0) > 0) {
+    return {
+      ...base,
+      source_health: 'degraded',
+      revenue_ground_truth: REVENUE_PARTIAL,
+      reason: 'ingestion_rejected_rows',
+    };
+  }
+
+  return {
+    ...base,
+    source_health: 'healthy',
+    revenue_ground_truth: REVENUE_VERIFIED,
+    reason: 'provider_read_and_persistence_verified',
+  };
+}
+
+module.exports = {
+  REVENUE_VERIFIED,
+  REVENUE_PARTIAL,
+  REVENUE_UNAVAILABLE,
+  buildOrderbirdRevenueStatus,
+};

--- a/test/orderbird-revenue-status.test.js
+++ b/test/orderbird-revenue-status.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  REVENUE_VERIFIED,
+  REVENUE_PARTIAL,
+  REVENUE_UNAVAILABLE,
+  buildOrderbirdRevenueStatus,
+} = require('../orderbird-revenue-status');
+
+test('orderbird revenue is unavailable without verified provider transport', () => {
+  const status = buildOrderbirdRevenueStatus({
+    adapter:{ usable:false, health:'unavailable' },
+    store:{ healthy:true, writable:true },
+    last_run:{ status:'never_run', received:0, rejected:0 },
+  });
+  assert.equal(status.revenue_ground_truth, REVENUE_UNAVAILABLE);
+  assert.equal(status.source_health, 'unavailable');
+  assert.equal(status.mutation_permission, false);
+  assert.equal(status.attribution_kind, 'none');
+});
+
+test('orderbird revenue is partial when durable store is unhealthy', () => {
+  const status = buildOrderbirdRevenueStatus({
+    adapter:{ usable:true, health:'healthy' },
+    store:{ healthy:false, writable:false },
+    last_run:{ status:'success', received:1, rejected:0 },
+  });
+  assert.equal(status.revenue_ground_truth, REVENUE_PARTIAL);
+  assert.equal(status.reason, 'durable_store_unhealthy');
+});
+
+test('orderbird revenue is partial when rows were rejected', () => {
+  const status = buildOrderbirdRevenueStatus({
+    adapter:{ usable:true, health:'healthy' },
+    store:{ healthy:true, writable:true },
+    last_run:{ status:'success', received:3, rejected:1 },
+  });
+  assert.equal(status.revenue_ground_truth, REVENUE_PARTIAL);
+  assert.equal(status.reason, 'ingestion_rejected_rows');
+});
+
+test('orderbird revenue is unavailable when transport works but no revenue has been ingested', () => {
+  const status = buildOrderbirdRevenueStatus({
+    adapter:{ usable:true, health:'healthy' },
+    store:{ healthy:true, writable:true },
+    last_run:{ status:'never_run', received:0, rejected:0 },
+  });
+  assert.equal(status.revenue_ground_truth, REVENUE_UNAVAILABLE);
+  assert.equal(status.source_health, 'healthy');
+});
+
+test('orderbird revenue is verified only after successful non-empty clean ingestion', () => {
+  const status = buildOrderbirdRevenueStatus({
+    adapter:{ usable:true, health:'healthy' },
+    store:{ healthy:true, writable:true },
+    last_run:{ status:'success', received:4, upserted:4, rejected:0 },
+  });
+  assert.equal(status.revenue_ground_truth, REVENUE_VERIFIED);
+  assert.equal(status.source_health, 'healthy');
+  assert.equal(status.reason, 'provider_read_and_persistence_verified');
+  assert.equal(status.contains_pii, false);
+});


### PR DESCRIPTION
Adds fail-closed Orderbird revenue status semantics on top of the already merged read-only ingestion stack.

Scope only: ORDERBIRD → REVENUE GROUND TRUTH.

- Adds REVENUE_VERIFIED / REVENUE_PARTIAL / REVENUE_UNAVAILABLE.
- Never invents revenue when provider transport is unavailable.
- Keeps attribution_kind=none and mutation_permission=false.
- Marks durable-store or ingestion problems as PARTIAL.
- Exposes revenueStatus() from the ingestion object.
- Adds focused tests.

No Google Ads, tracking, Meta/Instagram, campaign, budget or POS write changes.