### PR TITLE
Pause scheduled publication when provider writes are frozen

### DIFF
--- a/instagram-editorial-runtime.js
+++ b/instagram-editorial-runtime.js
@@ -61,12 +61,14 @@ function startInstagramEditorialRuntime({
     store: resolvedStore,
     now,
   });
+  const executionEnabled = providerWritesAllowed(env);
 
   resolvedScheduler.start({
     technical_ready: true,
     editorial_ready: true,
     execute: callback,
     reconcile,
+    execution_enabled: executionEnabled,
     intervalMs,
   });
 
@@ -80,6 +82,7 @@ function startInstagramEditorialRuntime({
       editorial_ready: true,
       execute: callback,
       reconcile,
+      execution_enabled: executionEnabled,
     }),
   };
 }

--- a/instagram-editorial-timing.js
+++ b/instagram-editorial-timing.js
@@ -229,7 +229,7 @@ class InstagramEditorialScheduler {
     });
   }
 
-  async tick({ technical_ready, editorial_ready, execute, reconcile = null }) {
+  async tick({ technical_ready, editorial_ready, execute, reconcile = null, execution_enabled = true }) {
     const due = this.store.list('change').filter(record =>
       record.payload?.kind_event === 'instagram_editorial_schedule_created' &&
       !hasScheduleExecuted(this.store, record.payload.schedule_fingerprint)
@@ -316,6 +316,19 @@ class InstagramEditorialScheduler {
           now: this.now,
         });
         results.push({ publication_id: pkg.publication_id, status: currentState.status, provider_writes: 0 });
+        continue;
+      }
+
+      if (execution_enabled !== true) {
+        if (!currentState || currentState.status !== PUBLICATION_STATES.SCHEDULED || currentState.reason !== 'provider_writes_frozen') {
+          markPublicationState(this.store, {
+            publicationId: pkg.publication_id,
+            status: PUBLICATION_STATES.SCHEDULED,
+            reason: 'provider_writes_frozen',
+            now: this.now,
+          });
+        }
+        results.push({ publication_id: pkg.publication_id, status: 'PROVIDER_WRITES_FROZEN', provider_writes: 0 });
         continue;
       }
 
@@ -420,12 +433,12 @@ class InstagramEditorialScheduler {
     return results;
   }
 
-  start({ technical_ready = false, editorial_ready = false, execute, reconcile = null, intervalMs = 60000 } = {}) {
+  start({ technical_ready = false, editorial_ready = false, execute, reconcile = null, execution_enabled = true, intervalMs = 60000 } = {}) {
     if (typeof execute !== 'function') throw new Error('execute_callback_required');
     if (this.timer) return this;
     const run = async () => {
       try {
-        await this.tick({ technical_ready, editorial_ready, execute, reconcile });
+        await this.tick({ technical_ready, editorial_ready, execute, reconcile, execution_enabled });
       } catch {
         // No blind retry inside the same tick. Next interval may evaluate again
         // only if no durable execution intent exists.

--- a/instagram-publication-state.js
+++ b/instagram-publication-state.js
@@ -31,7 +31,6 @@ const NON_RETRYABLE_FAILURE_REASONS = Object.freeze(new Set([
   'authorization_already_used',
   'authorization_expired',
   'publication_window_expired',
-  'provider_writes_frozen',
   'content_fingerprint_required',
   'account_required',
 ]));

--- a/test/instagram-editorial-timing.test.js
+++ b/test/instagram-editorial-timing.test.js
@@ -177,6 +177,32 @@ test('retryable preflight failure can dispatch again after a durable intent', as
   assert.equal(executions, 2);
 });
 
+test('provider write freeze pauses without closing the schedule', async t => {
+  const store = makeStore(t);
+  const scheduler = new InstagramEditorialScheduler({ store, now });
+  const pkg = packageFixture();
+  scheduler.schedule(pkg);
+  current = Date.parse('2026-09-08T12:00:00.000Z');
+  let executions = 0;
+  const first = await scheduler.tick({
+    technical_ready: true,
+    editorial_ready: true,
+    execute: async () => { executions += 1; return { status: 'INSTAGRAM_PUBLISH_VERIFIED', provider_writes: 1 }; },
+    execution_enabled: false,
+  });
+  assert.equal(first[0].status, 'PROVIDER_WRITES_FROZEN');
+  assert.equal(executions, 0);
+  assert.equal(latestPublicationState(store, pkg.publication_id).status, 'SCHEDULED');
+  const second = await scheduler.tick({
+    technical_ready: true,
+    editorial_ready: true,
+    execute: async () => { executions += 1; return { status: 'INSTAGRAM_PUBLISH_VERIFIED', provider_writes: 1 }; },
+    execution_enabled: false,
+  });
+  assert.equal(second[0].status, 'PROVIDER_WRITES_FROZEN');
+  assert.equal(executions, 0);
+});
+
 test('Europe/Berlin wall-clock and DST offset are deterministic', () => {
   const winter = berlinParts('2026-01-15T12:00:00.000Z');
   const summer = berlinParts('2026-07-15T12:00:00.000Z');


### PR DESCRIPTION
Keep a frozen provider-write window in SCHEDULED state without dispatching or closing the schedule. This keeps the canary ready for a single later approval while PROVIDER_WRITES=0.